### PR TITLE
Do not reset statistics on hatch complete 

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -216,9 +216,15 @@ def parse_options():
     parser.add_option(
         '--no-reset-stats',
         action='store_true',
-        dest='no_reset_stats',
+        help="[DEPRECATED] Do not reset statistics once hatching has been completed. This is now the default behavior. See --reset-stats to disable",
+    )
+
+    parser.add_option(
+        '--reset-stats',
+        action='store_true',
+        dest='reset_stats',
         default=False,
-        help="Do not reset statistics once hatching has been completed",
+        help="Reset statistics once hatching has been completed. Should be set on both master and slaves when running in distributed mode",
     )
     
     # List locust commands found in loaded locust files/source files

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -44,7 +44,7 @@ class LocustRunner(object):
         # register listener that resets stats when hatching is complete
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
-            if not self.options.no_reset_stats:
+            if self.options.reset_stats:
                 logger.info("Resetting stats\n")
                 self.stats.reset_all()
         events.hatch_complete += on_hatch_complete

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -1,0 +1,26 @@
+import unittest
+
+from locust.main import parse_options
+
+
+class TestParser(unittest.TestCase):
+    def setUp(self):
+        self.parser, _, _ = parse_options()
+
+    def test_default(self):
+        opts, _ = self.parser.parse_args([])
+        self.assertEqual(opts.reset_stats, False)
+
+    def test_reset_stats(self):
+        args = [
+            "--reset-stats"
+        ]
+        opts, _ = self.parser.parse_args(args)
+        self.assertEqual(opts.reset_stats, True)
+
+    def test_should_accept_legacy_no_reset_stats(self):
+        args = [
+            "--no-reset-stats"
+        ]
+        opts, _ = self.parser.parse_args(args)
+        self.assertEqual(opts.reset_stats, False)


### PR DESCRIPTION
Do not reset statistics on hatch complete unless the user specifically chooses to. Added a `--reset-stats` option to force a reset, which inverts the meaning of the older `--no-reset-stats` option. Deprecated the `--no-reset-stats` option, but continue to allow it for backwards compatibility.

Closes #672 