### PR TITLE
Allow running --no-web in distributed with multiple locustfiles

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -57,7 +57,8 @@ def parse_options():
         '-f', '--locustfile',
         dest='locustfile',
         default='locustfile',
-        help="Python module file to import, e.g. '../other.py'. Default: locustfile"
+        help="Python module file or directory to import, e.g. '../other.py' or 'locustfiles/'. If directory, "
+             "the default locustfile will be the first valid module found in that directory. Default: locustfile"
     )
 
     # if locust should be run in distributed mode as master

--- a/locust/main.py
+++ b/locust/main.py
@@ -8,18 +8,23 @@ import signal
 import inspect
 import logging
 import socket
+import time
 from optparse import OptionParser
+from gevent.pool import Group
 
 import web
 from log import setup_logging, console_logger
 from stats import stats_printer, print_percentile_stats, print_error_report, print_stats
 from inspectlocust import print_task_ratio, get_task_ratio_dict
 from core import Locust, HttpLocust
-from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
+from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner, NoWebMasterLocustRunner
 import events
+
+import polling
 
 _internals = [Locust, HttpLocust]
 version = locust.version
+
 
 def parse_options():
     """
@@ -116,6 +121,15 @@ def parse_options():
         help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557. Note that Locust will also use this port + 1, so by default the master node will bind to 5557 and 5558."
     )
 
+    parser.add_option(
+        '--min-slaves',
+        action='store',
+        type='int',
+        dest='min_slaves',
+        default=1,
+        help="The minimum number of slaves for the master to expect before it starts swarming. Only used when running with --master and --no-web."
+    )
+
     # if we should print stats in the console
     parser.add_option(
         '--no-web',
@@ -153,6 +167,24 @@ def parse_options():
         dest='num_requests',
         default=None,
         help="Number of requests to perform. Only used together with --no-web"
+    )
+
+    parser.add_option(
+        '-t', '--timeout',
+        action='store',
+        type='int',
+        dest='timeout',
+        default=None,
+        help="Maximum number of seconds to run each locustfile for. Note that there may be multiple locustfiles and this is not a global timeout."
+    )
+
+    parser.add_option(
+        '--cooldown',
+        action='store',
+        type='int',
+        dest='cooldown',
+        default=0,
+        help='Number of seconds to wait before running the next locustfile.'
     )
     
     # log level
@@ -437,32 +469,56 @@ def main():
         }
         console_logger.info(dumps(task_data))
         sys.exit(0)
-    
-    # if --master is set, make sure --no-web isn't set
-    if options.master and options.no_web:
-        logger.error("Locust can not run distributed with the web interface disabled (do not use --no-web and --master together)")
-        sys.exit(0)
+
+    if options.master and options.no_web and not options.min_slaves:
+        logger.error("When running --master and --no-web, you must specify --min-slaves to be available before starting to swarm")
+        sys.exit(1)
+
+    if options.master and options.no_web and not (options.timeout or options.num_requests):
+        logger.error("When running --master and --no-web, you must specify either --num-request or --timeout to tell the slaves when to stop running each locustfile")
+        sys.exit(1)
 
     if not options.no_web and not options.slave:
         # spawn web greenlet
         logger.info("Starting web monitor at %s:%s" % (options.web_host or "*", options.port))
         main_greenlet = gevent.spawn(web.start, locust_classes, options)
-    
-    if not options.master and not options.slave:
-        runners.locust_runner = LocalLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles)
-        # spawn client spawning/hatching greenlet
-        if options.no_web:
-            runners.locust_runner.start_hatching(wait=True)
-            main_greenlet = runners.locust_runner.greenlet
-    elif options.master:
-        runners.locust_runner = MasterLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles)
-    elif options.slave:
+
+    if options.slave:
+        logger.info("Waiting for master to become available")
         try:
-            runners.locust_runner = SlaveLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles)
-            main_greenlet = runners.locust_runner.greenlet
-        except socket.error, e:
-            logger.error("Failed to connect to the Locust master: %s", e)
+            runners.locust_runner = polling.poll(
+                lambda: SlaveLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles),
+                timeout=60,
+                step=1,
+                ignore_exceptions=(socket.error,))
+
+        except polling.TimeoutException, e:
+            logger.error("Failed to connect to the Locust master: %s", e.last)
             sys.exit(-1)
+
+        main_greenlet = runners.locust_runner.greenlet
+
+    elif options.master:
+
+        if options.no_web:
+            # Just start running the suites as soon as the minimum number of slaves come online
+            runners.locust_runner = NoWebMasterLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles)
+
+            logger.info("Waiting for {} slaves to become available before swarming".format(options.min_slaves))
+            try:
+                runners.locust_runner.wait_for_slaves(options.min_slaves, timeout=60)
+            except polling.TimeoutException, e:
+                logger.error("Minimum expected slaves were never available. Expected {} ({} available)".format(options.min_slaves, e.last))
+                sys.exit(1)
+
+            runners.locust_runner.slaves_start_swarming(
+                max_num_requests=options.num_requests,
+                max_seconds_elapsed=options.timeout)
+
+        else:
+            runners.locust_runner = MasterLocustRunner(locust_classes, options, available_locustfiles=all_locustfiles)
+
+        main_greenlet = runners.locust_runner.greenlet
     
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet

--- a/locust/main.py
+++ b/locust/main.py
@@ -293,10 +293,10 @@ def is_locust(tup):
 
 def load_locustfile(path):
     """
