### PR TITLE
find locustfile in the root directory

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -158,6 +158,7 @@ def parse_options():
     parser.add_option(
         '-n', '--num-request',
         action='store',
+        
         type='int',
         dest='num_requests',
         default=None,
@@ -288,10 +289,11 @@ def find_locustfile(locustfile):
                 if os.path.exists(joined):
                     if name.endswith('.py') or _is_package(joined):
                         return os.path.abspath(joined)
-            np = os.path.dirname(path)
-            if np == path:
+            parent_path = os.path.dirname(path)
+            if parent_path == path:
+                # we've reached the root path which has been checked this iteration
                 break
-            path = np
+            path = parent_path
     # Implicit 'return None' if nothing was found
 
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -281,16 +281,17 @@ def find_locustfile(locustfile):
                     return os.path.abspath(expanded)
     else:
         # Otherwise, start in cwd and work downwards towards filesystem root
-        path = '.'
-        # Stop before falling off root of filesystem (should be platform
-        # agnostic)
-        while os.path.split(os.path.abspath(path))[1]:
+        path = os.path.abspath('.')
+        while True:
             for name in names:
                 joined = os.path.join(path, name)
                 if os.path.exists(joined):
                     if name.endswith('.py') or _is_package(joined):
                         return os.path.abspath(joined)
-            path = os.path.join('..', path)
+            np = os.path.dirname(path)
+            if np == path:
+                break
+            path = np
     # Implicit 'return None' if nothing was found
 
 


### PR DESCRIPTION
if the `locustfile.py` file is located in the filesystem root, and the `locust` command is launched from the fs root too, then the file is not found.

(to work around this issue, `-f /locustfile` has to be explicitly passed to the `locust` command)

having the locustfile in the fs root is a common use case when running in docker