### PR TITLE
Truncate number of errors displayed in the web UI

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -150,8 +150,13 @@ def request_stats():
             "median_response_time": s.median_response_time,
             "avg_content_length": s.avg_content_length,
         })
-    
-    report = {"stats":stats, "errors":[e.to_dict() for e in six.itervalues(runners.locust_runner.errors)]}
+
+    errors = [e.to_dict() for e in six.itervalues(runners.locust_runner.errors)]
+
+    # Truncate the total number of stats and errors displayed since a large number of rows will cause the app
+    # to render extremely slowly. Aggregate stats should be preserved.
+    report = {"stats": stats[:500], "errors": errors[:500]}
+
     if stats:
         report["total_rps"] = stats[len(stats)-1]["current_rps"]
         report["fail_ratio"] = runners.locust_runner.stats.aggregated_stats("Total").fail_ratio


### PR DESCRIPTION
This change limits the number of rows on the web UI to display at most **500** rows in the `stats` and `failures` tabs. A common scenario is the app failing under load, resulting in a large number of unique failures, bringing the rendering to a halt. 

A simple locustfile demonstrates the issue:

```python
import random 

from locust import HttpLocust, TaskSet, task

class UserTasks(TaskSet):

    @task
    def error(self):
        self.client.get("/404/{}".format(random.randint(0,99999999999))

class WebsiteUser(HttpLocust):
    min_wait = 0
    max_wait = 0
    task_set = UserTasks
```

This will generate a large number of results and errors, eventually killing the page. I feel that 500 results is a reasonable number to display as it's more than anyone could consume manually through the web UI. But for automated processes, the _actual_ results will remain intact. 