### PR TITLE
Sort all Python imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,12 @@
 
 import os
 
+# The default replacements for |version| and |release|, also used in various
+# other places throughout the built documents.
+#
+# The short X.Y version.
+from locust import __version__
+
 # General configuration
 # ---------------------
 
@@ -38,11 +44,6 @@ intersphinx_mapping = {
     'requests': ('http://requests.readthedocs.org/en/latest/', None),
 }
 
-# The default replacements for |version| and |release|, also used in various
-# other places throughout the built documents.
-#
-# The short X.Y version.
-from locust import __version__
 
 # The full version, including alpha/beta/rc tags.
 release = __version__

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,5 +1,6 @@
 from locust import HttpLocust, TaskSet, task
 
+
 def index(l):
     l.client.get("/")
 

--- a/examples/custom_xmlrpc_client/server.py
+++ b/examples/custom_xmlrpc_client/server.py
@@ -1,6 +1,7 @@
-import time
 import random
+import time
 from SimpleXMLRPCServer import SimpleXMLRPCServer
+
 
 def get_time():
     time.sleep(random.random())

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -1,7 +1,7 @@
 import time
 import xmlrpclib
 
-from locust import Locust, events, task, TaskSet
+from locust import Locust, TaskSet, events, task
 
 
 class XmlRpcClient(xmlrpclib.ServerProxy):

--- a/examples/events.py
+++ b/examples/events.py
@@ -5,7 +5,8 @@ This is an example of a locustfile that uses Locust's built in event hooks to
 track the sum of the content-length header in all successful HTTP responses
 """
 
-from locust import HttpLocust, TaskSet, task, events, web
+from locust import HttpLocust, TaskSet, events, task, web
+
 
 class MyTaskSet(TaskSet):
     @task(2)

--- a/locust/cache.py
+++ b/locust/cache.py
@@ -1,5 +1,6 @@
 from time import time
 
+
 def memoize(timeout, dynamic_timeout=False):
     """
     Memoization decorator with support for timeout.
@@ -28,4 +29,3 @@ def memoize(timeout, dynamic_timeout=False):
         wrapper.clear_cache = clear_cache
         return wrapper
     return decorator
-

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -1,13 +1,14 @@
 import re
 import time
-from six.moves.urllib.parse import urlparse, urlunparse
-import six
 
 import requests
-from requests import Response, Request
+import six
+from requests import Request, Response
 from requests.auth import HTTPBasicAuth
-from requests.exceptions import (RequestException, MissingSchema,
-    InvalidSchema, InvalidURL)
+from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
+                                 RequestException)
+
+from six.moves.urllib.parse import urlparse, urlunparse
 
 from . import events
 from .exception import CatchResponseError, ResponseError

--- a/locust/core.py
+++ b/locust/core.py
@@ -1,21 +1,21 @@
+import logging
+import random
+import sys
+import traceback
+from time import time
+
 import gevent
-from gevent import monkey, GreenletExit
 import six
+from gevent import GreenletExit, monkey
+
 from six.moves import xrange
 
-monkey.patch_all(thread=False)
-
-from time import time
-import sys
-import random
-import traceback
-import logging
-
-from .clients import HttpSession
 from . import events
+from .clients import HttpSession
+from .exception import (InterruptTaskSet, LocustError, RescheduleTask,
+                        RescheduleTaskImmediately, StopLocust)
 
-from .exception import LocustError, InterruptTaskSet, RescheduleTask, RescheduleTaskImmediately, StopLocust
-
+monkey.patch_all(thread=False)
 logger = logging.getLogger(__name__)
 
 
