### PR TITLE
Include method name in percentile distribution reports

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -342,7 +342,7 @@ class StatsEntry(object):
             raise ValueError("Can't calculate percentile on url with no successful requests")
         
         return tpl % (
-            self.name,
+            str(self.method) + " " + self.name,
             self.num_requests,
             self.get_response_time_percentile(0.5),
             self.get_response_time_percentile(0.66),


### PR DESCRIPTION
As requested, this is the first part of the changes from PR #160. Description from that PR:

> Include method in the percentile reports (both the generated CSV and the one logged on the command line). Before this, there was no way to tell whether a given row of the report was for a GET or a POST to an endpoint.
