### PR TITLE
Support receive and handle custom stats

### DIFF
--- a/locust/events.py
+++ b/locust/events.py
@@ -125,3 +125,8 @@ locust_stop_hatching = EventHook()
 """
 *locust_stop_hatching* is fired when terminate the hatching process on any locust worker.
 """
+
+slave_report_custom_stats = EventHook()
+"""
+*slave_custom_stats* is fired when receive message names "custom_stats"
+"""

--- a/locust/main.py
+++ b/locust/main.py
@@ -46,7 +46,7 @@ def parse_options():
         default="",
         help="Host to bind the web interface to. Defaults to '' (all interfaces)"
     )
-    
+
     parser.add_option(
         '-P', '--port', '--web-port',
         type="int",
@@ -54,7 +54,7 @@ def parse_options():
         default=8089,
         help="Port on which to run web host"
     )
-    
+
     parser.add_option(
         '-f', '--locustfile',
         dest='locustfile',
@@ -89,7 +89,7 @@ def parse_options():
         default=False,
         help="Set locust to run in distributed mode with this process as slave"
     )
-    
+
     # master host options
     parser.add_option(
         '--master-host',
@@ -99,7 +99,7 @@ def parse_options():
         default="127.0.0.1",
         help="Host or IP address of locust master for distributed load testing. Only used when running with --slave. Defaults to 127.0.0.1."
     )
-    
+
     parser.add_option(
         '--master-port',
         action='store',
@@ -117,7 +117,7 @@ def parse_options():
         default="*",
         help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces)."
     )
-    
+
     parser.add_option(
         '--master-bind-port',
         action='store',
@@ -164,7 +164,7 @@ def parse_options():
         default=1,
         help="The rate per second in which clients are spawned. Only used together with --no-web"
     )
-    
+
     # Time limit of the test run
     parser.add_option(
         '-t', '--run-time',
@@ -174,7 +174,7 @@ def parse_options():
         default=None,
         help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --no-web"
     )
-    
+
     # log level
     parser.add_option(
         '--loglevel', '-L',
@@ -184,7 +184,7 @@ def parse_options():
         default='INFO',
         help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
     )
-    
+
     # log file
     parser.add_option(
         '--logfile',
@@ -194,7 +194,7 @@ def parse_options():
         default=None,
         help="Path to log file. If not set, log will go to stdout/stderr",
     )
-    
+
     # if we should print stats in the console
     parser.add_option(
         '--print-stats',
@@ -220,7 +220,7 @@ def parse_options():
         default=False,
         help="Do not reset statistics once hatching has been completed",
     )
-    
+
     # List locust commands found in loaded locust files/source files
     parser.add_option(
         '-l', '--list',
@@ -229,7 +229,7 @@ def parse_options():
         default=False,
         help="Show list of possible locust classes and exit"
     )
-    
+
     # Display ratio table of all tasks
     parser.add_option(
         '--show-task-ratio',
@@ -246,7 +246,7 @@ def parse_options():
         default=False,
         help="print json data of the locust classes' task execution ratio"
     )
-    
+
     # Version number (optparse gives you --version but we have to do it
     # ourselves to get -V too. sigh)
     parser.add_option(
@@ -255,6 +255,15 @@ def parse_options():
         dest='show_version',
         default=False,
         help="show program's version number and exit"
+    )
+
+    parser.add_option(
+        '--wait-before-master-quit',
+        action='store',
+        type='float',
+        dest='wait_before_master_quit',
+        default=0,
+        help="Wait time before master locust quit"
     )
 
     # Finalize
@@ -367,7 +376,7 @@ def main():
     # setup logging
     setup_logging(options.loglevel, options.logfile)
     logger = logging.getLogger(__name__)
-    
+
     if options.show_version:
         print("Locust %s" % (version,))
         sys.exit(0)
@@ -406,7 +415,7 @@ def main():
     else:
         # list() call is needed to consume the dict_view object in Python 3
         locust_classes = list(locusts.values())
-    
+
     if options.show_task_ratio:
         console_logger.info("\n Task ratio per locust class")
         console_logger.info( "-" * 80)
@@ -418,12 +427,12 @@ def main():
     if options.show_task_ratio_json:
         from json import dumps
         task_data = {
-            "per_class": get_task_ratio_dict(locust_classes), 
+            "per_class": get_task_ratio_dict(locust_classes),
             "total": get_task_ratio_dict(locust_classes, total=True)
         }
         console_logger.info(dumps(task_data))
         sys.exit(0)
-    
+
     if options.run_time:
         if not options.no_web:
             logger.error("The --run-time argument can only be used together with --no-web")
@@ -444,7 +453,7 @@ def main():
         # spawn web greenlet
         logger.info("Starting web monitor at %s:%s" % (options.web_host or "*", options.port))
         main_greenlet = gevent.spawn(web.start, locust_classes, options)
