### PR TITLE
Add description of RPS breakdown between multiple locusts.

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -50,6 +50,8 @@ You can run two locusts from the same file like so::
 
     locust -f locust_file.py WebUserLocust MobileUserLocust
 
+By default, all locusts in the locustfile with a *task_set* are used.
+
 If you wish to make one of these locusts execute more often you can set a weight attribute on those
 classes. Say for example, web users are three times more likely than mobile users::
 
@@ -61,6 +63,9 @@ classes. Say for example, web users are three times more likely than mobile user
         weight = 1
         ....
 
+In this case, if you were to hatch 100 locusts using the UI and assuming each of the above had min/max
+wait of 1s, they would combine to produce 100 requests per second, with 75rps from *WebUserLocust* and
+25rps from *MobileUserLocust*.
 
 The *host* attribute
 --------------------


### PR DESCRIPTION
I'm guessing this is how it works. But, I'm trying to put my question / guesses in the form of doc updates in case that's useful for posterity.

If you have multiple Locusts, by default it looks like it runs all of them (but not base classes; maybe it looks for a task_set)?

If you hatch N total Locusts via the UI, is that the total across all Locust classes? I assume, given the weighting, it wouldn't be N of each.