### PR TITLE
changed how request_meta["method"] is set

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -107,6 +107,7 @@ class HttpSession(requests.Session):
         request_meta = {}
         
         # set up pre_request hook for attaching meta data to the request object
+        request_meta["method"] = method
         request_meta["start_time"] = time.time()
         
         response = self._send_request_safe_mode(method, url, **kwargs)
@@ -114,7 +115,7 @@ class HttpSession(requests.Session):
         # record the consumed time
         request_meta["response_time"] = int((time.time() - request_meta["start_time"]) * 1000)
         
-        request_meta["method"] = response.request.method
+    
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url
         
         # get the length of the content, but if the argument stream is set to True, we take


### PR DESCRIPTION
method was set against the request response method. In the case of a POST request being redirected to GET, common on success of POSTs for login and registration. The request is incorrectly logged against the GET method for the original URL.

Closes locustio/locust#236