### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -63,7 +63,7 @@ will use both port 5557 and 5558.
 ------------------------------
 
 Optionally used together with ``--master``. Determines what network interface that the master node 
-will bind to. Defaults to * (all available inrefaces).
+will bind to. Defaults to * (all available interfaces).
 
 ``--master-bind-port=5557``
 ------------------------------

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -127,7 +127,7 @@ the following example *task2* will be executed twice as much as *task1*::
         task_set = MyTaskSet
 
 
-task attribute
+tasks attribute
 --------------
 
 Using the @task decorator to declare tasks is a convenience, and usually that's the best way to do 


### PR DESCRIPTION
Also, the attribute is `tasks` not `task`
