### PR TITLE
Add headless flags

### DIFF
--- a/locust/events.py
+++ b/locust/events.py
@@ -102,6 +102,11 @@ quitting = EventHook()
 *quitting* is fired when the locust process in exiting
 """
 
+stopping = EventHook()
+"""
+*stopping* is fired when the locust test run is stopped
+"""
+
 master_start_hatching = EventHook()
 """
 *master_start_hatching* is fired when we initiate the hatching process on the master.


### PR DESCRIPTION
Based on code / comments in https://github.com/locustio/locust/pull/278

Added a --run-time flag to support headless testing (such as via CI build system) where a predefined run-time can be specified.
Added a --slave-count flag to support headless testing in distributed mode. Once slave_count slaves connect, distributed locusts will begin hatching. Again, this is useful for CI build system testing.
