### PR TITLE
Add ability to write csv stats files  

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -101,6 +101,20 @@ host defaults to 127.0.0.1)::
 
     locust -f locust_files/my_locust_file.py --slave --master-host=192.168.0.100 --host=http://example.com
 
+You may wish to consume your Locust results via a csv file. In this case, there are two ways to do this.
+
+First, when running the webserver, you can retrieve a csv from ``localhost:8089/stats/requests/csv`` and ``localhost:8089/stats/distribution/csv``.
+Second you can run Locust with a flag which will periodically save the csv file. This is particularly useful
+if you plan on running Locust in an automated way with the ``--no-web`` flag::
+
+    locust -f locust_files/my_locust_file.py --csv=foobar --no-web -n10 -c1
+
+You can also customize how frequently this is written if you desire faster (or slower) writing::
+
+
+    import locust.stats
+    locust.stats.CSV_STATS_INTERVAL_SEC = 5 # default is 2 seconds
+
 .. note::
 
 To see all available options type::

--- a/locust/main.py
+++ b/locust/main.py
@@ -13,7 +13,7 @@ from optparse import OptionParser
 
 from . import web
 from .log import setup_logging, console_logger
-from .stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from .stats import stats_printer, print_percentile_stats, print_error_report, print_stats, stats_writer, write_stat_csvs
 from .inspectlocust import print_task_ratio, get_task_ratio_dict
 from .core import Locust, HttpLocust
 from .runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -59,6 +59,16 @@ def parse_options():
         dest='locustfile',
         default='locustfile',
         help="Python module file to import, e.g. '../other.py'. Default: locustfile"
+    )
+
+    # A file that contains the current request stats.
+    parser.add_option(
+        '--csv', '--csv-base-name',
+        action='store',
+        type='str',
+        dest='csvfilebase',
+        default=None,
+        help="Store current request stats to files in CSV format.",
     )
 
     # if locust should be run in distributed mode as master
@@ -443,17 +453,22 @@ def main():
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
         gevent.spawn(stats_printer)
+
+    if options.csvfilebase:
+        gevent.spawn(stats_writer, options.csvfilebase)
+
     
     def shutdown(code=0):
         """
-        Shut down locust by firing quitting event, printing stats and exiting
+        Shut down locust by firing quitting event, printing/writing stats and exiting
         """
         logger.info("Shutting down (exit code %s), bye." % code)
 
         events.quitting.fire()
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
-
+        if options.csvfilebase:
+            write_stat_csvs(options.csvfilebase)
         print_error_report()
         sys.exit(code)
     

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -11,6 +11,13 @@ from .log import console_logger
 
 STATS_NAME_WIDTH = 60
 
+"""Default interval for how frequently the CSV file is written if this option
+is configured."""
+CSV_STATS_INTERVAL_SEC = 2
+
+"""Default interval for how frequently results are written to console."""
+CONSOLE_STATS_INTERVAL_SEC = 2
+
 class RequestStatsAdditionError(Exception):
     pass
 
@@ -517,13 +524,13 @@ def stats_printer():
     from . import runners
     while True:
         print_stats(runners.locust_runner.request_stats)
-        gevent.sleep(2)
+        gevent.sleep(CONSOLE_STATS_INTERVAL_SEC)
 
 def stats_writer(base_filepath):
     """Writes the csv files for the locust run."""
     while True:
         write_stat_csvs(base_filepath)
-        gevent.sleep(2)
+        gevent.sleep(CSV_STATS_INTERVAL_SEC)
 
 
 def write_stat_csvs(base_filepath):

--- a/locust/web.py
+++ b/locust/web.py
@@ -15,8 +15,7 @@ from flask import Flask, make_response, request, render_template
 from . import runners
 from .cache import memoize
 from .runners import MasterLocustRunner
-from .stats import sort_stats
-from locust.stats import median_from_dict, requests_csv, distribution_csv
+from .stats import sort_stats, median_from_dict, requests_csv, distribution_csv
 from locust import __version__ as version
 
 import logging

