### PR TITLE
Fixed failures percentage calculation in Total

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -21,7 +21,7 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
-    
+
     def get(self, name, method):
         """
         Retrieve a StatsEntry instance by name and method
@@ -31,17 +31,17 @@ class RequestStats(object):
             entry = StatsEntry(self, name, method)
             self.entries[(name, method)] = entry
         return entry
-    
+
     def aggregated_stats(self, name="Total", full_request_history=False):
         """
-        Returns a StatsEntry which is an aggregate of all stats entries 
+        Returns a StatsEntry which is an aggregate of all stats entries
         within entries.
         """
         total = StatsEntry(self, name, method=None)
         for r in self.entries.itervalues():
             total.extend(r, full_request_history=full_request_history)
         return total
-    
+
     def reset_all(self):
         """
         Go through all stats entries and reset them to zero
@@ -51,7 +51,7 @@ class RequestStats(object):
         self.num_failures = 0
         for r in self.entries.itervalues():
             r.reset()
-    
+
     def clear_all(self):
         """
         Remove all stats entries and errors
@@ -63,63 +63,63 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
-        
+
 
 class StatsEntry(object):
     """
     Represents a single stats entry (name and method)
     """
-    
+
     name = None
     """ Name (URL) of this stats entry """
-    
+
     method = None
     """ Method (GET, POST, PUT, etc.) """
-    
+
     num_requests = None
     """ The number of requests made """
-    
+
     num_failures = None
     """ Number of failed request """
-    
+
     total_response_time = None
     """ Total sum of the response times """
-    
+
     min_response_time = None
     """ Minimum response time """
-    
+
     max_response_time = None
     """ Maximum response time """
-    
+
     num_reqs_per_sec = None
     """ A {second => request_count} dict that holds the number of requests made per second """
-    
+
     response_times = None
     """
     A {response_time => count} dict that holds the response time distribution of all
     the requests.
-    
-    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90, 
+
+    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90,
     100, 200 .. 900, 1000, 2000 ... 9000, in order to save memory.
-    
+
     This dict is used to calculate the median and percentile response times.
     """
-    
+
     total_content_length = None
     """ The sum of the content length of all the requests for this entry """
-    
+
     start_time = None
     """ Time of the first request for this entry """
-    
+
     last_request_timestamp = None
     """ Time of the last request for this entry """
-    
+
     def __init__(self, stats, name, method):
         self.stats = stats
         self.name = name
         self.method = method
         self.reset()
-    
+
     def reset(self):
         self.start_time = time.time()
         self.num_requests = 0
@@ -131,7 +131,7 @@ class StatsEntry(object):
         self.last_request_timestamp = int(time.time())
         self.num_reqs_per_sec = {}
         self.total_content_length = 0
-    
+
     def log(self, response_time, content_length):
         self.stats.num_requests += 1
         self.num_requests += 1
@@ -230,16 +230,16 @@ class StatsEntry(object):
             return self.total_content_length / self.num_requests
         except ZeroDivisionError:
             return 0
-    
+
     def extend(self, other, full_request_history=False):
         """
         Extend the data fro the current StatsEntry with the stats from another
-        StatsEntry instance. 
-        
-        If full_request_history is False, we'll only care to add the data from 
-        the last 20 seconds of other's stats. The reason for this argument is that 
-        extend can be used to generate an aggregate of multiple different StatsEntry 
-        instances on the fly, in order to get the *total* current RPS, average 
+        StatsEntry instance.
+
+        If full_request_history is False, we'll only care to add the data from
+        the last 20 seconds of other's stats. The reason for this argument is that
+        extend can be used to generate an aggregate of multiple different StatsEntry
+        instances on the fly, in order to get the *total* current RPS, average
         response time, etc.
         """
         self.last_request_timestamp = max(self.last_request_timestamp, other.last_request_timestamp)
@@ -262,7 +262,7 @@ class StatsEntry(object):
             for i in xrange(other.last_request_timestamp-20, other.last_request_timestamp+1):
                 if i in other.num_reqs_per_sec:
                     self.num_reqs_per_sec[i] = self.num_reqs_per_sec.get(i, 0) + other.num_reqs_per_sec[i]
-    
+
     def serialize(self):
         return {
             "name": self.name,
@@ -278,7 +278,7 @@ class StatsEntry(object):
             "response_times": self.response_times,
             "num_reqs_per_sec": self.num_reqs_per_sec,
         }
-    
+
     @classmethod
     def unserialize(cls, data):
         obj = cls(None, data["name"], data["method"])
@@ -296,7 +296,7 @@ class StatsEntry(object):
         ]:
             setattr(obj, key, data[key])
         return obj
-    
+
     def get_stripped_report(self):
         """
         Return the serialized version of this StatsEntry, and then clear the current stats.
