### PR TITLE
Configurable precision

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -12,7 +12,7 @@ from optparse import OptionParser
 
 from . import web
 from .log import setup_logging, console_logger
-from .stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from .stats import stats_printer, print_percentile_stats, print_error_report, print_stats, global_stats
 from .inspectlocust import print_task_ratio, get_task_ratio_dict
 from .core import Locust, HttpLocust
 from .runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -228,6 +228,15 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # Customize the precision with which request values are saved
+    parser.add_option(
+        '--precision',
+        action='store',
+        dest='precision',
+        default=2,
+        help="how many digits of precision to store for the response time aggregations"
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -340,6 +349,9 @@ def main():
     if options.show_version:
         print("Locust %s" % (version,))
         sys.exit(0)
+
+    if options.precision:
+        global_stats.precision = options.precision
 
     locustfile = find_locustfile(options.locustfile)
     if not locustfile:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -159,21 +159,24 @@ class StatsEntry(object):
         self.min_response_time = min(self.min_response_time, response_time)
         self.max_response_time = max(self.max_response_time, response_time)
 
-        # to avoid to much data that has to be transfered to the master node when
-        # running in distributed mode, we save the response time rounded in a dict
-        # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
-        if response_time < 100:
-            rounded_response_time = response_time
-        elif response_time < 1000:
-            rounded_response_time = int(round(response_time, -1))
-        elif response_time < 10000:
-            rounded_response_time = int(round(response_time, -2))
-        else:
-            rounded_response_time = int(round(response_time, -3))
+        rounded_response_time = self._round_response_time(response_time)
 
         # increase request count for the rounded key in response time dict
         self.response_times.setdefault(rounded_response_time, 0)
         self.response_times[rounded_response_time] += 1
+
+    def _round_response_time(self, response_time):
+        # to avoid to much data that has to be transfered to the master node when
+        # running in distributed mode, we save the response time rounded in a dict
+        # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
+        if response_time < 100:
+            return response_time
+        elif response_time < 1000:
+            return int(round(response_time, -1))
+        elif response_time < 10000:
+            return int(round(response_time, -2))
+        else:
+            return int(round(response_time, -3))
 
     def log_error(self, error):
         self.num_failures += 1

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,6 +1,7 @@
 import time
 import gevent
 import hashlib
+import math
 import six
 from six.moves import xrange
 
@@ -169,14 +170,14 @@ class StatsEntry(object):
         # to avoid to much data that has to be transfered to the master node when
         # running in distributed mode, we save the response time rounded in a dict
         # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
-        if response_time < 100:
+        if response_time == 0:
+            return 0
+
+        num_digits = int(math.log10(response_time)) + 1
+        if num_digits <= 2:
             return response_time
-        elif response_time < 1000:
-            return int(round(response_time, -1))
-        elif response_time < 10000:
-            return int(round(response_time, -2))
         else:
-            return int(round(response_time, -3))
+            return int(round(response_time, 2 - num_digits))
 
     def log_error(self, error):
         self.num_failures += 1

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -66,7 +66,7 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(self.s.num_failures, 1)
         self.assertEqual(self.s.avg_response_time, 420.5)
         self.assertEqual(self.s.median_response_time, 85)
-    
+
     def test_reset_min_response_time(self):
         self.s.reset()
         self.s.log(756, 0)
@@ -98,11 +98,11 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(s.num_failures, 3)
         self.assertEqual(s.median_response_time, 38)
         self.assertEqual(s.avg_response_time, 43.2)
-    
+
     def test_serialize_through_message(self):
         """
-        Serialize a RequestStats instance, then serialize it through a Message, 
-        and unserialize the whole thing again. This is done "IRL" when stats are sent 
+        Serialize a RequestStats instance, then serialize it through a Message,
+        and unserialize the whole thing again. This is done "IRL" when stats are sent
         from slaves to master.
         """
         s1 = StatsEntry(self.stats, "test", "GET")
@@ -110,24 +110,34 @@ class TestRequestStats(unittest.TestCase):
         s1.log(20, 0)
         s1.log(40, 0)
         u1 = StatsEntry.unserialize(s1.serialize())
-        
+
         data = Message.unserialize(Message("dummy", s1.serialize(), "none").serialize()).data
         u1 = StatsEntry.unserialize(data)
-        
+
         self.assertEqual(20, u1.median_response_time)
+
+    def test_response_time_rounding(self):
+        self.assertEquals(self.s._round_response_time(0), 0)
+        self.assertEquals(self.s._round_response_time(4), 4)
+        self.assertEquals(self.s._round_response_time(22), 22)
+        self.assertEquals(self.s._round_response_time(123), 120)
+        self.assertEquals(self.s._round_response_time(455), 460)
+        self.assertEquals(self.s._round_response_time(1123), 1100)
+        self.assertEquals(self.s._round_response_time(1455), 1500)
+        self.assertEquals(self.s._round_response_time(12345), 12000)
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def test_request_stats_content_length(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast")
         self.assertEqual(global_stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
         locust.client.get("/ultra_fast")
         self.assertEqual(global_stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
-    
+
     def test_request_stats_no_content_length(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
@@ -135,7 +145,7 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
         path = "/no_content_length"
         r = l.client.get(path)
         self.assertEqual(global_stats.get(path, "GET").avg_content_length, len("This response does not have content-length in the header"))
-    
+
     def test_request_stats_no_content_length_streaming(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
@@ -143,41 +153,41 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
         path = "/no_content_length"
         r = l.client.get(path, stream=True)
         self.assertEqual(0, global_stats.get(path, "GET").avg_content_length)
-    
+
     def test_request_stats_named_endpoint(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast", name="my_custom_name")
         self.assertEqual(1, global_stats.get("my_custom_name", "GET").num_requests)
-    
+
     def test_request_stats_query_variables(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast?query=1")
         self.assertEqual(1, global_stats.get("/ultra_fast?query=1", "GET").num_requests)
-    
+
     def test_request_stats_put(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.put("/put")
         self.assertEqual(1, global_stats.get("/put", "PUT").num_requests)
-    
+
     def test_request_connection_error(self):
         class MyLocust(HttpLocust):
             host = "http://localhost:1"
-        
+
         locust = MyLocust()
         response = locust.client.get("/", timeout=0.1)
         self.assertEqual(response.status_code, 0)
         self.assertEqual(1, global_stats.get("/", "GET").num_failures)
         self.assertEqual(0, global_stats.get("/", "GET").num_requests)
-    
+
     def test_max_requests(self):
         class MyTaskSet(TaskSet):
             @task
@@ -188,26 +198,26 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
             task_set = MyTaskSet
             min_wait = 1
             max_wait = 1
-            
+
         try:
             from locust.exception import StopLocust
             global_stats.clear_all()
             global_stats.max_requests = 2
-            
+
             l = MyLocust()
             self.assertRaises(StopLocust, lambda: l.task_set(l).run())
             self.assertEqual(2, global_stats.num_requests)
-            
+
             global_stats.clear_all()
             global_stats.max_requests = 2
             self.assertEqual(0, global_stats.num_requests)
-            
+
             l.run()
             self.assertEqual(2, global_stats.num_requests)
         finally:
             global_stats.clear_all()
             global_stats.max_requests = None
-    
+
     def test_max_requests_failed_requests(self):
         class MyTaskSet(TaskSet):
             @task
@@ -215,23 +225,23 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
                 self.client.get("/ultra_fast")
                 self.client.get("/fail")
                 self.client.get("/fail")
-            
+
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
             task_set = MyTaskSet
             min_wait = 1
             max_wait = 1
-            
+
         try:
             from locust.exception import StopLocust
             global_stats.clear_all()
             global_stats.max_requests = 3
-            
+
             l = MyLocust()
             self.assertRaises(StopLocust, lambda: l.task_set(l).run())
             self.assertEqual(1, global_stats.num_requests)
             self.assertEqual(2, global_stats.num_failures)
-            
+
             global_stats.clear_all()
             global_stats.max_requests = 2
             self.assertEqual(0, global_stats.num_requests)
@@ -248,7 +258,7 @@ class MyTaskSet(TaskSet):
     @task(75)
     def root_task(self):
         pass
-    
+
     @task(25)
     class MySubTaskSet(TaskSet):
         @task
@@ -257,7 +267,7 @@ class MyTaskSet(TaskSet):
         @task
         def task2(self):
             pass
-    
+
 class TestInspectLocust(unittest.TestCase):
     def test_get_task_ratio_dict_relative(self):
         ratio = get_task_ratio_dict([MyTaskSet])
@@ -266,7 +276,7 @@ class TestInspectLocust(unittest.TestCase):
         self.assertEqual(0.25, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task1"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task2"]["ratio"])
-    
+
     def test_get_task_ratio_dict_total(self):
         ratio = get_task_ratio_dict([MyTaskSet], total=True)
         self.assertEqual(1.0, ratio["MyTaskSet"]["ratio"])

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -116,7 +116,7 @@ class TestRequestStats(unittest.TestCase):
 
         self.assertEqual(20, u1.median_response_time)
 
-    def test_response_time_rounding(self):
+    def test_default_response_time_rounding(self):
         self.assertEquals(self.s._round_response_time(0), 0)
         self.assertEquals(self.s._round_response_time(4), 4)
         self.assertEquals(self.s._round_response_time(22), 22)
@@ -125,6 +125,16 @@ class TestRequestStats(unittest.TestCase):
         self.assertEquals(self.s._round_response_time(1123), 1100)
         self.assertEquals(self.s._round_response_time(1455), 1500)
         self.assertEquals(self.s._round_response_time(12345), 12000)
+
+    def test_configurable_response_time_rounding(self):
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(0), round(0, 2))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(4), round(4, 2))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 1)._round_response_time(22), round(22, -1))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(123), round(123, 0))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 1)._round_response_time(455), round(455, -2))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 5)._round_response_time(1123), round(1123, 1))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(1455), round(1455, -1))
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 4)._round_response_time(12345), round(12345, -1))
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):


### PR DESCRIPTION
This allows the user to set `--precision X` on the commandline to store up to that many digits of precision in response times.
