### PR TITLE
Update docs/api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,7 +68,7 @@ The event hooks are instances of the **locust.events.EventHook** class:
 Available hooks
 ---------------
 
-The wollowing event hooks are available under the **locust.events** module:
+The following event hooks are available under the **locust.events** module:
 
 .. automodule:: locust.events
 	:members: request_success, request_failure, locust_error, report_to_master, slave_report, hatch_complete, quitting


### PR DESCRIPTION
world's most challenging fix. Line 71 currently reads "The `wollowing` event hooks..."
Changing to read "The following event hooks...." 
