### PR TITLE
main function accepts direct call.

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -22,9 +22,11 @@ from .stats import (print_error_report, print_percentile_stats, print_stats,
 _internals = [Locust, HttpLocust]
 version = locust.__version__
 
-def parse_options():
+def parse_options(args=None):
     """
     Handle command-line options with optparse.OptionParser.
+    If args is given, parser regards them as command line arguments like ['--opt1=value1', '-o', value2'].
+    If not, sys.argv[1:] will be used.(default action of OptionParser)
 
     Return list of arguments, largely for use in `parse_arguments`.
     """
@@ -258,8 +260,11 @@ def parse_options():
 
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
-    opts, args = parser.parse_args()
-    return parser, opts, args
+    if args:
+        options, arguments = parser.parse_args(args)
+    else:
+        options, arguments = parser.parse_args()
+    return parser, options, arguments
 
 
 def _is_package(path):
@@ -358,8 +363,8 @@ def load_locustfile(path):
     locusts = dict(filter(is_locust, vars(imported).items()))
     return imported.__doc__, locusts
 
-def main():
-    parser, options, arguments = parse_options()
+def main(args=None):
+    parser, options, arguments = parse_options(args)
 
     # setup logging
     setup_logging(options.loglevel, options.logfile)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -36,8 +36,7 @@ class TestTaskSet(LocustTestCase):
         parser, options, args = main.parse_options()
         self.assertEqual('locustfile', options.locustfile)
         self.assertEqual(None, options.host)
-        # The value: python setup.py 'test'
-        self.assertEqual(['test'], args)
+        self.assertEqual([], args)
 
         parser, options, args = main.parse_options(args=shlex.split('--locustfile=test.py -H http://localhost:5000'))
         self.assertEqual('test.py', options.locustfile)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1,3 +1,5 @@
+import shlex
+
 from locust import main
 from locust.core import HttpLocust, Locust, TaskSet
 
@@ -27,3 +29,17 @@ class TestTaskSet(LocustTestCase):
             pass
         
         self.assertFalse(main.is_locust(("ThriftLocust", ThriftLocust)))
+
+
+    def test_parse_options(self):
+
+        parser, options, args = main.parse_options()
+        self.assertEqual('locustfile', options.locustfile)
+        self.assertEqual(None, options.host)
+        # The value: python setup.py 'test'
+        self.assertEqual(['test'], args)
+
+        parser, options, args = main.parse_options(args=shlex.split('--locustfile=test.py -H http://localhost:5000'))
+        self.assertEqual('test.py', options.locustfile)
+        self.assertEqual('http://localhost:5000', options.host)
+        self.assertEqual([], args)


### PR DESCRIPTION
This PR allows main function to be called directly with command line arguments. Could you check and merge it if you think it's good feature?
## Motivation

I want to integrate locust testing to setuptools like [tox](http://tox.readthedocs.org/en/latest/example/basic.html#integration-with-setuptools-distribute-test-commands).

Current implementation uses optparse.OptionParser#parse_args(). This regards sys.argv[1:] as command line arguments automatically. Thus, this also gets arguments(like custom args of setuptools) not related to locust unexpectedly. 

```
# -a is custom arguments of setuptools for tox.
$ python setup.py test -a "-epy27"
```

For this PR, we can run locust tests with arbitrary arguments like this.

```
class Locust(TestCommand):

    user_options = [
        ('locust-args=', 'a', 'Arguments for Locust')
    ]

    def initialize_options(self):
        TestCommand.initialize_options(self)
        self.locust_args = []

    def finalize_options(self):
        TestCommand.finalize_options(self)
        self.test_args = []
        self.test_suite = True

    def run_tests(self):
        import shlex
        from locust.main import main

        args = None
        if self.locust_args:
            args = shlex.split(self.locust_args)
        main(args=args)
```
