### PR TITLE
Fix off by 1 error in stats.py resulting in additional request always being off

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -429,14 +429,14 @@ A global instance for holding the statistics. Should be removed eventually.
 """
 
 def on_request_success(request_type, name, response_time, response_length):
+    global_stats.get(name, request_type).log(response_time, response_length)
     if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
         raise StopLocust("Maximum number of requests reached")
-    global_stats.get(name, request_type).log(response_time, response_length)
 
 def on_request_failure(request_type, name, response_time, exception):
+    global_stats.get(name, request_type).log_error(exception)
     if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
         raise StopLocust("Maximum number of requests reached")
-    global_stats.get(name, request_type).log_error(exception)
 
 def on_report_to_master(client_id, data):
     data["stats"] = [global_stats.entries[key].get_stripped_report() for key in six.iterkeys(global_stats.entries) if not (global_stats.entries[key].num_requests == 0 and global_stats.entries[key].num_failures == 0)]


### PR DESCRIPTION
Address #399, which is the same issue we just hit in our usage.

The counter is incremented in `log` but it was being checked for the end condition before that point was hit.
This meant that if you ran 3 requests using the command line mode:

```
locust --no-web -c 1 -r 1 -n 3 -f tornado_nats_locust.py
```
you would end with Locust actually executing 4 tasks.


FYI @cgoldberg @heyman @seangerhardt-wf 