### PR TITLE
Expose number of clients to TaskSet

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -96,9 +96,9 @@ class Locust(object):
     client = NoClientWarningRaiser()
     _catch_exceptions = True
     
-    def __init__(self):
-        super(Locust, self).__init__()
-    
+    def __init__(self, runner=None):
+        self.runner = runner
+
     def run(self):
         try:
             self.task_set(self).run()
@@ -125,8 +125,8 @@ class HttpLocust(Locust):
     The client support cookies, and therefore keeps the session between HTTP requests.
     """
     
-    def __init__(self):
-        super(HttpLocust, self).__init__()
+    def __init__(self, runner=None):
+        super(HttpLocust, self).__init__(runner=runner)
         if self.host is None:
             raise LocustError("You must specify the base host. Either in the host attribute in the Locust class, or on the command line using the --host option.")
         

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -28,6 +28,7 @@ SLAVE_REPORT_INTERVAL = 3.0
 
 
 class LocustRunner(object):
+    client_index = 0
     def __init__(self, locust_classes, options):
         self.options = options
         self.locust_classes = locust_classes
@@ -114,7 +115,7 @@ class LocustRunner(object):
                 occurence_count[locust.__name__] += 1
                 def start_locust(_):
                     try:
-                        locust().run()
+                        locust(self).run()
                     except GreenletExit:
                         pass
                 new_locust = self.locusts.spawn(start_locust, locust)
@@ -285,13 +286,14 @@ class MasterLocustRunner(DistributedLocustRunner):
             self.exceptions = {}
             events.master_start_hatching.fire()
         
-        for client in six.itervalues(self.clients):
+        for client_index, client in enumerate(six.itervalues(self.clients)):
             data = {
                 "hatch_rate":slave_hatch_rate,
                 "num_clients":slave_num_clients,
                 "num_requests": self.num_requests,
                 "host":self.host,
-                "stop_timeout":None
+                "stop_timeout":None,
+                "client_index": client_index,
             }
 
             if remaining > 0:
@@ -392,6 +394,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
                 #self.num_clients = job["num_clients"]
                 self.num_requests = job["num_requests"]
                 self.host = job["host"]
+                self.client_index = job["client_index"]
                 self.hatching_greenlet = gevent.spawn(lambda: self.start_hatching(locust_count=job["num_clients"], hatch_rate=job["hatch_rate"]))
             elif msg.type == "stop":
                 self.stop()


### PR DESCRIPTION
Expose client_index to `TaskSet`

Useful in distributed mode, when we need to simulate users identified uniquely.
Otherwise a `TaskSet` doesn't know its range of ids to generate.

Example: 3 clients share the work of 3000 users.
    
client 1 will generate ids from 1 to 1000
client 2 will generate ids from 1001 to 2000
client 3 will generate ids from 2001 to 3000.

Otherwise all clients will generate ids from 1 to 1000 since they don't know how many they are.
    