### PR TITLE
Fixed Docs Homebrew Link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,7 +52,7 @@ Installing Locust on OS X
 
 The following is currently the shortest path to installing gevent on OS X using Homebrew.
 
-#. Install [Homebrew](http://mxcl.github.com/homebrew/).
+#. Install `Homebrew <http://mxcl.github.com/homebrew/>`_.
 #. Install libevent (dependency for gevent)::
 
     brew install libevent


### PR DESCRIPTION
Someone tried to use a Markdown style link in REST, I updated the link to use the REST inline link syntax.