@@ -310,7 +310,7 @@ class StatsEntry(object):
             fail_percent = (self.num_failures/float(self.num_requests + self.num_failures))*100
         except ZeroDivisionError:
             fail_percent = 0
-        
+
         return (" %-" + str(STATS_NAME_WIDTH) + "s %7d %12s %7d %7d %7d  | %7d %7.2f") % (
             self.method + " " + self.name,
             self.num_requests,
@@ -321,12 +321,12 @@ class StatsEntry(object):
             self.median_response_time or 0,
             self.current_rps or 0
         )
-    
+
     def get_response_time_percentile(self, percent):
         """
         Get the response time that a certain number of percent of the requests
         finished within.
-        
+
         Percent specified in range: 0.0 - 1.0
         """
         num_of_request = int((self.num_requests * percent))
@@ -340,7 +340,7 @@ class StatsEntry(object):
     def percentile(self, tpl=" %-" + str(STATS_NAME_WIDTH) + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d"):
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
-        
+
         return tpl % (
             str(self.method) + " " + self.name,
             self.num_requests,
@@ -371,7 +371,7 @@ class StatsError(object):
         self.occurences += 1
 
     def to_name(self):
-        return "%s %s: %r" % (self.method, 
+        return "%s %s: %r" % (self.method,
             self.name, repr(self.error))
 
     def to_dict(self):
@@ -385,9 +385,9 @@ class StatsError(object):
     @classmethod
     def from_dict(cls, data):
         return cls(
-            data["method"], 
-            data["name"], 
-            data["error"], 
+            data["method"],
+            data["name"],
+            data["error"],
             data["occurences"]
         )
 
@@ -463,7 +463,7 @@ def print_stats(stats):
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
 
     try:
-        fail_percent = (total_failures/float(total_reqs))*100
+        fail_percent = (total_failures/float(total_reqs+total_failures))*100
     except ZeroDivisionError:
         fail_percent = 0
 
@@ -479,7 +479,7 @@ def print_percentile_stats(stats):
         if r.response_times:
             console_logger.info(r.percentile())
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
-    
+
     total_stats = global_stats.aggregated_stats()
     if total_stats.response_times:
         console_logger.info(total_stats.percentile())

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -21,7 +21,7 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
-
+    
     def get(self, name, method):
         """
         Retrieve a StatsEntry instance by name and method
@@ -31,17 +31,17 @@ class RequestStats(object):
             entry = StatsEntry(self, name, method)
             self.entries[(name, method)] = entry
         return entry
-
+    
     def aggregated_stats(self, name="Total", full_request_history=False):
         """
-        Returns a StatsEntry which is an aggregate of all stats entries
+        Returns a StatsEntry which is an aggregate of all stats entries 
         within entries.
         """
         total = StatsEntry(self, name, method=None)
         for r in self.entries.itervalues():
             total.extend(r, full_request_history=full_request_history)
         return total
-
+    
     def reset_all(self):
         """
         Go through all stats entries and reset them to zero
@@ -51,7 +51,7 @@ class RequestStats(object):
         self.num_failures = 0
         for r in self.entries.itervalues():
             r.reset()
-
+    
     def clear_all(self):
         """
         Remove all stats entries and errors
@@ -63,63 +63,63 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
-
+        
 
 class StatsEntry(object):
     """
     Represents a single stats entry (name and method)
     """
-
+    
     name = None
     """ Name (URL) of this stats entry """
-
+    
     method = None
     """ Method (GET, POST, PUT, etc.) """
-
+    
     num_requests = None
     """ The number of requests made """
-
+    
     num_failures = None
     """ Number of failed request """
-
+    
     total_response_time = None
     """ Total sum of the response times """
-
+    
     min_response_time = None
     """ Minimum response time """
-
+    
     max_response_time = None
     """ Maximum response time """
-
+    
     num_reqs_per_sec = None
     """ A {second => request_count} dict that holds the number of requests made per second """
-
+    
     response_times = None
     """
     A {response_time => count} dict that holds the response time distribution of all
     the requests.
-
-    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90,
+    
+    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90, 
     100, 200 .. 900, 1000, 2000 ... 9000, in order to save memory.
-
+    
     This dict is used to calculate the median and percentile response times.
     """
-
+    
     total_content_length = None
     """ The sum of the content length of all the requests for this entry """
-
+    
     start_time = None
     """ Time of the first request for this entry """
-
+    
     last_request_timestamp = None
     """ Time of the last request for this entry """
-
+    
     def __init__(self, stats, name, method):
         self.stats = stats
         self.name = name
         self.method = method
         self.reset()
-
+    
     def reset(self):
         self.start_time = time.time()
         self.num_requests = 0
@@ -131,7 +131,7 @@ class StatsEntry(object):
         self.last_request_timestamp = int(time.time())
         self.num_reqs_per_sec = {}
         self.total_content_length = 0
-
+    
     def log(self, response_time, content_length):
         self.stats.num_requests += 1
         self.num_requests += 1
@@ -230,16 +230,16 @@ class StatsEntry(object):
             return self.total_content_length / self.num_requests
         except ZeroDivisionError:
             return 0
-
+    
     def extend(self, other, full_request_history=False):
         """
         Extend the data fro the current StatsEntry with the stats from another
-        StatsEntry instance.
-
-        If full_request_history is False, we'll only care to add the data from
-        the last 20 seconds of other's stats. The reason for this argument is that
-        extend can be used to generate an aggregate of multiple different StatsEntry
-        instances on the fly, in order to get the *total* current RPS, average
+        StatsEntry instance. 
+        
+        If full_request_history is False, we'll only care to add the data from 
+        the last 20 seconds of other's stats. The reason for this argument is that 
+        extend can be used to generate an aggregate of multiple different StatsEntry 
+        instances on the fly, in order to get the *total* current RPS, average 
         response time, etc.
         """
         self.last_request_timestamp = max(self.last_request_timestamp, other.last_request_timestamp)
@@ -262,7 +262,7 @@ class StatsEntry(object):
             for i in xrange(other.last_request_timestamp-20, other.last_request_timestamp+1):
                 if i in other.num_reqs_per_sec:
                     self.num_reqs_per_sec[i] = self.num_reqs_per_sec.get(i, 0) + other.num_reqs_per_sec[i]
-
+    
     def serialize(self):
         return {
             "name": self.name,
@@ -278,7 +278,7 @@ class StatsEntry(object):
             "response_times": self.response_times,
             "num_reqs_per_sec": self.num_reqs_per_sec,
         }
-
+    
     @classmethod
     def unserialize(cls, data):
         obj = cls(None, data["name"], data["method"])
@@ -296,7 +296,7 @@ class StatsEntry(object):
         ]:
             setattr(obj, key, data[key])
         return obj
-
+    
     def get_stripped_report(self):
         """
         Return the serialized version of this StatsEntry, and then clear the current stats.
@@ -310,7 +310,7 @@ class StatsEntry(object):
             fail_percent = (self.num_failures/float(self.num_requests + self.num_failures))*100
         except ZeroDivisionError:
             fail_percent = 0
-
+        
         return (" %-" + str(STATS_NAME_WIDTH) + "s %7d %12s %7d %7d %7d  | %7d %7.2f") % (
             self.method + " " + self.name,
             self.num_requests,
@@ -321,12 +321,12 @@ class StatsEntry(object):
             self.median_response_time or 0,
             self.current_rps or 0
         )
-
+    
     def get_response_time_percentile(self, percent):
         """
         Get the response time that a certain number of percent of the requests
         finished within.
-
+        
         Percent specified in range: 0.0 - 1.0
         """
         num_of_request = int((self.num_requests * percent))
@@ -340,7 +340,7 @@ class StatsEntry(object):
     def percentile(self, tpl=" %-" + str(STATS_NAME_WIDTH) + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d"):
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
-
+        
         return tpl % (
             str(self.method) + " " + self.name,
             self.num_requests,
@@ -371,7 +371,7 @@ class StatsError(object):
         self.occurences += 1
 
     def to_name(self):
-        return "%s %s: %r" % (self.method,
+        return "%s %s: %r" % (self.method, 
             self.name, repr(self.error))
 
     def to_dict(self):
@@ -385,9 +385,9 @@ class StatsError(object):
     @classmethod
     def from_dict(cls, data):
         return cls(
-            data["method"],
-            data["name"],
-            data["error"],
+            data["method"], 
+            data["name"], 
+            data["error"], 
             data["occurences"]
         )
 
@@ -463,7 +463,7 @@ def print_stats(stats):
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
 
     try:
-        fail_percent = (total_failures/float(total_reqs+total_failures))*100
+        fail_percent = (total_failures/float(total_reqs + total_failures))*100
     except ZeroDivisionError:
         fail_percent = 0
 
@@ -479,7 +479,7 @@ def print_percentile_stats(stats):
         if r.response_times:
             console_logger.info(r.percentile())
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
-
+    
     total_stats = global_stats.aggregated_stats()
     if total_stats.response_times:
         console_logger.info(total_stats.percentile())


### PR DESCRIPTION
The percentage calculation was essentially comparing failures to the number of successes (confusingly referred to as reqs [requests]) - fixed the math to have it calculate percent failure as a percentage of all requests.