### PR TITLE
adding visual representation of host in Locust UI

### DIFF
--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -278,3 +278,20 @@ ul.tabs li a.current {
     padding: 30px;
     padding-top: 0px;
 }
+
+.hostname {
+    margin-top: 25px;
+    margin-left: 50px;
+    float: left;
+}
+
+.hostname .label {
+    color: #7a7a7a;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.hostname .value {
+    font-weight: bold;
+    font-size: 1.2 em;
+}

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -7,6 +7,10 @@
 </head> 
 <body class="{{state}}">
     <div class="top">
+        <div class="hostname">
+            <div class="label">Host</div>
+            <div class="value">{{host}}</div>
+        </div>
         <div class="top_content">
             <img src="/static/img/logo.png" class="logo" onclick="$('.about').fadeIn();" />
             <div class="boxes">

--- a/locust/web.py
+++ b/locust/web.py
@@ -40,7 +40,8 @@ def index():
         is_distributed=is_distributed,
         slave_count=slave_count,
         user_count=runners.locust_runner.user_count,
-        version=version
+        version=version,
+        host=runners.locust_runner.host or runners.locust_runner.locust_classes[0].host
     )
 
 @app.route('/swarm', methods=["POST"])


### PR DESCRIPTION
When running a locustfile via the web UI, it would be helpful to be able to see what host you're hitting. This thought is echoed in issue 270 (https://github.com/locustio/locust/issues/270).

I've added a little bit of HTML and CSS code to show the host name in the top left hand corner
![host](https://cloud.githubusercontent.com/assets/711228/8264666/314a179a-16b7-11e5-814f-ad0148256d18.PNG)
