### PR TITLE
graph error rates and make charts downloadable

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -43,6 +43,7 @@ $("ul.tabs").tabs("div.panes > div").on("onClick", function(event) {
         // trigger resizing of charts
         rpsChart.resize();
         responseTimeChart.resize();
+        errorCountChart.resize();
         usersChart.resize();
     }
 });
@@ -120,6 +121,7 @@ $(".stats_label").click(function(event) {
 // init charts
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS"], "reqs/s");
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times", ["Median Response Time", "95% percentile"], "ms");
+var errorCountChart = new LocustLineChart($(".charts-container"), "Error Count", ["Error Count"], "errors");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
 function updateStats() {
@@ -156,6 +158,7 @@ function updateStats() {
             // update charts
             rpsChart.addValue([total.current_rps]);
             responseTimeChart.addValue([report.current_response_time_percentile_50, report.current_response_time_percentile_95]);
+            errorCountChart.addValue([total.num_failures]);
             usersChart.addValue([report.user_count]);
         }
 
@@ -172,3 +175,53 @@ function updateExceptions() {
     });
 }
 updateExceptions();
+
+function reduceChartData(chart) {
+    return chart.dates.reduce(function(acc, date, i) {
+        acc.push([date, chart.data[0][i]]);
+        return acc
+    }, []);
+}
+
+function buildChartCSV(header, data) {
+    return data.reduce(function(str, point) {
+        return str + point[0] + "," + point[1] + "\n";
+    }, header);
+}
+
+// download chart data
+$('#download_rps_chart').click(function() {
+    var data = reduceChartData(rpsChart);
+    var csv = buildChartCSV("timestamp,RPS\n", data);
+    var octetStream = encodeURIComponent(csv);
+    var toDownload = "data:application/octet-stream;filename=rps.csv," + octetStream;
+
+    $('#download_rps_chart').attr('href', toDownload);
+});
+
+$('#download_response_chart').click(function() {
+    var data = reduceChartData(responseTimeChart);
+    var csv = buildChartCSV("timestamp,time(ms)\n", data);
+    var octetStream = encodeURIComponent(csv);
+    var toDownload = "data:application/octet-stream;filename=responseTimes.csv," + octetStream;
+
+    $('#download_response_chart').attr('href', toDownload);
+});
+
+$('#download_error_chart').click(function() {
+    var data = reduceChartData(errorCountChart);
+    var csv = buildChartCSV("timestamp,errors\n", data);
+    var octetStream = encodeURIComponent(csv);
+    var toDownload = "data:application/octet-stream;filename=errors.csv," + octetStream;
+
+    $('#download_error_chart').attr('href', toDownload);
+});
+
+$('#download_user_chart').click(function() {
+    var data = reduceChartData(usersChart);
+    var csv = buildChartCSV("timestamp,users\n", data);
+    var octetStream = encodeURIComponent(csv);
+    var toDownload = "data:application/octet-stream;filename=users.csv," + octetStream;
+
+    $('#download_user_chart').attr('href', toDownload);
+});

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -43,7 +43,6 @@ $("ul.tabs").tabs("div.panes > div").on("onClick", function(event) {
         // trigger resizing of charts
         rpsChart.resize();
         responseTimeChart.resize();
-        errorCountChart.resize();
         usersChart.resize();
     }
 });
@@ -121,7 +120,6 @@ $(".stats_label").click(function(event) {
 // init charts
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS"], "reqs/s");
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times", ["Median Response Time", "95% percentile"], "ms");
-var errorCountChart = new LocustLineChart($(".charts-container"), "Error Count", ["Error Count"], "errors");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
 function updateStats() {
@@ -158,7 +156,6 @@ function updateStats() {
             // update charts
             rpsChart.addValue([total.current_rps]);
             responseTimeChart.addValue([report.current_response_time_percentile_50, report.current_response_time_percentile_95]);
-            errorCountChart.addValue([total.num_failures]);
             usersChart.addValue([report.user_count]);
         }
 
@@ -206,15 +203,6 @@ $('#download_response_chart').click(function() {
     var toDownload = "data:application/octet-stream;filename=responseTimes.csv," + octetStream;
 
     $('#download_response_chart').attr('href', toDownload);
-});
-
-$('#download_error_chart').click(function() {
-    var data = reduceChartData(errorCountChart);
-    var csv = buildChartCSV("timestamp,errors\n", data);
-    var octetStream = encodeURIComponent(csv);
-    var toDownload = "data:application/octet-stream;filename=errors.csv," + octetStream;
-
-    $('#download_error_chart').attr('href', toDownload);
 });
 
 $('#download_user_chart').click(function() {

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -343,8 +343,8 @@ a:hover {
     width: 100%;
 }
 #charts .chart {
-    height: 350px;
-    margin-bottom: 30px;
+    height: 260px;
+    margin-bottom: 10px;
     box-sizing: border-box;
     border: 1px solid #11271e;
     border-radius: 3px;

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -343,8 +343,8 @@ a:hover {
     width: 100%;
 }
 #charts .chart {
-    height: 260px;
-    margin-bottom: 10px;
+    height: 350px;
+    margin-bottom: 30px;
     box-sizing: border-box;
     border: 1px solid #11271e;
     border-radius: 3px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -146,9 +146,17 @@
                 </div>
                 <div style="display:none;">
                     <div style="margin-top:20px;">
+                        <h3>Summary</h3>
                         <a href="/stats/requests/csv">Download request statistics CSV</a><br>
                         <a href="/stats/distribution/csv">Download response time distribution CSV</a><br>
                         <a href="/exceptions/csv">Download exceptions CSV</a>
+                    </div>
+                    <div style="margin-top:20px;">
+                        <h3>Full Chart Data</h3>
+                        <a href="" id="download_rps_chart" download="rps.csv">Download RPS Chart Data</a><br>
+                        <a href="" id="download_response_chart" download="responseTimes.csv">Download Response Time Chart Data</a><br>
+                        <a href="" id="download_error_chart" download="errors.csv">Download Error Chart Data</a><br>
+                        <a href="" id="download_user_chart" download="users.csv">Download User Chart Data</a>
                     </div>
                 </div>
                 <div style="display:none;">

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -155,7 +155,6 @@
                         <h3>Full Chart Data</h3>
                         <a href="" id="download_rps_chart" download="rps.csv">Download RPS Chart Data</a><br>
                         <a href="" id="download_response_chart" download="responseTimes.csv">Download Response Time Chart Data</a><br>
-                        <a href="" id="download_error_chart" download="errors.csv">Download Error Chart Data</a><br>
                         <a href="" id="download_user_chart" download="users.csv">Download User Chart Data</a>
                     </div>
                 </div>


### PR DESCRIPTION
First, thanks for the amazing tool! It was super simple to deploy and get running.

~I found myself wanting to see more detailed error information and I believe this is useful for other users as well. This just adds another chart that simply shows the total error count over time.~ I also wanted to be able to save the full chart data so I could reproduce the graphs later, so I added links to the downloads page for each carts exact data points. Hopefully others find this useful.

/cc @cgbystrom @heyman @mbeacom 

Screenshots of the ~new charts page and the~ download page. 

![screen shot 2017-11-21 at 11 01 59 am](https://user-images.githubusercontent.com/6731804/33091272-7c436c34-ceab-11e7-9cdd-a65faca21b17.png)
  