--- a/locust/web.py
+++ b/locust/web.py
@@ -15,7 +15,8 @@ from flask import Flask, make_response, request, render_template
 from . import runners
 from .cache import memoize
 from .runners import MasterLocustRunner
-from locust.stats import median_from_dict
+from .stats import sort_stats
+from locust.stats import median_from_dict, requests_csv, distribution_csv
 from locust import __version__ as version
 
 import logging
@@ -77,36 +78,8 @@ def reset_stats():
     
 @app.route("/stats/requests/csv")
 def request_stats_csv():
-    rows = [
-        ",".join([
-            '"Method"',
-            '"Name"',
-            '"# requests"',
-            '"# failures"',
-            '"Median response time"',
-            '"Average response time"',
-            '"Min response time"', 
-            '"Max response time"',
-            '"Average Content Size"',
-            '"Requests/s"',
-        ])
-    ]
-    
-    for s in chain(_sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.aggregated_stats("Total", full_request_history=True)]):
-        rows.append('"%s","%s",%i,%i,%i,%i,%i,%i,%i,%.2f' % (
-            s.method,
-            s.name,
-            s.num_requests,
-            s.num_failures,
-            s.median_response_time,
-            s.avg_response_time,
-            s.min_response_time or 0,
-            s.max_response_time,
-            s.avg_content_length,
-            s.total_rps,
-        ))
+    response = make_response(requests_csv())
 
-    response = make_response("\n".join(rows))
     file_name = "requests_{0}.csv".format(time())
     disposition = "attachment;filename={0}".format(file_name)
     response.headers["Content-type"] = "text/csv"
@@ -115,26 +88,8 @@ def request_stats_csv():
 
 @app.route("/stats/distribution/csv")
 def distribution_stats_csv():
-    rows = [",".join((
-        '"Name"',
-        '"# requests"',
-        '"50%"',
-        '"66%"',
-        '"75%"',
-        '"80%"',
-        '"90%"',
-        '"95%"',
-        '"98%"',
-        '"99%"',
-        '"100%"',
-    ))]
-    for s in chain(_sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.aggregated_stats("Total", full_request_history=True)]):
-        if s.num_requests:
-            rows.append(s.percentile(tpl='"%s",%i,%i,%i,%i,%i,%i,%i,%i,%i,%i'))
-        else:
-            rows.append('"%s",0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"' % s.name)
 
-    response = make_response("\n".join(rows))
+    response = make_response(distribution_csv())
     file_name = "distribution_{0}.csv".format(time())
     disposition = "attachment;filename={0}".format(file_name)
     response.headers["Content-type"] = "text/csv"
@@ -145,7 +100,7 @@ def distribution_stats_csv():
 @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
 def request_stats():
     stats = []
-    for s in chain(_sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.aggregated_stats("Total")]):
+    for s in chain(sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.aggregated_stats("Total")]):
         stats.append({
             "method": s.method,
             "name": s.name,
@@ -223,5 +178,3 @@ def exceptions_csv():
 def start(locust, options):
     wsgi.WSGIServer((options.web_host, options.port), app, log=None).serve_forever()
 
-def _sort_stats(stats):
-    return [stats[key] for key in sorted(six.iterkeys(stats))]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent>=1.1.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack-python>=0.4.2", "six>=1.10.0", "pyzmq==15.2.0"],
+    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack-python>=0.4.2", "six>=1.10.0", "pyzmq==15.2.0"],
     tests_require=['unittest2', 'mock'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
I started reviewing https://github.com/locustio/locust/pull/445 but found that it had enough problems that it'd be just easier to rewrite the entire PR.

This:

 - Ability to write csv files for both the requests and distribution csv as a command line flag
- Refactored the logic in the web handler to reuse this csv generation for better portability

I also fixed #598 because that issue has been annoying me for a while.