### PR TITLE
Include method name in command line logging

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -231,7 +231,7 @@ class RequestStats(object):
             fail_percent = 0
         
         return (" %-" + str(STATS_NAME_WIDTH) + "s %7d %12s %7d %7d %7d  | %7d %7.2f") % (
-            self.name,
+            self.method + " " + self.name,
             self.num_reqs,
             "%d(%.2f%%)" % (self.num_failures, fail_percent),
             self.avg_response_time,


### PR DESCRIPTION
When using the command line `--no-web` option, it'll print out stats on each request. But it only prints out the request url, however internally it uses method (GET/POST/etc) and url. If you're GETting and POSTing to the same url (quite common with html forms ;) ), you'll see duplicate urls and you won't (easily) be able to tell how long the GET request vs the POST request for a url took.

This patch shows `GET $URL`/`POST $URL` in the command line stats
