### PR TITLE
Detect non-locust classes based on "client" property rather than on global _internals

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -18,7 +18,6 @@ from core import Locust, HttpLocust
 from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
 import events
 
-_internals = [Locust, HttpLocust]
 version = locust.version
 
 def parse_options():
@@ -284,7 +283,7 @@ def is_locust(tup):
     return (
         inspect.isclass(item)
         and issubclass(item, Locust)
-        and (item not in _internals)
+        and ('client' not in item.__dict__)
         and not name.startswith('_')
     )
 


### PR DESCRIPTION
This allows to add custom transport adapters without monkey patching.

After declaring support for custom clients and introducing HttpLocust class (#83), a subclass of Locust can either represent a new "locust" (or "user"; typical case) or new transport adapter.

For the purpose of collecting locusts, the latter should be filtered out. Currently it's detected based on the content of global list (main._internals), which requires updating for new adapters included in core (like in d5c12eabe6df08e3e7ab07adcbde181030f9ef1c for HttpLocust), or monkey patching for custom adapters.

As I'm implementing new non-HTTP adapter, I had to provide my custom client class. I thought that could serve as a better qualifier of non-locust classes, as I can't imagine an adapter without the new client type associated.