-    Import given locustfile path and return {module: (docstring, callables)}.
+    Import given locustfile path and return {module: (callables)}.
 
-    Specifically, the locustfile's ``__doc__`` attribute (a string) and a
-    dictionary of ``{'name': callable}`` containing all callables which pass
+    <module> -- the name of the module in which the locusts are contained
+    <callables> -- a dictionary of ``{'name': callable}`` containing all callables which pass
     the "is a Locust" test.
     """
     # Get directory and locustfile name
@@ -327,9 +327,9 @@ def load_locustfile(path):
     if index is not None:
         sys.path.insert(index + 1, directory)
         del sys.path[0]
-    # Return our two-tuple
+
     locusts = dict(filter(is_locust, vars(imported).items()))
-    return {os.path.splitext(locustfile)[0]: (imported.__doc__, locusts)}
+    return {os.path.splitext(locustfile)[0]: locusts}
 
 
 def getmodule(path, suffixes=('.py',)):
@@ -397,7 +397,7 @@ def main():
     logger.info("All available locustfiles: {}".format(all_locustfiles))
 
     # Use the first locustfile for the default locusts
-    docstring, locusts = all_locustfiles.values()[0]
+    locusts = all_locustfiles.values()[0]
 
     if options.list_commands:
         console_logger.info("Available Locusts:")

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -61,6 +61,23 @@ $('#swarm_form').submit(function(event) {
     );
 });
 
+$('#switch_form').submit(function(event) {
+    event.preventDefault();
+    $.post($(this).attr("action"), $(this).serialize(),
+        function(response) {
+            if (response.success) {
+                $("body").attr("class", "hatching");
+                $("#start").fadeOut();
+                $("#status").fadeIn();
+                $(".box_running").fadeIn();
+                $("a.new_test").fadeOut();
+                $("a.edit_test").fadeIn();
+                $(".user_count").fadeIn();
+            }
+        }
+    );
+});
+
 $('#edit_form').submit(function(event) {
     event.preventDefault();
     $.post($(this).attr("action"), $(this).serialize(),

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -122,12 +122,16 @@ a {
     float: right;
 }
 
+.start select {
+    width: 100%;
+}
+
 
 .stopped .start {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }
@@ -137,7 +141,7 @@ a {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }
@@ -265,7 +269,7 @@ ul.tabs li a.current {
     margin-left: -169px;
     border-radius: 5px;
     -moz-border-radius: 5px;
-    -webkit-border-radisu: 5px;
+    -webkit-border-radius: 5px;
     border: 3px solid #eee;
     background: #111717;
 }

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -58,6 +58,13 @@
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
                     <input type="text" name="hatch_rate" id="hatch_rate" class="val" /><br>
+                    <label for="locustfile">Locust file to execute</label>
+                    <select name="locustfile" id="locustfile" class="val">
+                        {% for name in available_locustfiles %}
+                            <option value="{{name}}">{{name}}</option>
+                        {% endfor %}
+                    </select>
+                    <br>
                     <input type="image" src="/static/img/start_button.png" value="Start swarming" class="start_button">
                 </form>
                 <div style="clear:right;"></div>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -41,6 +41,18 @@
                 <div class="top_box box_stop box_running" id="box_reset">
                     <a href="/stats/reset">Reset Stats</a>
                 </div>
+                <div class="top_box box_stop box_running" id="box_switch">
+                    <form action="/switch" method="POST" id="switch_form">
+                        <div class="label">Switch to locustfile</div>
+                        <select name="locustfile" id="locustfile_switch" class="val">
+                            {% for name in available_locustfiles %}
+                                <option value="{{name}}">{{name}}</option>
+                            {% endfor %}
+                        </select>
+                        <br>
+                        <input type="submit" value="restart" class="start_button">
+                    </form>
+                </div>
             </div>
             <div style="clear:both;"></div>
         </div>

--- a/locust/web.py
+++ b/locust/web.py
@@ -51,14 +51,29 @@ def swarm():
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
     runners.locust_runner.start_hatching(locust_count, hatch_rate)
-    response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
+    response = make_response(json.dumps({'success': True, 'message': 'Swarming started'}))
     response.headers["Content-type"] = "application/json"
     return response
 
 @app.route('/stop')
 def stop():
     runners.locust_runner.stop()
-    response = make_response(json.dumps({'success':True, 'message': 'Test stopped'}))
+    response = make_response(json.dumps({'success': True, 'message': 'Test stopped'}))
+    response.headers["Content-type"] = "application/json"
+    return response
+
+@app.route('/switch', methods=["POST"])
+def switch():
+    name = request.form["locustfile"]
+    assert name in runners.locust_runner.available_locustfiles
+
+    runners.locust_runner.stop()
+    runners.locust_runner.stats.reset_all()
+    runners.locust_runner.switch(name)
+    # Use whatever existing clients and hatch rate numbers are
+    runners.locust_runner.start_hatching(runners.locust_runner.num_clients, runners.locust_runner.hatch_rate)
+
+    response = make_response(json.dumps({'success': True, 'message': 'Switched to locustfile "{}"'.format(name)}))
     response.headers["Content-type"] = "application/json"
     return response
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -34,12 +34,13 @@ def index():
         slave_count = runners.locust_runner.slave_count
     else:
         slave_count = 0
-    
+
     return render_template("index.html",
         state=runners.locust_runner.state,
         is_distributed=is_distributed,
         slave_count=slave_count,
         user_count=runners.locust_runner.user_count,
+        available_locustfiles=runners.locust_runner.available_locustfiles.keys(),
         version=version
     )
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent==1.0.1", "flask>=0.10.1", "requests>=2.4.1", "msgpack-python>=0.4.2"],
+    install_requires=["gevent==1.0.1", "flask>=0.10.1", "polling==0.2.0", "requests>=2.4.1", "msgpack-python>=0.4.2"],
     tests_require=['unittest2', 'mock', 'pyzmq'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
WIP, should not be merged yet, but feel free to use for your own projects. 

This PR builds on PR's https://github.com/locustio/locust/pull/371 and https://github.com/locustio/locust/pull/333.

It also adresses issues:
https://github.com/locustio/locust/issues/304
https://github.com/locustio/locust/issues/222
https://github.com/locustio/locust/issues/196
https://github.com/locustio/locust/issues/71

With these changes, I am trying to meet the demand for using locust to do load testing as part of a continuous integration pipeline for tools like Jenkins/Bamboo/Travis. While useful for doing manual one-off tests, the current locust version is not conducive for automating a suite of locustfiles to track performance over time. 

These improvements allow the user to specify a directory of locustfiles rather than just one (though a single locustfile is still supported). When run in distributed mode using --master with --no-web, the locust master will cycle through each locustfile and have the slaves execute the tasks until either:

- the maximum number or requests is reached
- or the maximum timeout has elapsed

On either of these two events, move on to the next locustfile.

#### Example

On the slaves, run:
```
locust --slave -f locustfiles/
```

On the master:
```
locust --master --min-slaves 4 -f locustfiles/ --no-web --host http://google.com -c 100 -n 5000 -t 600 --cooldown 30
```
When the slaves or master are started, both will not begin swarming until the master is online and has made connection with at least 4 slaves (`--min-slaves 4`). Once that happens, swarm with 100 clients (`-c 100`) until a total of 5000 requests are made (`-n 5000`) or 600 seconds have passed (`-t 600`). When either of those conditions happen, wait 30 seconds (`--cooldown 30`) then start swarming the next locustfile with the same parameters. Repeat until this has been done for all locustfiles. 