### PR TITLE
Fixed link to ESN's Twitter page

### DIFF
--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -162,7 +162,7 @@
                 <a href="http://cgbystrom.com/">Carl Byström</a> (<a href="http://twitter.com/cgbystrom/">@cgbystrom</a>)<br>
                 <a href="http://heyman.info/">Jonatan Heyman</a> (<a href="http://twitter.com/jonatanheyman/">@jonatanheyman</a>)<br>
                 Joakim Hamrén (<a href="http://twitter.com/Jahaaja/">@jahaaja</a>)<br>
-                <a href="http://esn.me/">ESN Social Software</a> (<a href="http://twitter.com/esnme/">@esnme</a>)<br>
+                <a href="http://esn.me/">ESN Social Software</a> (<a href="http://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
                 Hugo Heyman (<a href="http://twitter.com/hugoheyman/">@hugoheyman</a>)
                 
                 


### PR DESCRIPTION
Old one (@esnme) is pointing to some other weird account.