### PR TITLE
Make resetting stats after hatching configurable

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -191,6 +191,13 @@ def parse_options():
        default=False,
        help='Only print the summary stats'
     )
+
+    parser.add_option(
+        '--no-reset-stats',
+        action='store_true',
+        dest='no_reset_stats',
+        default=False,
+        help="Never reset statistics after hatching")
     
     # List locust commands found in loaded locust files/source files
     parser.add_option(
@@ -391,6 +398,11 @@ def main():
     if options.master and options.no_web:
         logger.error("Locust can not run distributed with the web interface disabled (do not use --no-web and --master together)")
         sys.exit(0)
+
+    if options.no_reset_stats:
+        runners.RESET_STATS_AFTER_HATCHING = False
+    if not runners.RESET_STATS_AFTER_HATCHING:
+        logger.info("NOT resetting stats after hatching")
 
     if not options.no_web and not options.slave:
         # spawn web greenlet

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -23,6 +23,7 @@ locust_runner = None
 
 STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_STOPPED = ["ready", "hatching", "running", "stopped"]
 SLAVE_REPORT_INTERVAL = 3.0
+RESET_STATS_AFTER_HATCHING = True
 
 
 class LocustRunner(object):
@@ -41,8 +42,9 @@ class LocustRunner(object):
         # register listener that resets stats when hatching is complete
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
-            logger.info("Resetting stats\n")
-            self.stats.reset_all()
+            if RESET_STATS_AFTER_HATCHING:
+                logger.info("Resetting stats\n")
+                self.stats.reset_all()
         events.hatch_complete += on_hatch_complete
 
     @property


### PR DESCRIPTION
This adds a global variable `locust.runners.RESET_STATS_AFTER_HATCHING` that you can use from a locust file, as well as a command line flag `--no-reset-stats`. Locust should still default to resetting the statistics and the "Reset Stats" link in the web interface should work regardless of this flag.

Resolves #205 
