### PR TITLE
[#62] Correctly update slave count when drops below 1.

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -117,7 +117,7 @@ function updateStats() {
         $("#status_text").html(report.state);
         $("#userCount").html(report.user_count);
 
-        if (report.slave_count)
+        if (typeof report.slave_count !== "undefined")
             $("#slaveCount").html(report.slave_count)
 
         $('#stats tbody').empty();


### PR DESCRIPTION
"if (report.slave_count)" returns false when value is 0, so the UI doesn't update when all slaves are disconnected.