### PR TITLE
Handle invalid inputs in "start swarm" form better

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -56,6 +56,8 @@ $('#swarm_form').submit(function(event) {
                 $("a.new_test").fadeOut();
                 $("a.edit_test").fadeIn();
                 $(".user_count").fadeIn();
+            } else {
+                alert(response.message);
             }
         }
     );
@@ -68,6 +70,8 @@ $('#edit_form').submit(function(event) {
             if (response.success) {
                 $("body").attr("class", "hatching");
                 $("#edit").fadeOut();
+            } else {
+                alert(response.message);
             }
         }
     );

--- a/locust/web.py
+++ b/locust/web.py
@@ -46,17 +46,22 @@ def index():
 def swarm():
     assert request.method == "POST"
 
-    locust_count = int(request.form["locust_count"])
-    hatch_rate = float(request.form["hatch_rate"])
-    runners.locust_runner.start_hatching(locust_count, hatch_rate)
-    response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
+    try:
+        locust_count = int(request.form["locust_count"])
+        hatch_rate = float(request.form["hatch_rate"])
+        runners.locust_runner.start_hatching(locust_count, hatch_rate)
+        data = {'success': True, 'message': 'Swarming started'}
+    except ValueError:
+        data = {'success': False, 'message': 'Invalid swarm settings'}
+
+    response = make_response(json.dumps(data))
     response.headers["Content-type"] = "application/json"
     return response
 
 @app.route('/stop')
 def stop():
     runners.locust_runner.stop()
-    response = make_response(json.dumps({'success':True, 'message': 'Test stopped'}))
+    response = make_response(json.dumps({'success': True, 'message': 'Test stopped'}))
     response.headers["Content-type"] = "application/json"
     return response
 


### PR DESCRIPTION
With this change, the user will now see an alert with an error message if the inputs in the "Start new Locust swarm" or "Change the locust count" forms are invalid. Validation before sending it to the backend would be even better, but this is an easy stopgap so that the user at least sees _something_ happen after clicking "start".