-    
+
     if not options.master and not options.slave:
         runners.locust_runner = LocalLocustRunner(locust_classes, options)
         # spawn client spawning/hatching greenlet
@@ -475,7 +484,7 @@ def main():
         except socket.error as e:
             logger.error("Failed to connect to the Locust master: %s", e)
             sys.exit(-1)
-    
+
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
         gevent.spawn(stats_printer)
@@ -483,7 +492,7 @@ def main():
     if options.csvfilebase:
         gevent.spawn(stats_writer, options.csvfilebase)
 
-    
+
     def shutdown(code=0):
         """
         Shut down locust by firing quitting event, printing/writing stats and exiting
@@ -497,13 +506,13 @@ def main():
             write_stat_csvs(options.csvfilebase)
         print_error_report()
         sys.exit(code)
-    
+
     # install SIGTERM handler
     def sig_term_handler():
         logger.info("Got SIGTERM signal")
         shutdown(0)
     gevent.signal(signal.SIGTERM, sig_term_handler)
-    
+
     try:
         logger.info("Starting Locust %s" % version)
         main_greenlet.join()

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -6,10 +6,10 @@ class Message(object):
         self.type = message_type
         self.data = data
         self.node_id = node_id
-    
+
     def serialize(self):
         return msgpack.dumps((self.type, self.data, self.node_id))
-    
+
     @classmethod
     def unserialize(cls, data):
         msg = cls(*msgpack.loads(data, encoding='utf-8'))

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -7,7 +7,7 @@ class BaseSocket(object):
 
     def send(self, msg):
         self.sender.send(msg.serialize())
-    
+
     def recv(self):
         data = self.receiver.recv()
         return Message.unserialize(data)
@@ -18,16 +18,16 @@ class Server(BaseSocket):
         context = zmq.Context()
         self.receiver = context.socket(zmq.PULL)
         self.receiver.bind("tcp://%s:%i" % (host, port))
-        
+
         self.sender = context.socket(zmq.PUSH)
         self.sender.bind("tcp://%s:%i" % (host, port+1))
-    
+
 
 class Client(BaseSocket):
     def __init__(self, host, port):
         context = zmq.Context()
         self.receiver = context.socket(zmq.PULL)
         self.receiver.connect("tcp://%s:%i" % (host, port+1))
-        
+
         self.sender = context.socket(zmq.PUSH)
         self.sender.connect("tcp://%s:%i" % (host, port))

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -40,7 +40,8 @@ class LocustRunner(object):
         self.hatching_greenlet = None
         self.exceptions = {}
         self.stats = global_stats
-        
+        self.custom_stats = None
+
         # register listener that resets stats when hatching is complete
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
@@ -52,11 +53,11 @@ class LocustRunner(object):
     @property
     def request_stats(self):
         return self.stats.entries
-    
+
     @property
     def errors(self):
         return self.stats.errors
-    
+
     @property
     def user_count(self):
         return len(self.locusts)
@@ -98,7 +99,7 @@ class LocustRunner(object):
 
         logger.info("Hatching and swarming %i clients at the rate %g clients/s..." % (spawn_count, self.hatch_rate))
         occurence_count = dict([(l.__name__, 0) for l in self.locust_classes])
-        
+
         def hatch():
             sleep_time = 1.0 / self.hatch_rate
             while True:
@@ -118,7 +119,7 @@ class LocustRunner(object):
                 if len(self.locusts) % 10 == 0:
                     logger.debug("%i locusts hatched" % len(self.locusts))
                 gevent.sleep(sleep_time)
-        
+
         hatch()
         if wait:
             self.locusts.join()
@@ -180,7 +181,7 @@ class LocustRunner(object):
         self.locusts.kill(block=True)
         self.state = STATE_STOPPED
         events.locust_stop_hatching.fire()
-    
+
     def quit(self):
         self.stop()
         self.greenlet.kill(block=True)
@@ -213,7 +214,8 @@ class DistributedLocustRunner(LocustRunner):
         self.master_port = options.master_port
         self.master_bind_host = options.master_bind_host
         self.master_bind_port = options.master_bind_port
-    
+        self.wait_before_master_quit = options.wait_before_master_quit
+
     def noop(self, *args, **kwargs):
         """ Used to link() greenlets to in order to be compatible with gevent 1.0 """
         pass
@@ -227,28 +229,28 @@ class SlaveNode(object):
 class MasterLocustRunner(DistributedLocustRunner):
     def __init__(self, *args, **kwargs):
         super(MasterLocustRunner, self).__init__(*args, **kwargs)
-        
+
         class SlaveNodesDict(dict):
             def get_by_state(self, state):
                 return [c for c in six.itervalues(self) if c.state == state]
-            
+
             @property
             def ready(self):
                 return self.get_by_state(STATE_INIT)
-            
+
             @property
             def hatching(self):
                 return self.get_by_state(STATE_HATCHING)
-            
+
             @property
             def running(self):
                 return self.get_by_state(STATE_RUNNING)
-        
+
         self.clients = SlaveNodesDict()
         self.server = rpc.Server(self.master_bind_host, self.master_bind_port)
         self.greenlet = Group()
         self.greenlet.spawn(self.client_listener).link_exception(callback=self.noop)
-        
+
         # listener that gathers info on how many locust users the slaves has spawned
         def on_slave_report(client_id, data):
             if client_id not in self.clients:
@@ -257,16 +259,16 @@ class MasterLocustRunner(DistributedLocustRunner):
 
             self.clients[client_id].user_count = data["user_count"]
         events.slave_report += on_slave_report
-        
+
         # register listener that sends quit message to slave nodes
         def on_quitting():
             self.quit()
         events.quitting += on_quitting
-    
+
     @property
     def user_count(self):
         return sum([c.user_count for c in six.itervalues(self.clients)])
-    
+
     def start_hatching(self, locust_count, hatch_rate):
         num_slaves = len(self.clients.ready) + len(self.clients.running)
         if not num_slaves:
@@ -285,7 +287,7 @@ class MasterLocustRunner(DistributedLocustRunner):
             self.stats.clear_all()
             self.exceptions = {}
             events.master_start_hatching.fire()
-        
+
         for client in six.itervalues(self.clients):
             data = {
                 "hatch_rate":slave_hatch_rate,
@@ -299,7 +301,7 @@ class MasterLocustRunner(DistributedLocustRunner):
                 remaining -= 1
 
             self.server.send(Message("hatch", data, None))
-        
+
         self.stats.start_time = time()
         self.state = STATE_HATCHING
 
@@ -307,12 +309,13 @@ class MasterLocustRunner(DistributedLocustRunner):
         for client in self.clients.hatching + self.clients.running:
             self.server.send(Message("stop", None, None))
         events.master_stop_hatching.fire()
-    
+
     def quit(self):
         for client in six.itervalues(self.clients):
             self.server.send(Message("quit", None, None))
+        gevent.sleep(self.wait_before_master_quit)
         self.greenlet.kill(block=True)
-    
+
     def client_listener(self):
         while True:
             msg = self.server.recv()
@@ -344,6 +347,9 @@ class MasterLocustRunner(DistributedLocustRunner):
                     logger.info("Client %r quit. Currently %i clients connected." % (msg.node_id, len(self.clients.ready)))
             elif msg.type == "exception":
                 self.log_exception(msg.node_id, msg.data["msg"], msg.data["traceback"])
+            elif msg.type == 'custom_stats':
+                events.slave_report_custom_stats.fire(
+                    client_id=msg.node_id, data=msg.data)
 
     @property
     def slave_count(self):
@@ -353,24 +359,24 @@ class SlaveLocustRunner(DistributedLocustRunner):
     def __init__(self, *args, **kwargs):
         super(SlaveLocustRunner, self).__init__(*args, **kwargs)
         self.client_id = socket.gethostname() + "_" + md5(str(time() + random.randint(0,10000)).encode('utf-8')).hexdigest()
-        
+
         self.client = rpc.Client(self.master_host, self.master_port)
         self.greenlet = Group()
 
         self.greenlet.spawn(self.worker).link_exception(callback=self.noop)
         self.client.send(Message("client_ready", None, self.client_id))
         self.greenlet.spawn(self.stats_reporter).link_exception(callback=self.noop)
-        
+
         # register listener for when all locust users have hatched, and report it to the master node
         def on_hatch_complete(user_count):
             self.client.send(Message("hatch_complete", {"count":user_count}, self.client_id))
         events.hatch_complete += on_hatch_complete
-        
-        # register listener that adds the current number of spawned locusts to the report that is sent to the master node 
+
+        # register listener that adds the current number of spawned locusts to the report that is sent to the master node
         def on_report_to_master(client_id, data):
             data["user_count"] = self.user_count
         events.report_to_master += on_report_to_master
-        
+
         # register listener that sends quit message to master
         def on_quitting():
             self.client.send(Message("quit", None, self.client_id))
@@ -410,5 +416,5 @@ class SlaveLocustRunner(DistributedLocustRunner):
             except:
                 logger.error("Connection lost to master server. Aborting...")
                 break
-            
+
             gevent.sleep(SLAVE_REPORT_INTERVAL)


### PR DESCRIPTION
- Add `slave_report_custom_stats` event to handle custom stats when receive it.
- Add `wait-before-master-quit` option to used to sleep before main greenlet of master runner dead, so that master can handle custom stats which from slaves.