### PR TITLE
Modify gevent wsgi and libev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 addons:
   apt:
     packages:
-      - libevent-dev
+      - libev-dev
 install:
   - pip install tox
 script:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,9 +59,9 @@ Installing Locust on OS X
 The following is currently the shortest path to installing gevent on OS X using Homebrew.
 
 #. Install `Homebrew <http://mxcl.github.com/homebrew/>`_.
-#. Install libevent (dependency for gevent)::
+#. Install libev (dependency for gevent)::
 
-    brew install libevent
+    brew install libev
 
 #. Then follow the above instructions.
 

--- a/examples/vagrant/vagrant.sh
+++ b/examples/vagrant/vagrant.sh
@@ -6,7 +6,7 @@
 
 # Update and install some dependencies
 apt-get -y update 
-apt-get -y install build-essential python-pip python-dev libevent-dev libev-dev libzmq-dev
+apt-get -y install build-essential python-pip python-dev libev-dev libzmq-dev
 cd /vagrant
 
 pip install --use-mirrors pyzmq supervisor

--- a/locust/web.py
+++ b/locust/web.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from six.moves import StringIO, xrange
 import six
 
-from gevent import wsgi
+from gevent import pywsgi
 from flask import Flask, make_response, request, render_template
 
 from . import runners
@@ -175,5 +175,6 @@ def exceptions_csv():
     return response
 
 def start(locust, options):
-    wsgi.WSGIServer((options.web_host, options.port), app, log=None).serve_forever()
+    pywsgi.WSGIServer((options.web_host, options.port),
+                      app, log=None).serve_forever()
 


### PR DESCRIPTION
The goal of this PR is to migrate from `libevent` to `libev` and from gevent's `wsgi` module to `pywsgi` .

- Addresses #649 
