### PR TITLE
Added argument to options parser indicating on which port to run the web UI

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -36,7 +36,12 @@ def parse_options():
         default=None,
         help="Host to load test in the following format: http://10.21.32.33"
     )
-
+    parser.add_option(
+        '-P', '--port',
+        dest="port",
+        default=8089,
+        help="Port on which to run web host"
+    )
     parser.add_option(
         '-f', '--locustfile',
         dest='locustfile',
@@ -350,8 +355,8 @@ def main():
 
     if not options.no_web and not options.slave:
         # spawn web greenlet
-        logger.info("Starting web monitor on port 8089")
-        main_greenlet = gevent.spawn(web.start, locust_classes, options.hatch_rate, options.num_clients, options.num_requests, options.ramp)
+        logger.info("Starting web monitor on port %s" % options.port)
+        main_greenlet = gevent.spawn(web.start, locust_classes, options.hatch_rate, options.num_clients, options.num_requests, options.ramp, options.port)
     
     if not options.master and not options.slave:
         runners.locust_runner = LocalLocustRunner(locust_classes, options.hatch_rate, options.num_clients, options.num_requests, options.host)

--- a/locust/web.py
+++ b/locust/web.py
@@ -30,7 +30,7 @@ _num_requests = None
 _hatch_rate = None
 _request_stats_context_cache = {}
 _ramp = False
-
+_port = 8089
 
 @app.route('/')
 def index():
@@ -215,15 +215,16 @@ def exceptions():
     response.headers["Content-type"] = "application/json"
     return response
 
-def start(locust, hatch_rate, num_clients, num_requests, ramp):
-    global _locust, _hatch_rate, _num_clients, _num_requests, _ramp
+def start(locust, hatch_rate, num_clients, num_requests, ramp, port):
+    global _locust, _hatch_rate, _num_clients, _num_requests, _ramp, _port
     _locust = locust
     _hatch_rate = hatch_rate
     _num_clients = num_clients
     _num_requests = num_requests
     _ramp = ramp
+    _port = port
     
-    wsgi.WSGIServer(('', 8089), app, log=None).serve_forever()
+    wsgi.WSGIServer(('', int(port)), app, log=None).serve_forever()
 
 def _sort_stats(stats):
     return [stats[key] for key in sorted(stats.iterkeys())]


### PR DESCRIPTION
I had a problem running locust on my machine since the port 8089 was already being used by a Django application. While I was able to fix this by changing the source files, I thought it would be much more convenient to be able to specify on which port to run the web server. I set the default port to 8089 but the user can modify this by passing a -P or --port argument. 

Thanks for the good work. 
