### PR TITLE
Added full request history (available via report download)

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -33,6 +33,7 @@ class LocustRunner(object):
         self.num_requests = options.num_requests
         self.host = options.host
         self.locusts = Group()
+        self.locust_count = 0
         self.state = STATE_INIT
         self.hatching_greenlet = None
         self.exceptions = {}

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -33,7 +33,6 @@ class LocustRunner(object):
         self.num_requests = options.num_requests
         self.host = options.host
         self.locusts = Group()
-        self.locust_count = 0
         self.state = STATE_INIT
         self.hatching_greenlet = None
         self.exceptions = {}

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -33,6 +33,7 @@ class LocustRunner(object):
         self.num_requests = options.num_requests
         self.host = options.host
         self.locusts = Group()
+        self.locust_count = 0
         self.state = STATE_INIT
         self.hatching_greenlet = None
         self.exceptions = {}
@@ -48,6 +49,10 @@ class LocustRunner(object):
     @property
     def request_stats(self):
         return self.stats.entries
+
+    @property
+    def request_history(self):
+        return self.stats.history
     
     @property
     def errors(self):
@@ -92,6 +97,7 @@ class LocustRunner(object):
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.state = STATE_HATCHING
             self.num_clients = spawn_count
+            self.locust_count = self.num_clients
         else:
             self.num_clients += spawn_count
 
@@ -146,6 +152,7 @@ class LocustRunner(object):
         if self.state != STATE_RUNNING and self.state != STATE_HATCHING:
             self.stats.clear_all()
             self.stats.start_time = time()
+            self.stats.locust_count = locust_count
             self.exceptions = {}
             events.locust_start_hatching.fire()
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -33,7 +33,6 @@ class LocustRunner(object):
         self.num_requests = options.num_requests
         self.host = options.host
         self.locusts = Group()
-        self.locust_count = 0
         self.state = STATE_INIT
         self.hatching_greenlet = None
         self.exceptions = {}
@@ -97,7 +96,6 @@ class LocustRunner(object):
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.state = STATE_HATCHING
             self.num_clients = spawn_count
-            self.locust_count = self.num_clients
         else:
             self.num_clients += spawn_count
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,6 +1,7 @@
 import time
 import gevent
 import hashlib
+import runners
 
 import events
 from exception import StopLocust
@@ -16,6 +17,7 @@ class RequestStats(object):
     def __init__(self):
         self.entries = {}
         self.errors = {}
+        self.history = []
         self.num_requests = 0
         self.num_failures = 0
         self.max_requests = None
@@ -49,6 +51,7 @@ class RequestStats(object):
         self.start_time = time.time()
         self.num_requests = 0
         self.num_failures = 0
+        self.history = []
         for r in self.entries.itervalues():
             r.reset()
     
@@ -60,6 +63,7 @@ class RequestStats(object):
         self.num_failures = 0
         self.entries = {}
         self.errors = {}
+        self.history = []
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
@@ -416,6 +420,14 @@ def on_request_success(request_type, name, response_time, response_length):
     if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
         raise StopLocust("Maximum number of requests reached")
     global_stats.get(name, request_type).log(response_time, response_length)
+    global_stats.history.append({
+        "request_time": time.time(),
+        "request_type": request_type,
+        "request_url": name,
+        "response_time": response_time,
+        "response_length": response_length,
+        "user_count": runners.locust_runner.locust_count
+    })
 
 def on_request_failure(request_type, name, response_time, exception):
     if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -23,6 +23,7 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
+        self.locust_count = 0
     
     def get(self, name, method):
         """

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,7 +1,6 @@
 import time
 import gevent
 import hashlib
-import runners
 
 import events
 from exception import StopLocust

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -427,7 +427,7 @@ def on_request_success(request_type, name, response_time, response_length):
         "request_url": name,
         "response_time": response_time,
         "response_length": response_length,
-        "user_count": runners.locust_runner.locust_count
+        "user_count": global_stats.locust_count
     })
 
 def on_request_failure(request_type, name, response_time, exception):

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -136,7 +136,8 @@
                     <div style="margin-top:20px;">
                         <a href="/stats/requests/csv">Download request statistics CSV</a><br>
                         <a href="/stats/distribution/csv">Download response time distribution CSV</a><br>
-                        <a href="/exceptions/csv">Download exceptions CSV</a>
+                        <a href="/exceptions/csv">Download exceptions CSV</a><br>
+                        <a href="/request/history">Download full request history CSV</a>
                     </div>
                 </div>
             </div>

--- a/locust/web.py
+++ b/locust/web.py
@@ -132,6 +132,28 @@ def distribution_stats_csv():
     response.headers["Content-disposition"] = disposition
     return response
 
+
+@app.route('/request/history')
+def request_history():
+    rows = [",".join((
+        '"request_time"',
+        '"request_type"',
+        '"request_url"',
+        '"response_time"',
+        '"response_length"',
+        '"user_count"',
+    ))]
+    for s in runners.global_stats.history:
+        rows.append('"%s","%s","%s","%s","%i","%i"' % (s["request_time"], s["request_type"], s["request_url"], s["response_time"], s["response_length"], s["user_count"],))
+
+    response = make_response("\n".join(rows))
+    file_name = "request_history_{0}.csv".format(time())
+    disposition = "attachment;filename={0}".format(file_name)
+    response.headers["Content-type"] = "text/csv"
+    response.headers["Content-disposition"] = disposition
+    return response
+
+
 @app.route('/stats/requests')
 @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
 def request_stats():


### PR DESCRIPTION
Locust will now save the request statistics for each request into a "history". This history can be downloaded in CSV form. 

(This can help identify issues which happen intermittently in the run, such as the web server rubber banding on requests.)