### PR TITLE
Update working gevent versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent==1.0.1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
+    install_requires=["gevent>=1.0.1,<=1.0.2", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
     tests_require=['unittest2', 'mock', 'pyzmq'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
As mentioned by @yonnig, locustio 0.7.3 works also with gevent-1.0.2 (gevent-1.0.2-cp27-none-win_amd64.whl from http://www.lfd.uci.edu/~gohlke/pythonlibs/)

Enviroment:
 * Win 7 x64
 * Python 2.7.10
 * latest locustio