### PR TITLE
Add codecov integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+branch = True
+source = locust
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self\.debug
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    docs/*
+    examples/*
+    locust/test/*
+    setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ addons:
     packages:
       - libev-dev
 install:
-  - pip install tox
+  - pip install tox codecov
 script:
   - tox
+after_success:
+  - codecov -e TOXENV

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+coverage:
+	coverage run -m unittest2 discover
+
 test:
 	unit2 discover
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Locust
 
 [![Build Status](https://img.shields.io/travis/locustio/locust.svg)](https://travis-ci.org/locustio/locust)
+[![codecov](https://codecov.io/gh/locustio/locust/branch/master/graph/badge.svg)](https://codecov.io/gh/locustio/locust)
 [![license](https://img.shields.io/github/license/locustio/locust.svg)](https://github.com/locustio/locust/blob/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/locustio.svg)](https://pypi.python.org/pypi/locustio)
 [![PyPI](https://img.shields.io/pypi/pyversions/locustio.svg)](https://pypi.python.org/pypi/locustio)

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 envlist = py27, py33, py34, py35, py36
 
 [testenv]
+passenv = CI TRAVIS TRAVIS_* TOXENV
 deps =
+    codecov
     mock
     pyzmq
     unittest2
 commands =
-    unit2 discover []
+    coverage run -m unittest2 discover []


### PR DESCRIPTION
# Purpose
The goal of this PR is to add automated coverage reports via https://codecov.io/

## Additional steps required

- Eventually needs repo owner to configure the integration at:  https://github.com/integration/codecov
- Configure GitHub policy to allow or deny contributor ability to override the integration PR enforcement in the event of a decrease in coverage
