### PR TITLE
Fix document bug concerning '--host' option.

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -66,8 +66,8 @@ The *host* attribute
 --------------------
 
 The host attribute is a URL prefix (i.e. "http://google.com") to the host that is to be loaded. 
-Usually, this is specified on the command line, using the --host option, when locust is started. 
-If one declares a host attribute in the locust class, it will be used in the case when no --host 
+Usually, this is specified on the command line, using the :code:`--host` option, when locust is started. 
+If one declares a host attribute in the locust class, it will be used in the case when no :code:`--host` 
 is specified on the command line.
 
 


### PR DESCRIPTION
When this rst is converted to html, the "--host" becomes "–host". This change fixes that with an inline code block.