### PR TITLE
fix module and variable name clash (traceback refers to a mod so it's a ...

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -273,7 +273,7 @@ class TaskSet(object):
             except GreenletExit:
                 raise
             except Exception as e:
-                events.locust_error.fire(locust_instance=self, exception=e, traceback=sys.exc_info()[2])
+                events.locust_error.fire(locust_instance=self, exception=e, tb=sys.exc_info()[2])
                 sys.stderr.write("\n" + traceback.format_exc())
                 self.wait()
     

--- a/locust/events.py
+++ b/locust/events.py
@@ -60,7 +60,7 @@ Event is fired with the following arguments:
 
 * *locust_instance*: Locust class instance where the exception occurred
 * *exception*: Exception that was thrown
-* *traceback*: Traceback object (from sys.exc_info()[2])
+* *tb*: Traceback object (from sys.exc_info()[2])
 """
 
 report_to_master = EventHook()

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -190,8 +190,8 @@ class LocalLocustRunner(LocustRunner):
         super(LocalLocustRunner, self).__init__(locust_classes, options)
 
         # register listener thats logs the exception for the local runner
-        def on_locust_error(locust_instance, exeption, traceback):
-            formatted_tb = "".join(traceback.format_tb(traceback))
+        def on_locust_error(locust_instance, exeption, tb):
+            formatted_tb = "".join(traceback.format_tb(tb))
             self.log_exception("local", str(exception), formatted_tb)
         events.locust_error += on_locust_error
 
@@ -373,8 +373,8 @@ class SlaveLocustRunner(DistributedLocustRunner):
         events.quitting += on_quitting
 
         # register listener thats sends locust exceptions to master
-        def on_locust_error(locust_instance, exception, traceback):
-            formatted_tb = "".join(traceback.format_tb(traceback))
+        def on_locust_error(locust_instance, exception, tb):
+            formatted_tb = "".join(traceback.format_tb(tb))
             self.client.send(Message("exception", {"msg" : str(exception), "traceback" : formatted_tb}, self.client_id))
         events.locust_error += on_locust_error
 


### PR DESCRIPTION
...bad idea to name a var the same thing)

Fixes #114
