### PR TITLE
Added event hatch_starting for pre-simulation setup.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,5 +74,5 @@ Available hooks
 The following event hooks are available under the **locust.events** module:
 
 .. automodule:: locust.events
-	:members: request_success, request_failure, locust_error, report_to_master, slave_report, hatch_complete, quitting
+	:members: request_success, request_failure, locust_error, report_to_master, slave_report, hatch_complete, hatch_starting, quitting
 

--- a/locust/events.py
+++ b/locust/events.py
@@ -94,17 +94,17 @@ hatch_complete = EventHook()
 
 Event is fire with the following arguments:
 
-* *user_count*: Number of users that was hatched
+* *user_count*: Number of users that were hatched
 """
 
 hatch_starting = EventHook()
 """
-*hatch_starting* is fired before any locust users have spawned
+*hatch_starting* is fired before any locust users have been spawned
 
-* *client_types*: Dictionary of Locust class that will be created once hatching starts
+* *client_types*: Dictionary of Locust classes that will be created once hatching starts
 """
 
 quitting = EventHook()
 """
-*quitting* is fired when the locust process in exiting
+*quitting* is fired when the locust process is exiting
 """

--- a/locust/events.py
+++ b/locust/events.py
@@ -97,6 +97,12 @@ Event is fire with the following arguments:
 * *user_count*: Number of users that was hatched
 """
 
+hatch_starting = EventHook()
+"""
+*hatch_starting* is fired before any locust users have spawned
+
+"""
+
 quitting = EventHook()
 """
 *quitting* is fired when the locust process in exiting

--- a/locust/events.py
+++ b/locust/events.py
@@ -101,6 +101,7 @@ hatch_starting = EventHook()
 """
 *hatch_starting* is fired before any locust users have spawned
 
+* *client_types*: Dictionary of Locust class that will be created once hatching starts
 """
 
 quitting = EventHook()

--- a/locust/events.py
+++ b/locust/events.py
@@ -92,14 +92,16 @@ hatch_complete = EventHook()
 """
 *hatch_complete* is fired when all locust users has been spawned.
 
-Event is fire with the following arguments:
+Event is fired with the following arguments:
 
 * *user_count*: Number of users that were hatched
 """
 
 hatch_starting = EventHook()
 """
-*hatch_starting* is fired before any locust users have been spawned
+*hatch_starting* is fired before any locust users have been spawned.
+
+Event is fired with the following arguments:
 
 * *client_types*: Dictionary of Locust classes that will be created once hatching starts
 """

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -92,6 +92,7 @@ class LocustRunner(object):
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.state = STATE_HATCHING
             self.num_clients = spawn_count
+            events.hatch_starting.fire(client_types=bucket)
         else:
             self.num_clients += spawn_count
 


### PR DESCRIPTION
One of the use cases I wanted to use Locust for required that I do some initial setup before beginning the simulation. Two or more Locust classes needed to have knowledge of how many instances of another type of Locust class and that number could not be gathered from the hatch_complete event. So I added an event that fires right when STATE_HATCHING is entered so that initial setup could be done before running the simulation.