### PR TITLE
Removing apostrophe from possessive its.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in your code before letting real users in.
 
 Locust is completely event based, and therefore it's possible to support thousands of concurrent users on a single machine.
 In contrast to many other event-based apps it doesn't use callbacks. Instead it uses light-weight processes, through <a href="http://www.gevent.org/">gevent</a>.
-Each locust swarming your site is actually running inside it's own process (or greenlet, to be correct).
+Each locust swarming your site is actually running inside its own process (or greenlet, to be correct).
 This allows you to write very expressive scenarios in Python without complicating your code with callbacks.
 
 

--- a/docs/testing-other-systems.rst
+++ b/docs/testing-other-systems.rst
@@ -2,7 +2,7 @@
 Testing other systems using custom clients
 ===========================================
 
-Locust was built with HTTP as it's main target. However, it can easily be extended to load test 
+Locust was built with HTTP as its main target. However, it can easily be extended to load test 
 any request/response based system, by writing a custom client that triggers 
 :py:attr:`request_success <locust.events.request_success>` and 
 :py:attr:`request_failure <locust.events.request_failure>` events.
@@ -16,10 +16,10 @@ Here is an example of a Locust class, **XmlRpcLocust**, which provides an XML-RP
 .. literalinclude:: ../examples/custom_xmlrpc_client/xmlrpc_locustfile.py
 
 If you've written Locust tests before, you'll recognize the class called *ApiUser* which is a normal 
-Locust class that has a *TaskSet* class with *tasks* in it's *task_set* attribute. However, the *ApiUser* 
+Locust class that has a *TaskSet* class with *tasks* in its *task_set* attribute. However, the *ApiUser* 
 inherits from *XmlRpcLocust* that you can see right above ApiUser. The *XmlRpcLocust* class provides an 
 instance of XmlRpcClient under the *client* attribute. The *XmlRpcClient* is a wrapper around the standard 
-library's :py:class:`xmlrpclib.ServerProxy`. It  basically just proxies the function calls, but with the 
+library's :py:class:`xmlrpclib.ServerProxy`. It basically just proxies the function calls, but with the 
 important addition of firing :py:attr:`locust.events.request_success` and :py:attr:`locust.events.request_failure` 
 events, which will make all calls reported in Locust's statistics.
 

--- a/docs/what-is-locust.rst
+++ b/docs/what-is-locust.rst
@@ -14,7 +14,7 @@ letting real users in.
 Locust is completely event based, and therefore it's possible to support thousands of concurrent 
 users on a single machine. In contrast to many other event-based apps it doesn't use callbacks. 
 Instead it uses light-weight processes, through `gevent <http://www.gevent.org/>`_. Each locust 
-swarming your site is actually running inside it's own process (or greenlet, to be correct). This 
+swarming your site is actually running inside its own process (or greenlet, to be correct). This 
 allows you to write very expressive scenarios in Python without complicating your code with callbacks.
 
 

--- a/locust/core.py
+++ b/locust/core.py
@@ -170,7 +170,7 @@ class TaskSet(object):
     Class defining a set of tasks that a Locust user will execute. 
     
     When a TaskSet starts running, it will pick a task from the *tasks* attribute, 
-    execute it, call it's wait function which will sleep a random number between
+    execute it, call its wait function which will sleep a random number between
     *min_wait* and *max_wait* milliseconds. It will then schedule another task for 
     execution and so on.
     
@@ -191,7 +191,7 @@ class TaskSet(object):
 
     If tasks is a *(callable,int)* list of two-tuples, or a  {callable:int} dict, 
     the task to be performed will be picked randomly, but each task will be weighted 
-    according to it's corresponding int value. So in the following case *ThreadPage* will 
+    according to its corresponding int value. So in the following case *ThreadPage* will 
     be fifteen times more likely to be picked than *write_post*::
 
         class ForumPage(TaskSet):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -59,7 +59,7 @@ class LocustRunner(object):
 
     def weight_locusts(self, amount, stop_timeout = None):
         """
-        Distributes the amount of locusts for each WebLocust-class according to it's weight
+        Distributes the amount of locusts for each WebLocust-class according to its weight
         returns a list "bucket" with the weighted locusts
         """
         bucket = []


### PR DESCRIPTION
I noticed a few instances of "it's" instead of "its" for the possessive form of "it" and wanted to correct them.

I left `changelog.md` untouched since I see it as more of a historical document than a living document.
