### PR TITLE
Lock gevent version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent>=1.0.1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
+    install_requires=["gevent==1.0.1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
     tests_require=['unittest2', 'mock', 'pyzmq'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Newer versions of gevent recently released to pypi seems not to work with locust

Below occurs with `gevent 1.1b4`

```
[2015-09-10 07:23:09,609] precise64/INFO/locust.main: Starting web monitor at *:8089
[2015-09-10 07:23:09,611] precise64/ERROR/stderr: Traceback (most recent call last):
[2015-09-10 07:23:09,611] precise64/ERROR/stderr: File "/usr/local/bin/locust", line 9, in <module>
[2015-09-10 07:23:09,611] precise64/ERROR/stderr:
[2015-09-10 07:23:09,612] precise64/ERROR/stderr: load_entry_point('locustio==0.7.3', 'console_scripts', 'locust')()
[2015-09-10 07:23:09,612] precise64/ERROR/stderr: File "/usr/local/lib/python2.7/dist-packages/locust/main.py", line 437, in main
[2015-09-10 07:23:09,612] precise64/ERROR/stderr:
[2015-09-10 07:23:09,613] precise64/ERROR/stderr: gevent.signal(signal.SIGTERM, sig_term_handler)
[2015-09-10 07:23:09,613] precise64/ERROR/stderr: TypeError
[2015-09-10 07:23:09,613] precise64/ERROR/stderr: :
[2015-09-10 07:23:09,613] precise64/ERROR/stderr: 'module' object is not callable
[2015-09-10 07:23:09,613] precise64/ERROR/stderr:
```
