### PR TITLE
Python 3 compatibility with --no-web option

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -499,7 +499,7 @@ def print_error_report():
     console_logger.info("")
 
 def stats_printer():
-    from runners import locust_runner
+    from .runners import locust_runner
     while True:
         print_stats(locust_runner.request_stats)
         gevent.sleep(2)


### PR DESCRIPTION
Fixes logging during locust hatching when using --no-web with Python 3.
(previously a "ImportError: No module named 'runners'" error is raised and no logging occurs)