### PR TITLE
Fix/on start run one time

### DIFF
--- a/locust.py
+++ b/locust.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+import re
+import sys
+import os
+
+
+from locust.main import main
+
+
+if __name__ == '__main__':
+	    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+	    sys.exit(main())

--- a/locust/main.py
+++ b/locust/main.py
@@ -12,7 +12,7 @@ from optparse import OptionParser
 
 import web
 from log import setup_logging, console_logger
-from stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from stats import stats_printer, print_percentile_stats, print_error_report, print_stats, stats_persist
 from inspectlocust import print_task_ratio, get_task_ratio_dict
 from core import Locust, HttpLocust
 from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -228,6 +228,16 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # A file that contains the current request stats.
+    parser.add_option(
+        '--statsfile',
+        action='store',
+        type='str',
+        dest='statsfile',
+        default=None,
+        help="Store current request stats to this file in CSV format.",
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -416,6 +426,9 @@ def main():
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
         gevent.spawn(stats_printer)
+
+    if options.statsfile:
+        gevent.spawn(stats_persist, options.statsfile)
     
     def shutdown(code=0):
         """
@@ -448,3 +461,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+    

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -112,7 +112,8 @@ class LocustRunner(object):
                 occurence_count[locust.__name__] += 1
                 def start_locust(_):
                     try:
-                        locust().run()
+                        if len(self.locusts) == 1:
+                            locust().run()
                     except GreenletExit:
                         pass
                 new_locust = self.locusts.spawn(start_locust, locust)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -7,7 +7,7 @@ from exception import StopLocust
 from log import console_logger
 
 STATS_NAME_WIDTH = 60
-
+ 
 class RequestStatsAdditionError(Exception):
     pass
 
@@ -496,8 +496,26 @@ def print_error_report():
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     console_logger.info("")
 
+def store_stats(filename, stats):
+    with open(filename, "w") as f:
+        f.write("path,method,num_requests,num_failures,min_response_time,max_response_time,avg_response_time\n")
+        for k in stats:
+            r = stats[k]
+            # need to add try - except block if one of the value is None
+            try:
+                f.write("%s,%s,%d,%d,%d,%d,%d\n" % (r.name,r.method,r.num_requests,r.num_failures,r.min_response_time,r.max_response_time,r.avg_response_time));
+            except:
+                pass
+
 def stats_printer():
     from runners import locust_runner
     while True:
         print_stats(locust_runner.request_stats)
         gevent.sleep(2)
+
+def stats_persist(filename):
+    from runners import locust_runner
+    while True:
+        store_stats(filename, locust_runner.request_stats);
+        gevent.sleep(2)
+        


### PR DESCRIPTION
fix for: https://github.com/locustio/locust/issues/529

**Printing `ON_START running` inside on_start before fix:**
`
~/P/m/p/responsive_gecis (master↑) locust -f all_links.py --host=http://test.com  --clients=5 --hatch-rate=1 --num-request=25 --no-web --only-summary
[2017-02-06 18:15:16,959] Mesuts-MacBook.local/INFO/locust.main: Starting Locust 0.7.5
[2017-02-06 18:15:16,959] Mesuts-MacBook.local/INFO/locust.runners: Hatching and swarming 5 clients at the rate 1 clients/s...
[2017-02-06 18:15:16,959] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:15:16,960] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:15:17,959] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:15:17,960] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:15:18,962] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:15:18,962] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:15:19,963] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:15:19,964] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:15:20,966] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:15:20,966] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:15:21,968] Mesuts-MacBook.local/INFO/locust.runners: All locusts hatched: User: 5
[2017-02-06 18:15:21,969] Mesuts-MacBook.local/INFO/locust.runners: Resetting stats

[2017-02-06 18:15:31,089] Mesuts-MacBook.local/INFO/locust.runners: All locusts dead

[2017-02-06 18:15:31,089] Mesuts-MacBook.local/INFO/locust.main: Shutting down (exit code 0), bye
`

**after fix:**
`
python /Users/mesutgunes/Projects/locust/locust.py  -f all_links.py --host=http://test.com  --clients=5 --hatch-rate=1 --num-request=25 --no-web --only-summary
[2017-02-06 18:13:51,758] Mesuts-MacBook.local/INFO/locust.main: Starting Locust 0.8a2
[2017-02-06 18:13:51,758] Mesuts-MacBook.local/INFO/locust.runners: Hatching and swarming 5 clients at the rate 1 clients/s...
[2017-02-06 18:13:51,759] Mesuts-MacBook.local/INFO/stdout: ON_START running
[2017-02-06 18:13:51,759] Mesuts-MacBook.local/INFO/stdout:
[2017-02-06 18:13:56,768] Mesuts-MacBook.local/INFO/locust.runners: All locusts hatched: User: 5
[2017-02-06 18:13:56,768] Mesuts-MacBook.local/INFO/locust.runners: Resetting stats

[2017-02-06 18:14:07,871] Mesuts-MacBook.local/INFO/locust.runners: All locusts dead

[2017-02-06 18:14:07,871] Mesuts-MacBook.local/INFO/locust.main: Shutting down (exit code 0), bye.
 Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s

`