### PR TITLE
fix missing import in socketrpc.py (branch 0.8)

### DIFF
--- a/locust/rpc/socketrpc.py
+++ b/locust/rpc/socketrpc.py
@@ -2,6 +2,7 @@ import logging
 import struct
 
 import gevent
+import gevent.queue
 from gevent import socket
 
 from locust.exception import LocustError


### PR DESCRIPTION
# Issue
This pull-request is to branch `0.8`. 
Locust pure python RPC not working in distributed mode (this makes, message seem confusing) - (https://github.com/locustio/locust/issues/680)

# Currrent/Expected Behaviour
pure Python socket RPC implementation works (when `pyzmq` is not installed/detected)
```
~ # locust --host=http://qq.com --master
/usr/local/lib/python3.6/site-packages/locust/rpc/__init__.py:6: UserWarning: WARNING: Using pure Python socket RPC implementation instead of zmq. If running in distributed mode, this could cause a performance decrease. We recommend you to install the pyzmq python package when running in distributed mode.
  warnings.warn("WARNING: Using pure Python socket RPC implementation instead of zmq. If running in distributed mode, this could cause a performance decrease. We recommend you to install the pyzmq python package when running in distributed mode.")
[2017-11-12 21:37:49,379] 1e2974af6aec/INFO/locust.main: Starting web monitor at *:8089
[2017-11-12 21:37:49,380] 1e2974af6aec/INFO/locust.main: Starting Locust 0.8.1
```

# Previous Behavour
pure Python socket RPC implementation doesn't work (when `pyzmq` is not installed/detected)
```
~ # locust --host=http://qq.com --master
/usr/local/lib/python3.6/site-packages/locust/rpc/__init__.py:6: UserWarning: WARNING: Using pure Python socket RPC implementation instead of zmq. If running in distributed mode, this could cause a performance decrease. We recommend you to install the pyzmq python package when running in distributed mode.
  warnings.warn("WARNING: Using pure Python socket RPC implementation instead of zmq. If running in distributed mode, this could cause a performance decrease. We recommend you to install the pyzmq python package when running in distributed mode.")
[2017-11-12 21:35:24,985] 1e2974af6aec/INFO/locust.main: Starting web monitor at *:8089
[2017-11-12 21:35:24,986] 1e2974af6aec/ERROR/stderr: Traceback (most recent call last):
[2017-11-12 21:35:24,986] 1e2974af6aec/ERROR/stderr: File "/usr/local/bin/locust", line 11, in <module>
[2017-11-12 21:35:24,987] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,987] 1e2974af6aec/ERROR/stderr: sys.exit(main())
[2017-11-12 21:35:24,988] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,988] 1e2974af6aec/ERROR/stderr: File "/usr/local/lib/python3.6/site-packages/locust/main.py", line 439, in main
[2017-11-12 21:35:24,989] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,989] 1e2974af6aec/ERROR/stderr: runners.locust_runner = MasterLocustRunner(locust_classes, options)
[2017-11-12 21:35:24,990] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,990] 1e2974af6aec/ERROR/stderr: File "/usr/local/lib/python3.6/site-packages/locust/runners.py", line 247, in __init__
[2017-11-12 21:35:24,991] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,992] 1e2974af6aec/ERROR/stderr: self.server = rpc.Server(self.master_bind_host, self.master_bind_port)
[2017-11-12 21:35:24,992] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,993] 1e2974af6aec/ERROR/stderr: File "/usr/local/lib/python3.6/site-packages/locust/rpc/socketrpc.py", line 74, in __init__
[2017-11-12 21:35:24,993] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,994] 1e2974af6aec/ERROR/stderr: self.event_queue = gevent.queue.Queue()
[2017-11-12 21:35:24,994] 1e2974af6aec/ERROR/stderr: 
[2017-11-12 21:35:24,994] 1e2974af6aec/ERROR/stderr: AttributeError
[2017-11-12 21:35:24,995] 1e2974af6aec/ERROR/stderr: :
[2017-11-12 21:35:24,995] 1e2974af6aec/ERROR/stderr: module 'gevent' has no attribute 'queue'
[2017-11-12 21:35:24,996] 1e2974af6aec/ERROR/stderr: 
```