### PR TITLE
Use super() for HttpSession init call

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -48,7 +48,7 @@ class HttpSession(requests.Session):
                            and then mark it as successful even if the response code was not (i.e 500 or 404).
     """
     def __init__(self, base_url, *args, **kwargs):
-        requests.Session.__init__(self, *args, **kwargs)
+        super(HttpSession, self).__init__(*args, **kwargs)
 
         self.base_url = base_url
         


### PR DESCRIPTION
This seems to be the only place in the code where you're not calling super() to init the superclass. With this change, HttpSession can participate in diamond class patterns which I have a specific use case for (integrating with requests_oauthlib).