### PR TITLE
Added failures per second as a series in the chart

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -116,7 +116,7 @@ $(".stats_label").click(function(event) {
 });
 
 // init charts
-var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS"], "reqs/s");
+var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "FPS"], "reqs/s");
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Average Response Time", ["Average Response Time"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
@@ -148,7 +148,7 @@ function updateStats() {
             // get total stats row
             var total = report.stats[report.stats.length-1];
             // update charts
-            rpsChart.addValue([total.current_rps]);
+            rpsChart.addValue([total.current_rps, total.current_fps]);
             responseTimeChart.addValue([total.avg_response_time]);
             usersChart.addValue([report.user_count]);
         }

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -179,7 +179,7 @@ class StatsEntry(object):
         self.response_times.setdefault(rounded_response_time, 0)
         self.response_times[rounded_response_time] += 1
 
-    def log_error(self, response_time, error):
+    def log_error(self, error):
         self.num_failures += 1
         self.stats.num_failures += 1
         key = StatsError.create_key(self.method, self.name, error)
@@ -457,7 +457,7 @@ def on_request_success(request_type, name, response_time, response_length):
         raise StopLocust("Maximum number of requests reached")
 
 def on_request_failure(request_type, name, response_time, exception):
-    global_stats.get(name, request_type).log_error(response_time, exception)
+    global_stats.get(name, request_type).log_error(exception)
     if global_stats.max_requests is not None and (global_stats.num_requests + global_stats.num_failures) >= global_stats.max_requests:
         raise StopLocust("Maximum number of requests reached")
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -155,6 +155,7 @@ def request_stats():
             "min_response_time": s.min_response_time or 0,
             "max_response_time": s.max_response_time,
             "current_rps": s.current_rps,
+            "current_fps": s.current_fps,
             "median_response_time": s.median_response_time,
             "avg_content_length": s.avg_content_length,
         })


### PR DESCRIPTION
As a user of locust it's very useful to know how many requests are failing in the chart. The failure % is useful but when pushing heavy loads against an API in my case it's common the autoscaling can't cope up with the demand and a lot of fails start to happen. Having those represented in the chart is very valuable to understand how the scaling overall is working.

![image](https://cloud.githubusercontent.com/assets/5490771/26178815/962e9e4e-3b25-11e7-8395-2e597c547a78.png)
