### PR TITLE
Make UI URL links relative

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -123,7 +123,7 @@ var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Ti
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
 function updateStats() {
-    $.get('/stats/requests', function (report) {
+    $.get('./stats/requests', function (report) {
         $("#total_rps").html(Math.round(report.total_rps*100)/100);
         //$("#fail_ratio").html(Math.round(report.fail_ratio*10000)/100);
         $("#fail_ratio").html(Math.round(report.fail_ratio*100));
@@ -164,7 +164,7 @@ function updateStats() {
 updateStats();
 
 function updateExceptions() {
-    $.get('/exceptions', function (data) {
+    $.get('./exceptions', function (data) {
         $('#exceptions tbody').empty();
         $('#exceptions tbody').jqoteapp(exceptions_tpl, data.exceptions);
         setTimeout(updateExceptions, 5000);

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <title>Locust</title>
-    <link rel="stylesheet" type="text/css" href="/static/style.css?v={{ version }}" media="screen">
-    <link rel="shortcut icon" href="/static/img/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" type="text/css" href="./static/style.css?v={{ version }}" media="screen">
+    <link rel="shortcut icon" href="./static/img/favicon.ico" type="image/x-icon"/>
 </head>
 <body class="{{state}}">
     <div class="top">
         <div class="top-content container">
-            <img src="/static/img/logo.png?v={{ version }}" class="logo" />
+            <img src="./static/img/logo.png?v={{ version }}" class="logo" />
             <div class="boxes">
                 <div class="top_box box_url">
                     <div class="label">HOST</div>
@@ -42,8 +42,8 @@
                     <div class="value"><span id="fail_ratio"></span>%</div>
                 </div>
                 <div class="top_box box_stop box_running" id="box_stop">
-                    <a href="/stop" class="stop-button"><i></i>STOP</a>
-                    <a href="/stats/reset" class="reset-button">Reset<br>Stats</a>
+                    <a href="./stop" class="stop-button"><i></i>STOP</a>
+                    <a href="./stats/reset" class="reset-button">Reset<br>Stats</a>
                 </div>
             </div>
             <div style="clear:both;"></div>
@@ -56,7 +56,7 @@
             </div>
             <div class="padder">
                 <h2>Start new Locust swarm</h2>
-                <form action="/swarm" method="POST" id="swarm_form">
+                <form action="./swarm" method="POST" id="swarm_form">
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
@@ -73,7 +73,7 @@
             </div>
             <div class="padder">
                 <h2>Change the locust count</h2>
-                <form action="/swarm" method="POST" id="edit_form">
+                <form action="./swarm" method="POST" id="edit_form">
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="new_locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
@@ -146,9 +146,9 @@
                 </div>
                 <div style="display:none;">
                     <div style="margin-top:20px;">
-                        <a href="/stats/requests/csv">Download request statistics CSV</a><br>
-                        <a href="/stats/distribution/csv">Download response time distribution CSV</a><br>
-                        <a href="/exceptions/csv">Download exceptions CSV</a>
+                        <a href="./stats/requests/csv">Download request statistics CSV</a><br>
+                        <a href="./stats/distribution/csv">Download response time distribution CSV</a><br>
+                        <a href="./exceptions/csv">Download exceptions CSV</a>
                     </div>
                 </div>
                 <div style="display:none;">
@@ -207,13 +207,13 @@
     </nav>
 
 
-    <script type="text/javascript" src="/static/jquery-1.11.3.min.js"></script>
-    <script type="text/javascript" src="/static/jquery.jqote2.min.js"></script>
-    <script type="text/javascript" src="/static/jquery.tools.min.js"></script>
+    <script type="text/javascript" src="./static/jquery-1.11.3.min.js"></script>
+    <script type="text/javascript" src="./static/jquery.jqote2.min.js"></script>
+    <script type="text/javascript" src="./static/jquery.tools.min.js"></script>
     <!-- echarts from https://github.com/ecomfe/echarts -->
-    <script type="text/javascript" src="/static/echarts.common.min.js"></script>
+    <script type="text/javascript" src="./static/echarts.common.min.js"></script>
     <!-- vintage theme of echarts -->
-    <script type="text/javascript" src="/static/vintage.js"></script>
+    <script type="text/javascript" src="./static/vintage.js"></script>
     <script type="text/x-jqote-template" id="stats-template">
         <![CDATA[
         <tr class="<%=(alternate ? "dark" : "")%> <%=(this.name == "Total" ? "total" : "")%>">
@@ -262,7 +262,7 @@
         <% alternate = !alternate; %>
         ]]>
     </script>
-    <script type="text/javascript" src="/static/chart.js?v={{ version }}"></script>
-    <script type="text/javascript" src="/static/locust.js?v={{ version }}"></script>
+    <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>
+    <script type="text/javascript" src="./static/locust.js?v={{ version }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #149

When using proxy or exposing Locust UI in Kubernetes (via ingress) the URLs get prefixed (for example, served under http://domain.com/locust instead of http://domain.com).

On the other hand, links in html template and JS (rest calls) are absolute (starting with '/') which makes the UI inoperable.

This PR makes the links relative - they work fine both with and without a prefix.

To validate:
```
git clone https://github.com/karol-brejna-i/locust.git
git checkout origin/149_url-prefix-for-web-ui
pip3.6 uninstall locustio -y 
pip3.6 install ./locust/ 
locust -f locust/examples/basic.py --host=http://localhost:8089
```

When looking at HTML page sources you should see `<link rel="stylesheet" type="text/css" href="./static/style.css?v=0.8" media="screen">` somewhere at the beginning of the doc.

Verify if the UI works: starting, stopping the tests, browsing the stats produce valid rest calls.
(Be aware of browser caching; sometimes "old" HTML and JS are served.)