@@ -352,4 +352,3 @@ class TaskSet(object):
         Locust instance.
         """
         return self.locust.client
-

--- a/locust/inspectlocust.py
+++ b/locust/inspectlocust.py
@@ -1,8 +1,10 @@
 import inspect
+
 import six
 
 from .core import Locust, TaskSet
 from .log import console_logger
+
 
 def print_task_ratio(locusts, total=False, level=0, parent_ratio=1.0):
     d = get_task_ratio_dict(locusts, total=total, parent_ratio=parent_ratio)

--- a/locust/log.py
+++ b/locust/log.py
@@ -1,6 +1,6 @@
 import logging
-import sys
 import socket
+import sys
 
 host = socket.gethostname()
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -1,23 +1,23 @@
-import locust
-from . import runners
-
-import gevent
-import sys
-import os
-import signal
 import inspect
 import logging
+import os
+import signal
 import socket
+import sys
 import time
 from optparse import OptionParser
 
-from . import web
-from .log import setup_logging, console_logger
-from .stats import stats_printer, print_percentile_stats, print_error_report, print_stats, stats_writer, write_stat_csvs
-from .inspectlocust import print_task_ratio, get_task_ratio_dict
-from .core import Locust, HttpLocust
-from .runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
-from . import events
+import gevent
+
+import locust
+
+from . import events, runners, web
+from .core import HttpLocust, Locust
+from .inspectlocust import get_task_ratio_dict, print_task_ratio
+from .log import console_logger, setup_logging
+from .runners import LocalLocustRunner, MasterLocustRunner, SlaveLocustRunner
+from .stats import (print_error_report, print_percentile_stats, print_stats,
+                    stats_printer, stats_writer, write_stat_csvs)
 
 _internals = [Locust, HttpLocust]
 version = locust.__version__

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -1,5 +1,6 @@
 import msgpack
 
+
 class Message(object):
     def __init__(self, message_type, data, node_id):
         self.type = message_type

--- a/locust/rpc/socketrpc.py
+++ b/locust/rpc/socketrpc.py
@@ -1,10 +1,11 @@
-import struct
 import logging
+import struct
 
 import gevent
 from gevent import socket
 
 from locust.exception import LocustError
+
 from .protocol import Message
 
 logger = logging.getLogger(__name__)

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,5 +1,7 @@
 import zmq.green as zmq
+
 from .protocol import Message
+
 
 class BaseSocket(object):
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1,22 +1,22 @@
 # coding=UTF-8
+import logging
+import random
 import socket
 import traceback
 import warnings
-import random
-import logging
-from time import time
 from hashlib import md5
+from time import time
 
 import gevent
+import six
 from gevent import GreenletExit
 from gevent.pool import Group
-import six
+
 from six.moves import xrange
 
 from . import events
+from .rpc import Message, rpc
 from .stats import global_stats
-
-from .rpc import rpc, Message
 
 logger = logging.getLogger(__name__)
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,9 +1,11 @@
-import time
-import gevent
 import hashlib
-import six
-from six.moves import xrange
+import time
 from itertools import chain
+
+import gevent
+import six
+
+from six.moves import xrange
 
 from . import events
 from .exception import StopLocust

--- a/locust/test/test_client.py
+++ b/locust/test/test_client.py
@@ -1,9 +1,11 @@
-from requests.exceptions import (RequestException, MissingSchema,
-        InvalidSchema, InvalidURL)
+from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
+                                 RequestException)
 
 from locust.clients import HttpSession
 from locust.stats import global_stats
+
 from .testcases import WebserverTestCase
+
 
 class TestHttpSession(WebserverTestCase):
     def test_get(self):
@@ -66,4 +68,3 @@ class TestHttpSession(WebserverTestCase):
         get_stats = global_stats.get(url, method="GET")
         self.assertEqual(1, post_stats.num_requests)
         self.assertEqual(0, get_stats.num_requests)
-    

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -1,10 +1,12 @@
 import six
 
-from locust.core import HttpLocust, Locust, TaskSet, task, events
-from locust import ResponseError, InterruptTaskSet
-from locust.exception import CatchResponseError, RescheduleTask, RescheduleTaskImmediately, LocustError
+from locust import InterruptTaskSet, ResponseError
+from locust.core import HttpLocust, Locust, TaskSet, events, task
+from locust.exception import (CatchResponseError, LocustError, RescheduleTask,
+                              RescheduleTaskImmediately)
 
 from .testcases import LocustTestCase, WebserverTestCase
+
 
 class TestTaskSet(LocustTestCase):
     def setUp(self):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1,6 +1,8 @@
-from locust.core import HttpLocust, Locust, TaskSet
 from locust import main
+from locust.core import HttpLocust, Locust, TaskSet
+
 from .testcases import LocustTestCase
+
 
 class TestTaskSet(LocustTestCase):
     def test_is_locust(self):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1,19 +1,18 @@
 import unittest
 
 import gevent
-import mock
-
-from gevent.queue import Queue
 from gevent import sleep
+from gevent.queue import Queue
 
-from locust.runners import LocalLocustRunner, MasterLocustRunner
-from locust.core import Locust, task, TaskSet
-from locust.exception import LocustError
-from locust.rpc import Message
-from locust.stats import global_stats
-from locust.main import parse_options
-from locust.test.testcases import LocustTestCase
+import mock
 from locust import events
+from locust.core import Locust, TaskSet, task
+from locust.exception import LocustError
+from locust.main import parse_options
+from locust.rpc import Message
+from locust.runners import LocalLocustRunner, MasterLocustRunner
+from locust.stats import global_stats
+from locust.test.testcases import LocustTestCase
 
 
 def mocked_rpc_server():
@@ -246,4 +245,3 @@ class TestMessageSerializing(unittest.TestCase):
         self.assertEqual(msg.type, rebuilt.type)
         self.assertEqual(msg.data, rebuilt.data)
         self.assertEqual(msg.node_id, rebuilt.node_id)
-        

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -1,13 +1,14 @@
-import unittest
 import time
+import unittest
 
-from six.moves import xrange
-
-from .testcases import WebserverTestCase
-from locust.stats import RequestStats, StatsEntry, global_stats
 from locust.core import HttpLocust, TaskSet, task
 from locust.inspectlocust import get_task_ratio_dict
 from locust.rpc.protocol import Message
+from locust.stats import RequestStats, StatsEntry, global_stats
+from six.moves import xrange
+
+from .testcases import WebserverTestCase
+
 
 class TestRequestStats(unittest.TestCase):
     def setUp(self):

--- a/locust/test/test_taskratio.py
+++ b/locust/test/test_taskratio.py
@@ -3,6 +3,7 @@ import unittest
 from locust.core import Locust, TaskSet, task
 from locust.inspectlocust import get_task_ratio_dict
 
+
 class TestTaskRatio(unittest.TestCase):
     def test_task_ratio_command(self):
         class Tasks(TaskSet):

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -1,19 +1,20 @@
 # encoding: utf-8
-
 import csv
 import json
 import sys
 import traceback
-from six.moves import StringIO
 
-import requests
 import gevent
+import requests
 from gevent import wsgi
 
-from locust import web, runners, stats
-from locust.runners import LocustRunner
+from locust import runners, stats, web
 from locust.main import parse_options
+from locust.runners import LocustRunner
+from six.moves import StringIO
+
 from .testcases import LocustTestCase
+
 
 class TestWebUI(LocustTestCase):
     def setUp(self):
@@ -119,4 +120,3 @@ class TestWebUI(LocustTestCase):
         self.assertEqual(2, len(rows))
         self.assertEqual("Test exception", rows[1][1])
         self.assertEqual(2, int(rows[1][0]), "Exception count should be 2")
-        

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -1,16 +1,18 @@
 import base64
-import gevent
-import gevent.pywsgi
 import random
+import sys
 import unittest
 from copy import copy
 from io import BytesIO
-import sys
+
+import gevent
+import gevent.pywsgi
 import six
+from flask import (Flask, Response, make_response, redirect, request,
+                   send_file, stream_with_context)
 
 from locust import events
 from locust.stats import global_stats
-from flask import Flask, request, redirect, make_response, send_file, Response, stream_with_context
 
 
 def safe_repr(obj, short=False):

--- a/locust/web.py
+++ b/locust/web.py
@@ -2,23 +2,24 @@
 
 import csv
 import json
+import logging
 import os.path
-from time import time
-from itertools import chain
 from collections import defaultdict
-from six.moves import StringIO, xrange
-import six
+from itertools import chain
+from time import time
 
+import six
+from flask import Flask, make_response, render_template, request
 from gevent import wsgi
-from flask import Flask, make_response, request, render_template
+
+from locust import __version__ as version
+from six.moves import StringIO, xrange
 
 from . import runners
 from .cache import memoize
 from .runners import MasterLocustRunner
-from .stats import sort_stats, median_from_dict, requests_csv, distribution_csv
-from locust import __version__ as version
+from .stats import distribution_csv, median_from_dict, requests_csv, sort_stats
 
-import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_TIME = 2.0
@@ -176,4 +177,3 @@ def exceptions_csv():
 
 def start(locust, options):
     wsgi.WSGIServer((options.web_host, options.port), app, log=None).serve_forever()
-

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
+import ast
+import os
+import re
 
-from setuptools import setup, find_packages
-import os, re, ast
-
+from setuptools import find_packages, setup
 
 # parse version from locust/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')


### PR DESCRIPTION
The goal of this PR is to sort all Python imports for readability in the following order:
 - Future
 - Python Standard Library
 - Third Party
 - Current Python Project
 - Explicitly Local (. before import, as in: from . import x)
 - Custom Separate Sections (Defined by forced_separate list in configuration file)
 - Custom Sections (Defined by sections list in configuration file)

You can automatically format your Python imports with the package `isort`.