### PR TITLE
Adding CSV output over time and fixing long-time typo

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,7 +55,7 @@ Changelog
 * Fixed bug which caused the download time of the request body not to be included in the 
   reported response time. 
 * Fixed bug that occurred on some linux dists that were tampering with the python-requests 
-  system package (removing dependencies which requests is bundling). This bug only occured 
+  system package (removing dependencies which requests is bundling). This bug only occurred 
   when installing Locust in the python system packages, and not when using virtualenv.
 * Various minor fixes and improvements.
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -97,18 +97,18 @@ class LocustRunner(object):
             self.num_clients += spawn_count
 
         logger.info("Hatching and swarming %i clients at the rate %g clients/s..." % (spawn_count, self.hatch_rate))
-        occurence_count = dict([(l.__name__, 0) for l in self.locust_classes])
+        occurrence_count = dict([(l.__name__, 0) for l in self.locust_classes])
         
         def hatch():
             sleep_time = 1.0 / self.hatch_rate
             while True:
                 if not bucket:
-                    logger.info("All locusts hatched: %s" % ", ".join(["%s: %d" % (name, count) for name, count in six.iteritems(occurence_count)]))
+                    logger.info("All locusts hatched: %s" % ", ".join(["%s: %d" % (name, count) for name, count in six.iteritems(occurrence_count)]))
                     events.hatch_complete.fire(user_count=self.num_clients)
                     return
 
                 locust = bucket.pop(random.randint(0, len(bucket)-1))
-                occurence_count[locust.__name__] += 1
+                occurrence_count[locust.__name__] += 1
                 def start_locust(_):
                     try:
                         locust().run()

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -40,13 +40,15 @@ class LocustRunner(object):
         self.hatching_greenlet = None
         self.exceptions = {}
         self.stats = global_stats
-        
+        self.runner_start_time = time()
+
         # register listener that resets stats when hatching is complete
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
             if not self.options.no_reset_stats:
                 logger.info("Resetting stats\n")
                 self.stats.reset_all()
+                self.runner_start_time = time()
         events.hatch_complete += on_hatch_complete
 
     @property

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -321,7 +321,7 @@ a:hover {
     text-align: left;
 }
 
-#exceptions th.exception_occurences {
+#exceptions th.exception_occurrences {
     width: 110px;
     text-align: center;
 }
@@ -329,7 +329,7 @@ a:hover {
     text-align: left;
 }
 
-#exceptions td.occurences {
+#exceptions td.occurrences {
     text-align: center;
 }
 #exceptions td.traceback {

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -273,6 +273,7 @@ class StatsEntry(object):
     def log_error(self, error):
         self.num_failures += 1
 
+
     @property
     def fail_ratio(self):
         try:
@@ -484,11 +485,11 @@ class StatsEntry(object):
 
 
 class StatsError(object):
-    def __init__(self, method, name, error, occurences=0):
+    def __init__(self, method, name, error, occurrences=0):
         self.method = method
         self.name = name
         self.error = error
-        self.occurences = occurences
+        self.occurrences = occurrences
 
     @classmethod
     def parse_error(cls, error):
@@ -509,8 +510,8 @@ class StatsError(object):
         key = "%s.%s.%r" % (method, name, StatsError.parse_error(error))
         return hashlib.md5(key.encode('utf-8')).hexdigest()
 
-    def occured(self):
-        self.occurences += 1
+    def occurred(self):
+        self.occurrences += 1
 
     def to_name(self):
         return "%s %s: %r" % (self.method, 
@@ -521,7 +522,7 @@ class StatsError(object):
             "method": self.method,
             "name": self.name,
             "error": StatsError.parse_error(self.error),
-            "occurences": self.occurences
+            "occurrences": self.occurrences
         }
 
     @classmethod
@@ -530,7 +531,7 @@ class StatsError(object):
             data["method"], 
             data["name"], 
             data["error"], 
-            data["occurences"]
+            data["occurrences"]
         )
 
 
@@ -578,8 +579,8 @@ def on_slave_report(client_id, data):
         if error_key not in global_stats.errors:
             global_stats.errors[error_key] = StatsError.from_dict(error)
         else:
-            global_stats.errors[error_key].occurences += error["occurences"]
-    
+            global_stats.errors[error_key].occurrences += error["occurrences"]
+
     # save the old last_request_timestamp, to see if we should store a new copy
     # of the response times in the response times cache
     old_last_request_timestamp = global_stats.total.last_request_timestamp
@@ -593,7 +594,7 @@ def on_slave_report(client_id, data):
         # (which is what the response times cache is used for) uses an approximation of the 
         # last 10 seconds anyway, it should be fine to ignore this. 
         global_stats.total._cache_response_times(global_stats.total.last_request_timestamp)
-    
+
 
 events.request_success += on_request_success
 events.request_failure += on_request_failure
@@ -642,10 +643,10 @@ def print_error_report():
     if not len(global_stats.errors):
         return
     console_logger.info("Error report")
