### PR TITLE
added a prometheus metrics endpoint

### DIFF
--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -37,6 +37,9 @@ class TestWebUI(LocustTestCase):
     
     def test_index(self):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % self.web_port).status_code)
+
+    def test_metrics(self):
+        self.assertEqual(200, requests.get("http://127.0.0.1:%i/metrics" % self.web_port).status_code)
     
     def test_stats_no_data(self):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code)

--- a/locust/web.py
+++ b/locust/web.py
@@ -10,7 +10,7 @@ from six.moves import StringIO, xrange
 import six
 
 from gevent import wsgi
-from flask import Flask, make_response, request, render_template
+from flask import Flask, jsonify, make_response, request, render_template
 
 from . import runners
 from .cache import memoize
@@ -51,6 +51,71 @@ def index():
         version=version,
         host=host
     )
+
+
+@app.route('/metrics')
+def metrics():
+    is_distributed = isinstance(runners.locust_runner, MasterLocustRunner)
+    if is_distributed:
+        slave_count = runners.locust_runner.slave_count
+    else:
+        slave_count = 0
+
+    if runners.locust_runner.host:
+        host = runners.locust_runner.host
+    elif len(runners.locust_runner.locust_classes) > 0:
+        host = runners.locust_runner.locust_classes[0].host
+    else:
+        host = None
+
+    state = 1
+    if runners.locust_runner.state != "running":
+        state = 0
+
+    rows = []
+    for s in chain(_sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.aggregated_stats("Total", full_request_history=True)]):
+        if s.name != "Total":
+            rows.append("locust_request_count{{endpoint=\"{}\", method=\"{}\"}} {}\n"
+                        "locust_request_per_second{{endpoint=\"{}\"}} {}\n"
+                        "locust_failed_requests{{endpoint=\"{}\", method=\"{}\"}} {}\n"
+                        "locust_average_response{{endpoint=\"{}\", method=\"{}\"}} {}\n"
+                        "locust_average_content_length{{endpoint=\"{}\", method=\"{}\"}} {}\n"
+                        "locust_max_response_time{{endpoint=\"{}\", method=\"{}\"}} {}\n"
+                        "locust_running{{site=\"{}\"}} {}\n"
+                        "locust_workers{{site=\"{}\"}} {}\n"
+                        "locust_users{{site=\"{}\"}} {}\n".format(
+                            s.name,
+                            s.method,
+                            s.num_requests,
+                            s.name,
+                            s.total_rps,
+                            s.name,
+                            s.method,
+                            s.num_failures,
+                            s.name,
+                            s.method,
+                            s.avg_response_time,
+                            s.name,
+                            s.method,
+                            s.avg_content_length,
+                            s.name,
+                            s.method,
+                            s.max_response_time,
+                            host,
+                            state,
+                            host,
+                            slave_count,
+                            host,
+                            runners.locust_runner.user_count,
+                        )
+            )
+
+    response = make_response("".join(rows))
+    response.mimetype = "text/plain; charset=utf-8'"
+    response.content_type = "text/plain; charset=utf-8'"
+    response.headers["Content-Type"] = "text/plain; charset=utf-8'"
+    return response
+
 
 @app.route('/swarm', methods=["POST"])
 def swarm():


### PR DESCRIPTION
I've added a /metrics route that allows prometheus to scrape locust so that you can cross compare the effects of load testing with other metrics gathered by prometheus.

The use case would be for people who want to see how their benchmarks affect systems performance. 

 