### PR TITLE
Add an option to persist request stats to a file on disk.

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -12,7 +12,7 @@ from optparse import OptionParser
 
 import web
 from log import setup_logging, console_logger
-from stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from stats import stats_printer, print_percentile_stats, print_error_report, print_stats, stats_persist
 from inspectlocust import print_task_ratio, get_task_ratio_dict
 from core import Locust, HttpLocust
 from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -228,6 +228,16 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # A file that contains the current request stats.
+    parser.add_option(
+        '--statsfile',
+        action='store',
+        type='str',
+        dest='statsfile',
+        default=None,
+        help="Store current request stats to this file in CSV format.",
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -416,6 +426,9 @@ def main():
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
         gevent.spawn(stats_printer)
+
+    if options.statsfile:
+        gevent.spawn(stats_persist, options.statsfile)
     
     def shutdown(code=0):
         """

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -7,7 +7,7 @@ from exception import StopLocust
 from log import console_logger
 
 STATS_NAME_WIDTH = 60
-
+ 
 class RequestStatsAdditionError(Exception):
     pass
 
@@ -496,8 +496,21 @@ def print_error_report():
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     console_logger.info("")
 
+def store_stats(filename, stats):
+    with open(filename, "w") as f:
+        f.write("path,method,num_requests,num_failures,min_response_time,max_response_time,avg_response_time\n")
+        for k in stats:
+            r = stats[k]
+            f.write("%s,%s,%d,%d,%d,%d,%d\n" % (r.name,r.method,r.num_requests,r.num_failures,r.min_response_time,r.max_response_time,r.avg_response_time));
+
 def stats_printer():
     from runners import locust_runner
     while True:
         print_stats(locust_runner.request_stats)
+        gevent.sleep(2)
+
+def stats_persist(filename):
+    from runners import locust_runner
+    while True:
+        store_stats(filename, locust_runner.request_stats);
         gevent.sleep(2)


### PR DESCRIPTION
This option is particularly useful when you run the load test with '--no-web' and want to access the current request stats.
