### PR TITLE
Fix failure percent calculations.

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -226,7 +226,7 @@ class RequestStats(object):
 
     def __str__(self):
         try:
-            fail_percent = (self.num_failures/float(self.num_reqs))*100
+            fail_percent = (self.num_failures/float(self.num_reqs + self.num_failures))*100
         except ZeroDivisionError:
             fail_percent = 0
         


### PR DESCRIPTION
Make fail percent be failures/(success+failures). If you have 1 success
and 4 failures, your fail percentage is 80%, not 400%.
