### PR TITLE
Zombie spawn should not kill master (or should they?)

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -303,7 +303,12 @@ class MasterLocustRunner(DistributedLocustRunner):
         
         # listener that gathers info on how many locust users the slaves has spawned
         def on_slave_report(client_id, data):
-            self.clients[client_id].user_count = data["user_count"]
+            client = self.clients.get(client_id)
+            if client:
+                client.user_count = data["user_count"]
+            else:
+                #do we want to kill the zombie?
+                logger.warn('Zombie client: %s' %client_id)
         events.slave_report += on_slave_report
     
     @property


### PR DESCRIPTION
If client_id lookup failed, this world would come crashing down. Maybe this is by design... Should be cleaning them, or perhaps adding them back to the lookup dict
