### PR TITLE
Enhancement: make the total row more easily visible

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -102,7 +102,7 @@ $(".stats_label").click(function(event) {
     alternate = false;
     totalRow = report.stats.pop()
     sortedStats = (report.stats).sort(sortBy(sortAttribute, desc))
-    sortedStats.push(totalRow)
+    sortedStats.unshift(totalRow)
     $('#stats tbody').jqoteapp(stats_tpl, sortedStats);
     alternate = false;
     $('#errors tbody').jqoteapp(errors_tpl, (report.errors).sort(sortBy(sortAttribute, desc)));
@@ -127,7 +127,7 @@ function updateStats() {
 
         totalRow = report.stats.pop()
         sortedStats = (report.stats).sort(sortBy(sortAttribute, desc))
-        sortedStats.push(totalRow)
+        sortedStats.unshift(totalRow)
         $('#stats tbody').jqoteapp(stats_tpl, sortedStats);
         alternate = false;
         $('#errors tbody').jqoteapp(errors_tpl, (report.errors).sort(sortBy(sortAttribute, desc)));

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -100,8 +100,8 @@ $(".stats_label").click(function(event) {
     $('#stats tbody').empty();
     $('#errors tbody').empty();
     alternate = false;
-    totalRow = report.stats.pop()
-    sortedStats = (report.stats).sort(sortBy(sortAttribute, desc))
+    totalRow = report.stats.slice(0, 1)
+    sortedStats = (report.stats).slice(1).sort(sortBy(sortAttribute, desc))
     sortedStats.unshift(totalRow)
     $('#stats tbody').jqoteapp(stats_tpl, sortedStats);
     alternate = false;


### PR DESCRIPTION
Tests that have a lot of responses can make the browser get bogged down and make it harder to see the total column. By simply making the total column the first row it solves the issue.

FYI - I ran into this under Firefox on Ubuntu 15.04 where I had 150+ requests being displayed where we were using it to do performance testing of a service API. Keeping the total at the top makes it a lot easier to see if one needs to look at the failures or exceptions; it was otherwise getting really hard to see the total as I always had to keep it scrolled to the bottom and at times that was difficult to do where Firefox just didn't want to cooperate. Pretty sure other browsers could have the same issue.
