### PR TITLE
Added a 'starting' event, as a compliment to 'quitting'

### DIFF
--- a/locust/events.py
+++ b/locust/events.py
@@ -101,5 +101,10 @@ Event is fire with the following arguments:
 
 quitting = EventHook()
 """
-*quitting* is fired when the locust process in exiting
+*quitting* is fired when the locust process is exiting. A compliment to starting.
+"""
+
+starting = EventHook()
+"""
+*starting* is fired when the locust process is starting. A compliment to quitting.
 """

--- a/locust/main.py
+++ b/locust/main.py
@@ -354,6 +354,9 @@ def main():
         logger.error("Locust can not run distributed with the web interface disabled (do not use --no-web and --master together)")
         sys.exit(0)
 
+    # Fire starting event
+    events.starting.fire()
+
     if not options.no_web and not options.slave:
         # spawn web greenlet
         logger.info("Starting web monitor on port %s" % options.port)


### PR DESCRIPTION
If you want to do any setUp in the locust test, you can now use a starting method
