### PR TITLE
Redefine err message for locustfile

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -343,7 +343,7 @@ def main():
 
     locustfile = find_locustfile(options.locustfile)
     if not locustfile:
-        logger.error("Could not find any locustfile! See --help for available options.")
+        logger.error("Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.")
         sys.exit(1)
 
     docstring, locusts = load_locustfile(locustfile)


### PR DESCRIPTION
I spent a bit of time trying to figure out why a simple "-f" would not accept my config file. While it may be the case that it uses the native python import functionality (which needs a ".py" suffix), this is not directly implied for users of this utility that haven't delved into the source. This will hopefully make it more clear. 
