### PR TITLE
Added a handler that will allow locusts and task sets to be notified …

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -112,6 +112,7 @@ class LocustRunner(object):
                     try:
                         locust().run()
                     except GreenletExit:
+                        instance.die()
                         pass
                 new_locust = self.locusts.spawn(start_locust, locust)
                 if len(self.locusts) % 10 == 0:


### PR DESCRIPTION
…when the locust is being killed. This can be useful for resource cleanup (i.e. such as killing threads).
