### PR TITLE
Allow passing additional args to locusts from the command line

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -99,7 +99,7 @@ class Locust(object):
     client = NoClientWarningRaiser()
     _catch_exceptions = True
     
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         super(Locust, self).__init__()
     
     def run(self):
@@ -128,8 +128,8 @@ class HttpLocust(Locust):
     The client support cookies, and therefore keeps the session between HTTP requests.
     """
     
-    def __init__(self):
-        super(HttpLocust, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(HttpLocust, self).__init__(*args, **kwargs)
         if self.host is None:
             raise LocustError("You must specify the base host. Either in the host attribute in the Locust class, or on the command line using the --host option.")
         

--- a/locust/main.py
+++ b/locust/main.py
@@ -263,6 +263,13 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    parser.add_option(
+        '--locust-arg',
+        action='append',
+        dest='locust_args',
+        help="additional args to pass to each locust"
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -30,6 +30,7 @@ SLAVE_REPORT_INTERVAL = 3.0
 class LocustRunner(object):
     def __init__(self, locust_classes, options):
         self.options = options
+        self.locust_args = options.locust_args
         self.locust_classes = locust_classes
         self.hatch_rate = options.hatch_rate
         self.num_clients = options.num_clients
@@ -111,7 +112,7 @@ class LocustRunner(object):
                 occurence_count[locust.__name__] += 1
                 def start_locust(_):
                     try:
-                        locust().run()
+                        locust(*self.locust_args).run()
                     except GreenletExit:
                         pass
                 new_locust = self.locusts.spawn(start_locust, locust)


### PR DESCRIPTION
ref: #345

This now allows you to specify arbitrary args to pass to locust instances e.g.
`locust -f locustfile.py --locust-arg foo --locust-arg bar`