### PR TITLE
Don't reset stats after hatching is complete

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -40,14 +40,8 @@ class LocustRunner(object):
         
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
-            
-        #def on_hatch_start(user_count):
-            # reset stats when hatching starts since early hatched users could be making
-            # requests before hatching is complete
-        #    logger.info("Resetting stats\n")
-        #    self.stats.reset_all()
+
         events.hatch_complete += on_hatch_complete
-        #events.hatch_start += on_hatch_start
 
     @property
     def request_stats(self):
@@ -100,7 +94,6 @@ class LocustRunner(object):
             self.num_clients += spawn_count
 
         logger.info("Hatching and swarming %i clients at the rate %g clients/s..." % (spawn_count, self.hatch_rate))
-        #events.hatch_start.fire(user_count=self.num_clients)
         occurence_count = dict([(l.__name__, 0) for l in self.locust_classes])
         
         def hatch():


### PR DESCRIPTION
The stats reset when hatching starts already and if you hatch slowly, there can be many tasks completed by the time hatching completes. Without this change, those completed tasks are removed from the stats as soon as hatching completes.
