### PR TITLE
Added reportfile option

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -12,7 +12,15 @@ from optparse import OptionParser
 
 import web
 from log import setup_logging, console_logger
-from stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from stats import (
+    stats_printer,
+    print_percentile_stats,
+    print_error_report,
+    print_stats,
+    get_string_stats,
+    get_string_percentile_stats,
+    get_string_error_report
+)
 from inspectlocust import print_task_ratio, get_task_ratio_dict
 from core import Locust, HttpLocust
 from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -228,6 +236,16 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # stats and error report file
+    parser.add_option(
+        '--reportfile',
+        action='store',
+        type='str',
+        dest='reportfile',
+        default=None,
+        help="Path to stats and error report file. If not set, stats and error report will go to stdout/stderr"
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -428,6 +446,14 @@ def main():
         print_percentile_stats(runners.locust_runner.request_stats)
 
         print_error_report()
+
+        if options.reportfile:
+            file = open(options.reportfile, 'w')
+            file.write(get_string_stats(runners.locust_runner.request_stats))
+            file.write(get_string_percentile_stats(runners.locust_runner.request_stats))
+            file.write(get_string_error_report())
+            file.close()
+
         sys.exit(code)
     
     # install SIGTERM handler

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -501,3 +501,54 @@ def stats_printer():
     while True:
         print_stats(locust_runner.request_stats)
         gevent.sleep(2)
+
+def get_string_stats(stats):
+    string_stats = (" %-" + str(STATS_NAME_WIDTH) + "s %7s %12s %7s %7s %7s  | %7s %7s") % ('Name', '# reqs', '# fails', 'Avg', 'Min', 'Max', 'Median', 'req/s\n')
+    string_stats += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+    total_rps = 0
+    total_reqs = 0
+    total_failures = 0
+    for key in sorted(stats.iterkeys()):
+        r = stats[key]
+        total_rps += r.current_rps
+        total_reqs += r.num_requests
+        total_failures += r.num_failures
+        string_stats += str(r) + "\n"
+    string_stats += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+
+    try:
+        fail_percent = (total_failures/float(total_reqs))*100
+    except ZeroDivisionError:
+        fail_percent = 0
+
+    string_stats += (" %-" + str(STATS_NAME_WIDTH) + "s %7d %12s %42.2f\n") % ('Total', total_reqs, "%d(%.2f%%)" % (total_failures, fail_percent), total_rps)
+    string_stats += "\n"
+    return string_stats
+
+def get_string_percentile_stats(stats):
+    string_percentile_stats = "Percentage of the requests completed within given times\n"
+    string_percentile_stats += (" %-" + str(STATS_NAME_WIDTH) + "s %8s %6s %6s %6s %6s %6s %6s %6s %6s %6s") % ('Name', '# reqs', '50%', '66%', '75%', '80%', '90%', '95%', '98%', '99%', '100%\n')
+    string_percentile_stats += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+    for key in sorted(stats.iterkeys()):
+        r = stats[key]
+        if r.response_times:
+            string_percentile_stats += r.percentile() + "\n"
+    string_percentile_stats += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+
+    total_stats = global_stats.aggregated_stats()
+    if total_stats.response_times:
+        string_percentile_stats += total_stats.percentile()
+    string_percentile_stats += "\n"
+    return string_percentile_stats
+
+def get_string_error_report():
+    if not len(global_stats.errors):
+        return ""
+    string_error_report = "Error report\n"
+    string_error_report += " %-18s %-100s\n" % ("# occurences", "Error")
+    string_error_report += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+    for error in global_stats.errors.itervalues():
+        string_error_report += " %-18i %-100s\n" % (error.occurences, error.to_name())
+    string_error_report += "-" * (80 + STATS_NAME_WIDTH) + "\n"
+    string_error_report += "\n"
+    return string_error_report


### PR DESCRIPTION
I want to automate the load test. So I want to write the stats and percentile_stats and error_report to a file. Therefore I added reportfile option.

# usage1
    $ locust -f my_locustfile.py --clients=1 --hatch-rate=1 --num-request=50 --no-web --host http://localhost:8000 --reportfile=locust_report.txt

# usage2
    $ locust -f my_locustfile.py --master --host http://localhost:8000 --reportfile=locust_report.txt

    $ locust -f my_locustfile.py --slave --host http://localhost:8000