### PR TITLE
Update writing-a-locustfile.rst

### DIFF
--- a/docs/testing-other-systems.rst
+++ b/docs/testing-other-systems.rst
@@ -2,7 +2,7 @@
 Testing other systems using custom clients
 ===========================================
 
-Locust was built with HTTP as it's main target. However, it can easily be extended to load test 
+Locust was built with HTTP as its main target. However, it can easily be extended to load test 
 any request/response based system, by writing a custom client that triggers 
 :py:attr:`request_success <locust.events.request_success>` and 
 :py:attr:`request_failure <locust.events.request_failure>` events.
@@ -16,7 +16,7 @@ Here is an example of a Locust class, **XmlRpcLocust**, which provides an XML-RP
 .. literalinclude:: ../examples/custom_xmlrpc_client/xmlrpc_locustfile.py
 
 If you've written Locust tests before, you'll recognize the class called *ApiUser* which is a normal 
-Locust class that has a *TaskSet* class with *tasks* in it's *task_set* attribute. However, the *ApiUser* 
+Locust class that has a *TaskSet* class with *tasks* in its *task_set* attribute. However, the *ApiUser* 
 inherits from *XmlRpcLocust* that you can see right above ApiUser. The *XmlRpcLocust* class provides an 
 instance of XmlRpcClient under the *client* attribute. The *XmlRpcClient* is a wrapper around the standard 
 library's :py:class:`xmlrpclib.ServerProxy`. It  basically just proxies the function calls, but with the 

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -212,7 +212,7 @@ instead of referring to a python function, you point it to another TaskSet::
             pass
 
 So in above example, if the ForumPage would get selected for execution when the UserBehaviour 
-TaskSet is executing, is. that the ForumPage TaskSet would start executing. The ForumPage TaskSet 
+TaskSet is executing, then the ForumPage TaskSet would start executing. The ForumPage TaskSet 
 would then pick one of its own tasks, execute it, then wait, and so on. 
 
 There is one important thing to note about the above example, and that is the call to 
@@ -357,7 +357,7 @@ Grouping requests to URLs with dynamic parameters
 It's very common for websites to have pages whose URLs contain some kind of dynamic parameter(s). 
 Often it makes sense to group these URL's together in Locust's statistics. This can be done 
 by passing a *name* argument to the :py:class:`HttpSession's <locust.clients.HttpSession>` 
-different reqeust methods. 
+different request methods. 
 
 Example::
 


### PR DESCRIPTION
fix typo in explanation of nested tasksets example

I made the smallest possible change that would make the sentence in question grammatically correct; it could still be re-worded more simply IMHO but I didn't want to start making stylistic changes on anyone else's behalf. :)

Thanks again for locust!