### PR TITLE
Prohibits the locustfile from being named 'locust.py'

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -350,8 +350,13 @@ def main():
         sys.exit(0)
 
     locustfile = find_locustfile(options.locustfile)
+
     if not locustfile:
         logger.error("Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.")
+        sys.exit(1)
+
+    if locustfile == "locust.py":
+        logger.error("The locustfile must not be named `locust.py`. Please rename the file and try again.")
         sys.exit(1)
 
     docstring, locusts = load_locustfile(locustfile)


### PR DESCRIPTION
Fixes #138

This PR prohibits naming your locustfile `locust.py`, which previously caused Locust to exit with a misleading message ("No Locust class found").

The new behavior is to exit with a more helpful error message explaining not to name the file `locust.py`. 

The issue was occuring because the locustfile gets imported as a Python module (with the .py extension removed).  So naming it `locust.py` caused a namespace clash with the internal `locust` module, which would get re-imported instead of the locustfile.


Note: This only fixes the common case where you have named it `locust.py`.  There are also other reserved names that can not be used as locustfile names.  We might want to add something to the docs to explain this.
