### PR TITLE
For master mode,we need to set host option as well

### DIFF
--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -24,7 +24,7 @@ Example
 
 To start locust in master mode::
 
-    locust -f my_locustfile.py --master
+    locust -f my_locustfile.py --master --host=http://example.com
 
 And then on each slave (replace ``192.168.0.14`` with IP of the master machine)::
 


### PR DESCRIPTION
To make locust run in distributed mode we also need to pass --host file while starting the master , otherwise test case executed on slave will show exception to pass --host option.
