### PR TITLE
Fix formatting issue combining double dashes into single dash

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -105,7 +105,7 @@ host defaults to 127.0.0.1)::
 
     To see all available options type
 
-        locust --help
+        ``locust --help``
 
 
 Open up Locust's web interface

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -103,9 +103,9 @@ host defaults to 127.0.0.1)::
 
 .. note::
 
-    To see all available options type
+To see all available options type::
 
-        ``locust --help``
+    locust --help
 
 
 Open up Locust's web interface


### PR DESCRIPTION
Copying and pasting the command to get help into the console fails because of a formatting issue that combines the double dashes into a single dash.