### PR TITLE
updated gevent version to support El Capitan release for MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent==1.0.1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
+    install_requires=["gevent==1.1.b1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
     tests_require=['unittest2', 'mock', 'pyzmq'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
I was running into issues installing gevent on Mac "El Capitan" release. This is the fix for the installation issue.

I bumped the gevent version to 1.1.b1 from 1.0.1