### PR TITLE
Small python 3 syntax improvement in docs

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -34,7 +34,7 @@ With the following locustfile, each user would wait between 5 and 15 seconds bet
     class MyTaskSet(TaskSet):
         @task
         def my_task(self):
-            print "executing my_task"
+            print("executing my_task")
     
     class MyLocust(Locust):
         task_set = MyTaskSet
@@ -100,7 +100,7 @@ Here is an example::
     class MyTaskSet(TaskSet):
         @task
         def my_task(self):
-            print "Locust instance (%r) executing my_task" % (self.locust)
+            print("Locust instance (%r) executing my_task" % (self.locust))
     
     class MyLocust(Locust):
         task_set = MyTaskSet
@@ -309,8 +309,8 @@ is an instance of a :py:class:`TaskSet <locust.core.TaskSet>` or :py:class:`Http
 class::
 
     response = self.client.get("/about")
-    print "Response status code:", response.status_code
-    print "Response content:", response.content
+    print("Response status code:", response.status_code)
+    print("Response content:", response.content)
 
 And here's an example making a POST request::
 


### PR DESCRIPTION
While browsing docs noticed in one doc small Python3 incompatibility. Switched to using `print()` as function call vs as statement