### PR TITLE
Adds support for setup, teardown, and on_stop methods

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,6 +12,9 @@ Below is a quick little example of a simple **locustfile.py**::
     def login(l):
         l.client.post("/login", {"username":"ellen_key", "password":"education"})
     
+    def logout(l):
+        l.client.post("/logout", {"username":"ellen_key", "password":"education"})
+    
     def index(l):
         l.client.get("/")
     
@@ -23,6 +26,9 @@ Below is a quick little example of a simple **locustfile.py**::
         
         def on_start(self):
             login(self)
+        
+        def on_stop(self):
+            logout(self)
     
     class WebsiteUser(HttpLocust):
         task_set = UserBehavior
@@ -52,8 +58,15 @@ Another way we could declare tasks, which is usually more convenient, is to use 
             """ on_start is called when a Locust start before any task is scheduled """
             self.login()
         
+        def on_stop(self):
+            """ on_stop is called when the TaskSet is stopping """
+            self.logout()
+        
         def login(self):
             self.client.post("/login", {"username":"ellen_key", "password":"education"})
+        
+        def logout(self):
+            self.client.post("/logout", {"username":"ellen_key", "password":"education"})
         
         @task(2)
         def index(self):

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -249,19 +249,19 @@ and :py:class:`TaskSet <locust.core.TaskSet>` :py:meth:`on_start <locust.core.Ta
 Setups and Teardowns
 --------------------
 
-:py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`, whether it's run on :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>`, are functions that are run only once.
+:py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`, whether it's run on :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>`, are methods that are run only once.
 :py:meth:`setup <locust.core.Locust.setup>` is run before tasks start running, while :py:meth:`teardown <locust.core.Locust.teardown>` is run after all tasks have finished and Locust is exiting.
 This enables you to perform some preparation before tasks start running (like creating a database) and to clean up before the Locust quits (like deleting the database).
 
 To use, simply declare a :py:meth:`setup <locust.core.Locust.setup>` and/or :py:meth:`teardown <locust.core.Locust.teardown>` on the :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>` class.
-These functions will be run for you.
+These methods will be run for you.
 
-The on_start and on_stop functions
+The on_start and on_stop methods
 ----------------------------------
 
-A TaskSet class can declare an :py:meth:`on_start <locust.core.TaskSet.on_start>` function or an :py:meth:`on_stop <locust.core.TaskSet.on_stop>` function.
-The :py:meth:`on_start <locust.core.TaskSet.on_start>` function is called when a simulated user starts executing that TaskSet class,
-while the :py:meth:`on_stop <locust.core.TaskSet.on_stop` function is called when the TaskSet is stopped.
+A TaskSet class can declare an :py:meth:`on_start <locust.core.TaskSet.on_start>` method or an :py:meth:`on_stop <locust.core.TaskSet.on_stop>` method.
+The :py:meth:`on_start <locust.core.TaskSet.on_start>` method is called when a simulated user starts executing that TaskSet class,
+while the :py:meth:`on_stop <locust.core.TaskSet.on_stop` method is called when the TaskSet is stopped.
 
 Order of events
 ---------------

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -231,20 +231,52 @@ It's also possible to declare a nested TaskSet, inline in a class, using the
             def my_task(self):
                 pass
 
-
-The on_start function
----------------------
-
-A TaskSet class can optionally declare an :py:meth:`on_start <locust.core.TaskSet.on_start>` function. 
-If so, that function is called when a simulated user starts executing that TaskSet class.
-
-
 Referencing the Locust instance, or the parent TaskSet instance
 ---------------------------------------------------------------
 
 A TaskSet instance will have the attribute :py:attr:`locust <locust.core.TaskSet.locust>` point to 
 its Locust instance, and the attribute :py:attr:`parent <locust.core.TaskSet.parent>` point to its 
 parent TaskSet (it will point to the Locust instance, in the base TaskSet).
+
+
+Setups, Teardowns, on_start, and on_stop
+========================================
+
+Locust optionally supports :py:class:`Locust <locust.core.Locust>` level :py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`,
+:py:class:`TaskSet <locust.core.TaskSet>` level :py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`,
+and :py:class:`TaskSet <locust.core.TaskSet>` :py:meth:`on_start <locust.core.TaskSet.on_start>` and :py:meth:`on_stop <locust.core.TaskSet.on_stop>`
+
+Setups and Teardowns
+--------------------
+
+:py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`, whether it's run on :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>`, are functions that are run only once.
+:py:meth:`setup <locust.core.Locust.setup>` is run before tasks start running, while :py:meth:`teardown <locust.core.Locust.teardown>` is run after all tasks have finished and Locust is exiting.
+This enables you to perform some preparation before tasks start running (like creating a database) and to clean up before the Locust quits (like deleting the database).
+
+To use, simply declare a :py:meth:`setup <locust.core.Locust.setup>` and/or :py:meth:`teardown <locust.core.Locust.teardown>` on the :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>` class.
+These functions will be run for you.
+
+The on_start and on_stop functions
+----------------------------------
+
+A TaskSet class can declare an :py:meth:`on_start <locust.core.TaskSet.on_start>` function or an :py:meth:`on_stop <locust.core.TaskSet.on_stop>` function.
+The :py:meth:`on_start <locust.core.TaskSet.on_start>` function is called when a simulated user starts executing that TaskSet class,
+while the :py:meth:`on_stop <locust.core.TaskSet.on_stop` function is called when the TaskSet is stopped.
+
+Order of events
+---------------
+
+Since many setup and cleanup operations are dependent on each other, here is the order which they are run:
+
+1. Locust setup
+2. TaskSet setup
+3. TaskSet on_start
+4. TaskSet tasks...
+5. TaskSet on_stop
+6. TaskSet teardown
+7. Locust teardown
+
+In general, the setup and teardown methods should be complementary.
 
 
 Making HTTP requests 

--- a/locust/core.py
+++ b/locust/core.py
@@ -108,7 +108,7 @@ class Locust(object):
             self.setup()
         if hasattr(self, "teardown") and self._teardown_is_set is False:
             self._set_teardown_flag()
-            events.parallel_quitting += self.teardown
+            events.quitting += self.teardown
 
     @classmethod
     def _set_setup_flag(cls):
@@ -283,7 +283,7 @@ class TaskSet(object):
             self.setup()
         if hasattr(self, "teardown") and self._teardown_is_set is False:
             self._set_teardown_flag()
-            events.parallel_quitting += self.teardown
+            events.quitting += self.teardown
 
     @classmethod
     def _set_setup_flag(cls):

--- a/locust/core.py
+++ b/locust/core.py
@@ -259,7 +259,7 @@ class TaskSet(object):
         self.kwargs = kwargs
         
         if self.always_run_on_stop and hasattr(self, "on_stop"):
-            events.gevent_quitting += self.on_stop
+            events.parallel_quitting += self.on_stop
         try:
             if hasattr(self, "on_start"):
                 self.on_start()
@@ -269,7 +269,7 @@ class TaskSet(object):
             else:
                 six.reraise(RescheduleTask, RescheduleTask(e.reschedule), sys.exc_info()[2])
         if not self.always_run_on_stop and hasattr(self, "on_stop"):
-            events.gevent_quitting += self.on_stop
+            events.parallel_quitting += self.on_stop
         
         while (True):
             try:

--- a/locust/core.py
+++ b/locust/core.py
@@ -255,13 +255,6 @@ class TaskSet(object):
     instantiated. Useful for nested TaskSet classes.
     """
 
-    always_run_on_stop = False
-    """
-    Used to control how the `on_stop` method is run.
-
-    If True, the `on_stop` method will be run regardless if the `on_start` method
-    has finished
-    """
     _setup_has_run = False  # Internal state to see if we have already run
     _teardown_is_set = False  # Internal state to see if we have already run
     _lock = gevent.lock.Semaphore()  # Lock to make sure setup is only run once

--- a/locust/events.py
+++ b/locust/events.py
@@ -33,20 +33,6 @@ class EventHook(object):
         for handler in self._handlers:
             handler(**kwargs)
 
-
-class ParallelEventHook(EventHook):
-    """
-    Based off of EventHook and is used in a similar way
-    Used to run many events in parallel
-    """
-    def fire(self, reverse=False, **kwargs):
-        g_handlers = []
-        if reverse:
-            self._handlers.reverse()
-        for handler in self._handlers:
-            g_handlers.append(gevent.spawn(handler, **kwargs))
-        gevent.joinall(g_handlers)
-
 request_success = EventHook()
 """
 *request_success* is fired when a request is completed successfully.
@@ -121,13 +107,6 @@ Event is fire with the following arguments:
 quitting = EventHook()
 """
 *quitting* is fired when the locust process in exiting
-"""
-
-parallel_quitting = ParallelEventHook()
-"""
-*parallel_quitting* is fired when the locust process is exiting
-
-This should be used when wanting to run many events before exiting
 """
 
 master_start_hatching = EventHook()

--- a/locust/events.py
+++ b/locust/events.py
@@ -11,6 +11,9 @@ class EventHook(object):
             print "Event was fired with arguments: %s, %s" % (a, b)
         my_event += on_my_event
         my_event.fire(a="foo", b="bar")
+
+    If reverse is True, then the handlers will run in the reverse order
+    that they were inserted
     """
 
     def __init__(self):
@@ -24,7 +27,9 @@ class EventHook(object):
         self._handlers.remove(handler)
         return self
 
-    def fire(self, **kwargs):
+    def fire(self, reverse=False, **kwargs):
+        if reverse:
+            self._handlers.reverse()
         for handler in self._handlers:
             handler(**kwargs)
 
@@ -33,9 +38,6 @@ class ParallelEventHook(EventHook):
     """
     Based off of EventHook and is used in a similar way
     Used to run many events in parallel
-
-    If reverse is True, then the handlers will run in the reverse order
-    that they were inserted
     """
     def fire(self, reverse=False, **kwargs):
         g_handlers = []

--- a/locust/events.py
+++ b/locust/events.py
@@ -1,3 +1,5 @@
+import gevent
+
 class EventHook(object):
     """
     Simple event class used to provide hooks for different types of events in Locust.
@@ -25,6 +27,19 @@ class EventHook(object):
     def fire(self, **kwargs):
         for handler in self._handlers:
             handler(**kwargs)
+
+
+class ParallelEventHook(EventHook):
+    """
+    Based off of EventHook and is used in the same way
+
+    Used to run many events in parallel
+    """
+    def fire(self, **kwargs):
+        g_handlers = []
+        for handler in self._handlers:
+            gevent.spawn(handler, **kwargs)
+        gevent.joinall(g_handlers)
 
 request_success = EventHook()
 """
@@ -100,6 +115,13 @@ Event is fire with the following arguments:
 quitting = EventHook()
 """
 *quitting* is fired when the locust process in exiting
+"""
+
+parallel_quitting = ParallelEventHook()
+"""
+*parallel_quitting* is fired when the locust process is exiting
+
+This should be used when wanting to run many events before exiting
 """
 
 master_start_hatching = EventHook()

--- a/locust/events.py
+++ b/locust/events.py
@@ -38,7 +38,7 @@ class ParallelEventHook(EventHook):
     def fire(self, **kwargs):
         g_handlers = []
         for handler in self._handlers:
-            gevent.spawn(handler, **kwargs)
+            g_handlers.append(gevent.spawn(handler, **kwargs))
         gevent.joinall(g_handlers)
 
 request_success = EventHook()

--- a/locust/events.py
+++ b/locust/events.py
@@ -31,12 +31,16 @@ class EventHook(object):
 
 class ParallelEventHook(EventHook):
     """
-    Based off of EventHook and is used in the same way
-
+    Based off of EventHook and is used in a similar way
     Used to run many events in parallel
+
+    If reverse is True, then the handlers will run in the reverse order
+    that they were inserted
     """
-    def fire(self, **kwargs):
+    def fire(self, reverse=False, **kwargs):
         g_handlers = []
+        if reverse:
+            self._handlers.reverse()
         for handler in self._handlers:
             g_handlers.append(gevent.spawn(handler, **kwargs))
         gevent.joinall(g_handlers)

--- a/locust/main.py
+++ b/locust/main.py
@@ -492,6 +492,8 @@ def main():
 
         events.quitting.fire()
         events.parallel_quitting.fire()
+        if runners.locust_runner is not None:
+            runners.locust_runner.quit()
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
         if options.csvfilebase:

--- a/locust/main.py
+++ b/locust/main.py
@@ -491,6 +491,7 @@ def main():
         logger.info("Shutting down (exit code %s), bye." % code)
 
         events.quitting.fire()
+        events.parallel_quitting.fire()
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
         if options.csvfilebase:

--- a/locust/main.py
+++ b/locust/main.py
@@ -495,7 +495,6 @@ def main():
             runners.locust_runner.quit()
         logger.info("Running teardowns...")
         events.quitting.fire(reverse=True)
-        events.parallel_quitting.fire(reverse=True)
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
         if options.csvfilebase:

--- a/locust/main.py
+++ b/locust/main.py
@@ -492,7 +492,7 @@ def main():
 
         if runners.locust_runner is not None:
             runners.locust_runner.quit()
-        events.quitting.fire()
+        events.quitting.fire(reverse=True)
         events.parallel_quitting.fire(reverse=True)
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)

--- a/locust/main.py
+++ b/locust/main.py
@@ -490,8 +490,10 @@ def main():
         """
         logger.info("Shutting down (exit code %s), bye." % code)
 
+        logger.info("Cleaning up runner...")
         if runners.locust_runner is not None:
             runners.locust_runner.quit()
+        logger.info("Running teardowns...")
         events.quitting.fire(reverse=True)
         events.parallel_quitting.fire(reverse=True)
         print_stats(runners.locust_runner.request_stats)

--- a/locust/main.py
+++ b/locust/main.py
@@ -490,10 +490,10 @@ def main():
         """
         logger.info("Shutting down (exit code %s), bye." % code)
 
-        events.quitting.fire()
-        events.parallel_quitting.fire()
         if runners.locust_runner is not None:
             runners.locust_runner.quit()
+        events.quitting.fire()
+        events.parallel_quitting.fire(reverse=True)
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
         if options.csvfilebase:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # global locust runner singleton
 locust_runner = None
 
-STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_STOPPED = ["ready", "hatching", "running", "stopped"]
+STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_CLEANUP, STATE_STOPPED = ["ready", "hatching", "running", "cleanup", "stopped"]
 SLAVE_REPORT_INTERVAL = 3.0
 
 
@@ -111,7 +111,7 @@ class LocustRunner(object):
                 occurence_count[locust.__name__] += 1
                 def start_locust(_):
                     try:
-                        locust().run()
+                        locust().run(runner=self)
                     except GreenletExit:
                         pass
                 new_locust = self.locusts.spawn(start_locust, locust)


### PR DESCRIPTION
If a TaskSet has an `on_stop` method, it will be run before the process exits. It will also look for a property on the class named `always_run_on_stop`, which if True will run regardless if the `on_start` method finished.

Looking to solve #59 

Any comments on this functionality?