### PR TITLE
Master node to configure slaves before hatching.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,5 +74,5 @@ Available hooks
 The following event hooks are available under the **locust.events** module:
 
 .. automodule:: locust.events
-	:members: request_success, request_failure, locust_error, report_to_master, slave_report, hatch_complete, quitting
+	:members: request_success, request_failure, locust_error, report_to_master, slave_report, configuration_to_slaves, master_configuration, hatch_complete, quitting
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -27,9 +27,10 @@ class WebsiteUser(HttpLocust):
 We need somewhere to store the stats.
 
 On the master node stats will contain the aggregated sum of all content-lengths,
-while on the slave nodes this will be the sum of the content-lengths since the 
+while on the slave nodes this will be the sum of the content-lengths since the
 last stats report was sent to the master
 """
+collect_content_length = False
 stats = {"content-length":0}
 
 def on_request_success(request_type, name, response_time, response_length):
@@ -44,7 +45,7 @@ def on_report_to_master(client_id, data):
     to be sent to the locust master. It will allow us to add our extra content-length
     data to the dict that is being sent, and then we clear the local stats in the slave.
     """
-    data["content-length"] = stats["content-length"]
+    data["content-length"] = stats["content-length"] if collect_content_length else 0
     stats["content-length"] = 0
 
 def on_slave_report(client_id, data):
@@ -55,10 +56,29 @@ def on_slave_report(client_id, data):
     """
     stats["content-length"] += data["content-length"]
 
+def on_configuration_to_slaves(data):
+    """
+    Event that provides an opportunity a master host to forward its configuration
+    to slaves. Here we allow collecting of content length attributes. By default
+    it is disabled by global declaration above.
+    """
+    data["collect-content-length"] = True
+
+def on_master_configuration(data):
+    """
+    Event to receive configuration sent from the master node. Here it enables collection
+    of content length attribute.
+    """
+    global collect_content_length
+    collect_content_length = data.get("collect-content-length", False)
+
+
 # Hook up the event listeners
 events.request_success += on_request_success
 events.report_to_master += on_report_to_master
 events.slave_report += on_slave_report
+events.configuration_to_slaves += on_configuration_to_slaves
+events.master_configuration += on_master_configuration
 
 @web.app.route("/content-length")
 def total_content_length():

--- a/locust/events.py
+++ b/locust/events.py
@@ -90,12 +90,13 @@ Event is fired with following arguments:
 
 configuration_to_slaves = EventHook()
 """
-*configuration_to_slaves* is used when locust is running in --master mode and is fired master server
+*configuration_to_slaves* is used when locust is running in --master mode and is fired when master server
 is about to start hatching slaves.
 
 It can be used to distribute master configuration to slaves.
 
 Event is fired with the following arguments:
+
 * *data*: Data dict that can be modified in order to define configuration parameters
 """
 
@@ -105,7 +106,8 @@ master_configuration = EventHook()
 from the master node before actual hatching is started.
 
 Event is fired with the following arguments:
-* *data* configuration data from the master node
+
+* *data*: configuration data from the master node
 """
 
 hatch_complete = EventHook()

--- a/locust/events.py
+++ b/locust/events.py
@@ -88,6 +88,26 @@ Event is fired with following arguments:
 * *data*: Data dict with the data from the slave node
 """
 
+configuration_to_slaves = EventHook()
+"""
+*configuration_to_slaves* is used when locust is running in --master mode and is fired master server
+is about to start hatching slaves.
+
+It can be used to distribute master configuration to slaves.
+
+Event is fired with the following arguments:
+* *data*: Data dict that can be modified in order to define configuration parameters
+"""
+
+master_configuration = EventHook()
+"""
+*master_configuration* is used when it is necessary to obtain configuration data
+from the master node before actual hatching is started.
+
+Event is fired with the following arguments:
+* *data* configuration data from the master node
+"""
+
 hatch_complete = EventHook()
 """
 *hatch_complete* is fired when all locust users has been spawned.


### PR DESCRIPTION
Hello colleagues,

I was looking for a way to dynamically configure slave nodes before hatching new users, but failed to utilize any existing locust mechanism. So I came with two new events to send configuration data from master node to all attached slaves.

Changes:
- _configuration_to_slaves_ event configuration data from master node before hatching new users.
- _master_configuration_ event provides configuration data received from master node.
- slightly modified `examples/events.py` sample to illustrate the usage of new events
- update `api.rst` to include new properties

Please let me know if my approach is suitable, or if there is some better/more traditional solution.
Thanks in advance!