-    console_logger.info(" %-18s %-100s" % ("# occurences", "Error"))
+    console_logger.info(" %-18s %-100s" % ("# occurrences", "Error"))
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     for error in six.itervalues(global_stats.errors):
-        console_logger.info(" %-18i %-100s" % (error.occurences, error.to_name()))
+        console_logger.info(" %-18i %-100s" % (error.occurrences, error.to_name()))
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     console_logger.info("")
 

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -134,7 +134,7 @@
                 <div style="display:none;">
                     <table id="exceptions" class="stats">
                         <thead>
-                            <th class="exception_occurences stats_label" data-sortkey="1"># occurences</th>
+                            <th class="exception_occurrences stats_label" data-sortkey="1"># occurrences</th>
                             <th class="exception_traceback stats_label" data-sortkey="0">Traceback</th>
                         </thead>
                         <tbody>
@@ -218,7 +218,7 @@
     <script type="text/x-jqote-template" id="errors-template">
         <![CDATA[
         <tr class="<%=(alternate ? "dark" : "")%>">
-            <td><%= this.occurences %></td>
+            <td><%= this.occurrences %></td>
             <td><%= this.method %></td>
             <td><%= this.name %></td>
             <td><%= function(e) { return e.replace("<", "&lt;"); }(this.error) %></td>
@@ -229,7 +229,7 @@
     <script type="text/x-jqote-template" id="exceptions-template">
         <![CDATA[
         <tr class="<%=(alternate ? "dark" : "")%>">
-            <td class="occurences"><%= this.count %></td>
+            <td class="occurrences"><%= this.count %></td>
             <td class="traceback" title="Occured on: <%= this.nodes %>"><%= function(e) { return e.replace("<", "&lt;"); }(this.traceback) %>
 <%= function(e) { return e.replace("<", "&lt;"); }(this.msg) %></td>
         </tr>

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -120,13 +120,14 @@ class TestRequestStats(unittest.TestCase):
         s1 = StatsEntry(self.stats, "rounding down!", "GET")
         s1.log(122, 0)    # (rounded 120) min
         actual_percentile = s1.percentile()
-        self.assertEqual(actual_percentile, " GET rounding down!                                                  1    120    120    120    120    120    120    120    120    120")
+        self.assertEqual(actual_percentile, " GET rounding down!                                                  0      1    120    120    120    120    120    120    120    120    120")
 
     def test_percentile_rounded_up(self):
         s2 = StatsEntry(self.stats, "rounding up!", "GET")
         s2.log(127, 0)    # (rounded 130) min
         actual_percentile = s2.percentile()
-        self.assertEqual(actual_percentile, " GET rounding up!                                                    1    130    130    130    130    130    130    130    130    130")
+        print()
+        self.assertEqual(actual_percentile, " GET rounding up!                                                    0      1    130    130    130    130    130    130    130    130    130")
     
     def test_error_grouping(self):
         # reset stats

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -136,7 +136,7 @@ class TestRequestStats(unittest.TestCase):
         self.stats.log_error("GET", "/some-path", Exception("Exception!"))
             
         self.assertEqual(1, len(self.stats.errors))
-        self.assertEqual(2, list(self.stats.errors.values())[0].occurences)
+        self.assertEqual(2, list(self.stats.errors.values())[0].occurrences)
         
         self.stats.log_error("GET", "/some-path", Exception("Another exception!"))
         self.stats.log_error("GET", "/some-path", Exception("Another exception!"))


### PR DESCRIPTION
## Summary:
Response times change over the course of a test, given that the CSV log continuously overwrites itself with stats based on a snapshot of the last 10 seconds, valuable data is lost of previous intervals. I have therefore added the option to allow writing an appended log of response times. While not set as default, I think this should be the default behaviour of the `--csv` flag.

## Changes
* **First commit:** All across the project every `occurrence` was missing the second `r`, this has been bugging me for a long time.

* **Second commit:** Adds flag (`--csv-append`) for writing out a CSV log over time, essentially giving you the ability to track changes in the statistics as a function of test duration. Also added a column for total test duration at reporting interval.

Normal output (response.csv):
```
"Method","Name","Total elapsed time","# requests","# failures","Median response time","Average response time","Min response time","Max response time","Average Content Size","Requests/s"
"GET","/",25,172,0,13,13,10,55,12722,6.64
"GET","/about-me/",25,162,0,13,14,11,78,11484,6.25
"None","Total",25,334,0,13,14,10,78,12121,12.88
```

Appended output (response.csv):
```
"Method","Name","Total elapsed time","# requests","# failures","Median response time","Average response time","Min response time","Max response time","Average Content Size","Requests/s"
"GET","/",5,33,0,13,15,11,55,12722,5.57
"GET","/about-me/",5,38,0,13,14,12,70,11484,6.42
"GET","/",15,100,0,13,13,10,55,12722,6.70
"GET","/about-me/",15,95,0,13,15,11,78,11484,6.37
"GET","/",25,167,0,13,13,10,55,12722,6.44
"GET","/about-me/",25,158,0,13,14,11,78,11484,6.10
"GET","/",25,172,0,13,13,10,55,12722,6.64
"GET","/about-me/",25,162,0,13,14,11,78,11484,6.25
"None","Total",25,334,0,13,14,10,78,12121,12.88
```
_same behaviour for the distribution.csv_

/CC @heyman 