### PR TITLE
Add slack signup link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 * Website: <a href="http://locust.io">locust.io</a>
 * Documentation: <a href="http://docs.locust.io">docs.locust.io</a>
+* Support/Questions: [Slack signup](https://slack.locust.io/)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Locust
 
 [![Build Status](https://secure.travis-ci.org/locustio/locust.png)](http://travis-ci.org/locustio/locust)
-[![Gitter Chat](https://badges.gitter.im/locustio/locust.png)](https://gitter.im/locustio/locust)
 
 ## Links
 


### PR DESCRIPTION
I don't think there are nice "badges" for slack the way there are for gitter.

I didn't remove that link either, is the goal here to replace gitter with Slack?

@heyman