### PR TITLE
Add starting events

### DIFF
--- a/locust/events.py
+++ b/locust/events.py
@@ -97,6 +97,14 @@ Event is fire with the following arguments:
 * *user_count*: Number of users that was hatched
 """
 
+starting = EventHook()
+"""
+*starting* is fired before locust runners are initialized
+
+Event is fired with the following arguments:
+* *options*: Locust options
+"""
+
 quitting = EventHook()
 """
 *quitting* is fired when the locust process in exiting

--- a/locust/main.py
+++ b/locust/main.py
@@ -396,7 +396,8 @@ def main():
         # spawn web greenlet
         logger.info("Starting web monitor at %s:%s" % (options.web_host or "*", options.port))
         main_greenlet = gevent.spawn(web.start, locust_classes, options)
-    
+
+    events.starting.fire(options=options)
     if not options.master and not options.slave:
         runners.locust_runner = LocalLocustRunner(locust_classes, options)
         # spawn client spawning/hatching greenlet


### PR DESCRIPTION
I need a way to perform at task before the workers are started. I cannot use the current starting_hatching events because i need the host.

Starting event is fired before the runners are setup, options
are passed as parameter.

I'd like to get some feedback if the feature is useful before spending time adding tests.
