### PR TITLE
Bump version to 0.8a3 for another pre-release candidate

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,12 +2,12 @@
 Changelog
 ##########
 
-0.8a2
+0.8a3
 =====
 
 .. note::
 
-   Locust 0.8 only exists as a pre-release on PyPI, and can be installed using: pip install locustio==0.8a2
+   Locust 0.8 only exists as a pre-release on PyPI, and can be installed using: pip install locustio==0.8a3
 
 
 * Support Python 3
@@ -15,6 +15,7 @@ Changelog
   the hatching is complete
 * Added charts, for RPS and average response time, to the web UI
 * Various bug fixes and improvements
+* Added ability to write a CSV file for results via command line flag
 
 
 0.7.5

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,4 +1,4 @@
 from .core import HttpLocust, Locust, TaskSet, task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 
-__version__ = "0.8a2"
+__version__ = "0.8a3"


### PR DESCRIPTION
@heyman  @cgbystrom  @cgoldberg 

This updates the version, however I cannot release the version to pypi (see [this request](https://github.com/locustio/locust/issues/628)).

Once this PR is merged, please also upload to pypi so that people can begin consuming.

FYI  @mbeacom 
