### PR TITLE
include hostname in log messages

### DIFF
--- a/locust/log.py
+++ b/locust/log.py
@@ -1,12 +1,15 @@
 import logging
 import sys
+import socket
+
+host = socket.gethostname()
 
 def setup_logging(loglevel, logfile):
     numeric_level = getattr(logging, loglevel.upper(), None)
     if numeric_level is None:
         raise ValueError("Invalid log level: %s" % loglevel)
     
-    log_format = "[%(asctime)s] %(levelname)s/%(name)s: %(message)s"
+    log_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(host)
     logging.basicConfig(level=numeric_level, filename=logfile, format=log_format)
     
     sys.stderr = StdErrWrapper()


### PR DESCRIPTION
Include the hostname in log messages. This makes it easier to track down host related problems. In a large cluster of slaves that's helpful.
