### PR TITLE
Allow the option to run a single Locust through the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/**
 build/
 .coverage
 .tox/
+/.cache/
+.DS_Store

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import collections
 import logging
 import random
 import socket
@@ -31,6 +32,7 @@ class LocustRunner(object):
     def __init__(self, locust_classes, options):
         self.options = options
         self.locust_classes = locust_classes
+        self.locust_classes_by_name = self.build_locust_classes_by_name(self.locust_classes)
         self.hatch_rate = options.hatch_rate
         self.num_clients = options.num_clients
         self.host = options.host
@@ -49,6 +51,18 @@ class LocustRunner(object):
                 self.stats.reset_all()
         events.hatch_complete += on_hatch_complete
 
+    @staticmethod
+    def build_locust_classes_by_name(locust_classes):
+        """
+        Returns a dictionary of the form {locust_class_name: locust_class}
+        """
+        if isinstance(locust_classes, type):
+            return {locust_classes.__name__: locust_classes}
+        elif isinstance(locust_classes, collections.Iterable):
+            return {locust.__name__: locust for locust in locust_classes}
+        else:
+            return {}
+
     @property
     def request_stats(self):
         return self.stats.entries
@@ -61,7 +75,7 @@ class LocustRunner(object):
     def user_count(self):
         return len(self.locusts)
 
-    def weight_locusts(self, amount, stop_timeout = None):
+    def weight_locusts(self, amount, stop_timeout=None):
         """
         Distributes the amount of locusts for each WebLocust-class according to it's weight
         returns a list "bucket" with the weighted locusts

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -182,7 +182,7 @@ class LocustRunner(object):
             if self.num_clients > locust_count:
                 # Kill some locusts
                 kill_count = self.num_clients - locust_count
-                self.kill_locusts(kill_count, locust_class=locust_class)
+                self.kill_locusts(kill_count)
             elif self.num_clients < locust_count:
                 # Spawn some locusts
                 if hatch_rate:

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -180,7 +180,7 @@ a:hover {
     margin-top: 20px;
     font-size: 16px;
 }
-.start input.val, .edit input.val {
+.start input.val, .edit input.val, select.val {
     border: none;
     background: #fff;
     height: 52px;
@@ -188,6 +188,11 @@ a:hover {
     font-size: 24px;
     padding-left: 10px;
 }
+
+select.val {
+    width: 338px;
+}
+
 .start button,
 .edit button {
     margin-top: 20px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -57,6 +57,13 @@
             <div class="padder">
                 <h2>Start new Locust swarm</h2>
                 <form action="/swarm" method="POST" id="swarm_form">
+                    <label for="locust_class">Locust to run</label>
+                    <select name="locust_class" id="locust_class" class="val">
+                        <option value="all" selected>All</option>
+                        {% for class in locust_class_names %}
+                            <option value="{{ class }}">{{ class }}</option>
+                        {% endfor %}
+                    </select>
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
@@ -74,6 +81,13 @@
             <div class="padder">
                 <h2>Change the locust count</h2>
                 <form action="/swarm" method="POST" id="edit_form">
+                    <label for="locust_class">Locust to run</label>
+                    <select name="locust_class" id="locust_class" class="val">
+                        <option value="all" selected>All</option>
+                        {% for class in locust_class_names %}
+                        <option value="{{ class }}">{{ class }}</option>
+                        {% endfor %}
+                    </select>
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="new_locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>

--- a/locust/web.py
+++ b/locust/web.py
@@ -59,7 +59,7 @@ def swarm():
 
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
-    locust_class = request.form["locust_class"]
+    locust_class = request.form.get("locust_class", 'all')
     if locust_class == 'all':
         locust_class = None
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -49,7 +49,8 @@ def index():
         is_distributed=is_distributed,
         user_count=runners.locust_runner.user_count,
         version=version,
-        host=host
+        host=host,
+        locust_class_names=runners.locust_runner.locust_classes_by_name.keys(),
     )
 
 @app.route('/swarm', methods=["POST"])
@@ -58,7 +59,11 @@ def swarm():
 
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
-    runners.locust_runner.start_hatching(locust_count, hatch_rate)
+    locust_class = request.form["locust_class"]
+    if locust_class == 'all':
+        locust_class = None
+
+    runners.locust_runner.start_hatching(locust_count, hatch_rate, locust_class=locust_class)
     response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
     response.headers["Content-type"] = "application/json"
     return response


### PR DESCRIPTION
I would like to be able to choose which Locust to run through the UI. This would make it very easy to support having a large corpus of tests and have the option to only run a single one when it suits the user. 

The core of this feature relies on the Locust class's `__name__` property. The `LocustRunner` holds a dict of `class.__name__` to `class` in `locust_classes_by_name` and provides a method to building that dict and a way of picking one with `filter_locusts_by_name`.

Right now this only supports running a single Locust or all of them. The web UI has a select that defaults to "All":

![image](https://user-images.githubusercontent.com/2565265/33097052-f373ee02-ced6-11e7-90cc-92c7ab5abc79.png)

And has a list of Locusts to run:

![image](https://user-images.githubusercontent.com/2565265/33097105-0dfca764-ced7-11e7-8b03-b402f19a1c67.png)

The URL `/swarm` accepts `locust_class` in the POST body but defaults it to `all`. `all` in this case will be converted to `None` when passed to the `LocustRunner`.

Let me know what you think, I'd be happy to make any changes you recommend. 
 