### PR TITLE
Adds host name to the header

### DIFF
--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -77,6 +77,8 @@ a:hover {
     color: #000;
     font-size: 16px;
     font-weight: bold;
+    max-width: 165px;
+    word-wrap: break-word;
 }
 .boxes .box_rps .value, .boxes .box_slaves .value {
     font-size: 32px;
@@ -128,6 +130,10 @@ a:hover {
     background: #4e4141;
 }
 
+#host_url {
+    font-size: 14px;
+    font-weight: normal;
+}
 .boxes .box_running {
     display: none;
 }

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -10,6 +10,12 @@
         <div class="top-content container">
             <img src="/static/img/logo.png?v={{ version }}" class="logo" />
             <div class="boxes">
+                <div class="top_box box_url">
+                    <div class="label">HOST</div>
+                    <div class="value" id="host_url">
+                        {{host}}
+                    </div>
+                </div>
                 <div class="top_box box_status">
                     <div class="label">STATUS</div>
                     <div class="value" id="status_text">

--- a/locust/web.py
+++ b/locust/web.py
@@ -35,13 +35,21 @@ def index():
         slave_count = runners.locust_runner.slave_count
     else:
         slave_count = 0
+
+    if runners.locust_runner.host:
+        host = runners.locust_runner.host
+    elif len(runners.locust_runner.locust_classes) > 0:
+        host = runners.locust_runner.locust_classes[0].host
+    else:
+        host = None
     
     return render_template("index.html",
         state=runners.locust_runner.state,
         is_distributed=is_distributed,
         slave_count=slave_count,
         user_count=runners.locust_runner.user_count,
-        version=version
+        version=version,
+        host=host
     )
 
 @app.route('/swarm', methods=["POST"])


### PR DESCRIPTION
Adds the host url to the header:

![screen shot 2016-07-13 at 17 11 22](https://cloud.githubusercontent.com/assets/14163530/16810727/01c5a874-491d-11e6-9954-c7675f233e7e.png)

PR #295 does the same thing slightly differently but failed tests and is over a year old so created my own (with less css changes as displaying it with the existing header items keeps the UI more visually consistent).
The max width and word wrap have been set to prevent long urls ruining the layout of whole header. 
