### PR TITLE
Multiple locustfile discovery and ability to "switch" between locustfiles while running

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -57,7 +57,8 @@ def parse_options():
         '-f', '--locustfile',
         dest='locustfile',
         default='locustfile',
-        help="Python module file to import, e.g. '../other.py'. Default: locustfile"
+        help="Python module file or directory to import, e.g. '../other.py' or 'locustfiles/'. If directory, "
+             "the default locustfile will be the first valid module found in that directory. Default: locustfile"
     )
 
     # if locust should be run in distributed mode as master

--- a/locust/main.py
+++ b/locust/main.py
@@ -293,10 +293,10 @@ def is_locust(tup):
 
 def load_locustfile(path):
     """
-    Import given locustfile path and return {module: (docstring, callables)}.
+    Import given locustfile path and return {module: (callables)}.
 
-    Specifically, the locustfile's ``__doc__`` attribute (a string) and a
-    dictionary of ``{'name': callable}`` containing all callables which pass
+    <module> -- the name of the module in which the locusts are contained
+    <callables> -- a dictionary of ``{'name': callable}`` containing all callables which pass
     the "is a Locust" test.
     """
     # Get directory and locustfile name
@@ -327,9 +327,9 @@ def load_locustfile(path):
     if index is not None:
         sys.path.insert(index + 1, directory)
         del sys.path[0]
-    # Return our two-tuple
+
     locusts = dict(filter(is_locust, vars(imported).items()))
-    return {os.path.splitext(locustfile)[0]: (imported.__doc__, locusts)}
+    return {os.path.splitext(locustfile)[0]: locusts}
 
 
 def getmodule(path, suffixes=('.py',)):
@@ -397,7 +397,7 @@ def main():
     logger.info("All available locustfiles: {}".format(all_locustfiles))
 
     # Use the first locustfile for the default locusts
-    docstring, locusts = all_locustfiles.values()[0]
+    locusts = all_locustfiles.values()[0]
 
     if options.list_commands:
         console_logger.info("Available Locusts:")

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -61,6 +61,23 @@ $('#swarm_form').submit(function(event) {
     );
 });
 
+$('#switch_form').submit(function(event) {
+    event.preventDefault();
+    $.post($(this).attr("action"), $(this).serialize(),
+        function(response) {
+            if (response.success) {
+                $("body").attr("class", "hatching");
+                $("#start").fadeOut();
+                $("#status").fadeIn();
+                $(".box_running").fadeIn();
+                $("a.new_test").fadeOut();
+                $("a.edit_test").fadeIn();
+                $(".user_count").fadeIn();
+            }
+        }
+    );
+});
+
 $('#edit_form').submit(function(event) {
     event.preventDefault();
     $.post($(this).attr("action"), $(this).serialize(),

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -122,12 +122,16 @@ a {
     float: right;
 }
 
+.start select {
+    width: 100%;
+}
+
 
 .stopped .start {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }
@@ -137,7 +141,7 @@ a {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }
@@ -265,7 +269,7 @@ ul.tabs li a.current {
     margin-left: -169px;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -58,6 +58,13 @@
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
                     <input type="text" name="hatch_rate" id="hatch_rate" class="val" /><br>
+                    <label for="locustfile">Locust file to execute</label>
+                    <select name="locustfile" id="locustfile" class="val">
+                        {% for name in available_locustfiles %}
+                            <option value="{{name}}">{{name}}</option>
+                        {% endfor %}
+                    </select>
+                    <br>
                     <input type="image" src="/static/img/start_button.png" value="Start swarming" class="start_button">
                 </form>
                 <div style="clear:right;"></div>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -41,6 +41,18 @@
                 <div class="top_box box_stop box_running" id="box_reset">
                     <a href="/stats/reset">Reset Stats</a>
                 </div>
+                <div class="top_box box_stop box_running" id="box_switch">
+                    <form action="/switch" method="POST" id="switch_form">
+                        <div class="label">Switch to locustfile</div>
+                        <select name="locustfile" id="locustfile_switch" class="val">
+                            {% for name in available_locustfiles %}
+                                <option value="{{name}}">{{name}}</option>
+                            {% endfor %}
+                        </select>
+                        <br>
+                        <input type="submit" value="restart" class="start_button">
+                    </form>
+                </div>
             </div>
             <div style="clear:both;"></div>
         </div>

--- a/locust/web.py
+++ b/locust/web.py
@@ -51,14 +51,29 @@ def swarm():
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
     runners.locust_runner.start_hatching(locust_count, hatch_rate)
-    response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
+    response = make_response(json.dumps({'success': True, 'message': 'Swarming started'}))
     response.headers["Content-type"] = "application/json"
     return response
 
 @app.route('/stop')
 def stop():
     runners.locust_runner.stop()
-    response = make_response(json.dumps({'success':True, 'message': 'Test stopped'}))
+    response = make_response(json.dumps({'success': True, 'message': 'Test stopped'}))
+    response.headers["Content-type"] = "application/json"
+    return response
+
+@app.route('/switch', methods=["POST"])
+def switch():
+    name = request.form["locustfile"]
+    assert name in runners.locust_runner.available_locustfiles
+
+    runners.locust_runner.stop()
+    runners.locust_runner.stats.reset_all()
+    runners.locust_runner.switch(name)
+    # Use whatever existing clients and hatch rate numbers are
+    runners.locust_runner.start_hatching(runners.locust_runner.num_clients, runners.locust_runner.hatch_rate)
+
+    response = make_response(json.dumps({'success': True, 'message': 'Switched to locustfile "{}"'.format(name)}))
     response.headers["Content-type"] = "application/json"
     return response
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -34,12 +34,13 @@ def index():
         slave_count = runners.locust_runner.slave_count
     else:
         slave_count = 0
-    
+
     return render_template("index.html",
         state=runners.locust_runner.state,
         is_distributed=is_distributed,
         slave_count=slave_count,
         user_count=runners.locust_runner.user_count,
+        available_locustfiles=runners.locust_runner.available_locustfiles.keys(),
         version=version
     )
 


### PR DESCRIPTION
This PR allows the user to specify a directory of locust files instead of a single file (similar to how nosetests discovers and runs tests). Using the list of available files, users can quickly switch between files while running. For instance, while running my "login" locustfile suite, I can instruct all slaves to switch to running my "logout" suite. The "discovered" locustfiles will appear as a dropdown menu in the web interface, but a switch can also be triggered programmatically by calling `.switch(locustfile)` on any of the runners. 
###### Two examples of valid commands with this update:

single file: 
`locust -f locustfiles/login.py`

directory:
`locust -f locustfiles/`
###### A valid switch assuming "login.py" is a locustfile:

`my_local_runner.switch('login')`
