### PR TITLE
fix typo in downloadable CSV

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -98,7 +98,7 @@ def request_stats_csv():
             '"Min response time"', 
             '"Max response time"',
             '"Average Content Size"',
-            '"Reqests/s"',
+            '"Requests/s"',
         ])
     ]
     


### PR DESCRIPTION
Thanks so much for this really great tool! I found it today and got it up and running inside of an hour.

When I downloaded the CSV report, I noticed that the `Requests/s` header had a typo. Hope this helps!
