### PR TITLE
make failed requests count towards the total

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -409,12 +409,15 @@ A global instance for holding the statistics. Should be removed eventually.
 """
 
 def on_request_success(method, name, response_time, response_length):
-    if global_stats.max_requests is not None and global_stats.num_requests >= global_stats.max_requests:
+    if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
         raise StopLocust("Maximum number of requests reached")
     
     global_stats.get(name, method).log(response_time, response_length)
 
 def on_request_failure(method, name, response_time, error, response=None):
+    if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
+        raise StopLocust("Maximum number of requests reached")
+
     global_stats.get(name, method).log_error(error)
 
 def on_report_to_master(client_id, data):


### PR DESCRIPTION
This is more of a feature request. I think the "total requests" should include failed requests as well as successed. If you want to run 100 requests, and things fail half way, locust will keep going forever until there are 100 successful request. However I think it should keep going until 100 requests have been sent to the server.

This patch changes this to include the total.
