### PR TITLE
Allow the option to run a single Locust through the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/**
 build/
 .coverage
 .tox/
+/.cache/
+.DS_Store

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import collections
 import logging
 import random
 import socket
@@ -31,6 +32,7 @@ class LocustRunner(object):
     def __init__(self, locust_classes, options):
         self.options = options
         self.locust_classes = locust_classes
+        self.locust_classes_by_name = self.build_locust_classes_by_name(self.locust_classes)
         self.hatch_rate = options.hatch_rate
         self.num_clients = options.num_clients
         self.host = options.host
@@ -49,6 +51,27 @@ class LocustRunner(object):
                 self.stats.reset_all()
         events.hatch_complete += on_hatch_complete
 
+    @staticmethod
+    def build_locust_classes_by_name(locust_classes):
+        """
+        Returns a dictionary of the form {locust_class_name: locust_class}
+        """
+        if isinstance(locust_classes, type):
+            return {locust_classes.__name__: locust_classes}
+        elif isinstance(locust_classes, collections.Iterable):
+            return {locust.__name__: locust for locust in locust_classes}
+        else:
+            return {}
+
+    def filter_locusts_by_name(self, locust_class=None):
+        """
+        By default, get all locusts. If locust_class is supplied, return a list of
+        only a locust with that class name. If it doesn't exist, return all locusts
+        """
+        if locust_class and locust_class in self.locust_classes_by_name:
+            return [self.locust_classes_by_name[locust_class]]
+        return self.locust_classes
+
     @property
     def request_stats(self):
         return self.stats.entries
@@ -61,14 +84,16 @@ class LocustRunner(object):
     def user_count(self):
         return len(self.locusts)
 
-    def weight_locusts(self, amount, stop_timeout = None):
+    def weight_locusts(self, amount, stop_timeout=None, locust_class=None):
         """
         Distributes the amount of locusts for each WebLocust-class according to it's weight
         returns a list "bucket" with the weighted locusts
         """
+        locust_classes = self.filter_locusts_by_name(locust_class=locust_class)
+
         bucket = []
-        weight_sum = sum((locust.weight for locust in self.locust_classes if locust.task_set))
-        for locust in self.locust_classes:
+        weight_sum = sum((locust.weight for locust in locust_classes if locust.task_set))
+        for locust in locust_classes:
             if not locust.task_set:
                 warnings.warn("Notice: Found Locust class (%s) got no task_set. Skipping..." % locust.__name__)
                 continue
@@ -84,11 +109,11 @@ class LocustRunner(object):
             bucket.extend([locust for x in xrange(0, num_locusts)])
         return bucket
 
-    def spawn_locusts(self, spawn_count=None, stop_timeout=None, wait=False):
+    def spawn_locusts(self, spawn_count=None, stop_timeout=None, wait=False, locust_class=None):
         if spawn_count is None:
             spawn_count = self.num_clients
 
-        bucket = self.weight_locusts(spawn_count, stop_timeout)
+        bucket = self.weight_locusts(spawn_count, stop_timeout, locust_class=locust_class)
         spawn_count = len(bucket)
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.state = STATE_HATCHING
@@ -97,7 +122,8 @@ class LocustRunner(object):
             self.num_clients += spawn_count
 
         logger.info("Hatching and swarming %i clients at the rate %g clients/s..." % (spawn_count, self.hatch_rate))
-        occurence_count = dict([(l.__name__, 0) for l in self.locust_classes])
+        locust_classes = self.filter_locusts_by_name(locust_class=locust_class)
+        occurence_count = dict([(l.__name__, 0) for l in locust_classes])
         
         def hatch():
             sleep_time = 1.0 / self.hatch_rate
@@ -124,11 +150,11 @@ class LocustRunner(object):
             self.locusts.join()
             logger.info("All locusts dead\n")
 
-    def kill_locusts(self, kill_count):
+    def kill_locusts(self, kill_count, locust_class=None):
         """
         Kill a kill_count of weighted locusts from the Group() object in self.locusts
         """
-        bucket = self.weight_locusts(kill_count)
+        bucket = self.weight_locusts(kill_count, locust_class=locust_class)
         kill_count = len(bucket)
         self.num_clients -= kill_count
         logger.info("Killing %i locusts" % kill_count)
@@ -143,7 +169,7 @@ class LocustRunner(object):
             self.locusts.killone(g)
         events.hatch_complete.fire(user_count=self.num_clients)
 
-    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False):
+    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False, locust_class=None):
         if self.state != STATE_RUNNING and self.state != STATE_HATCHING:
             self.stats.clear_all()
             self.stats.start_time = time()
@@ -162,16 +188,16 @@ class LocustRunner(object):
                 if hatch_rate:
                     self.hatch_rate = hatch_rate
                 spawn_count = locust_count - self.num_clients
-                self.spawn_locusts(spawn_count=spawn_count)
+                self.spawn_locusts(spawn_count=spawn_count, locust_class=locust_class)
             else:
                 events.hatch_complete.fire(user_count=self.num_clients)
         else:
             if hatch_rate:
                 self.hatch_rate = hatch_rate
             if locust_count is not None:
-                self.spawn_locusts(locust_count, wait=wait)
+                self.spawn_locusts(locust_count, wait=wait, locust_class=locust_class)
             else:
-                self.spawn_locusts(wait=wait)
+                self.spawn_locusts(wait=wait, locust_class=locust_class)
 
     def stop(self):
         # if we are currently hatching locusts we need to kill the hatching greenlet first
@@ -192,6 +218,7 @@ class LocustRunner(object):
         row["nodes"].add(node_id)
         self.exceptions[key] = row
 
+
 class LocalLocustRunner(LocustRunner):
     def __init__(self, locust_classes, options):
         super(LocalLocustRunner, self).__init__(locust_classes, options)
@@ -202,9 +229,10 @@ class LocalLocustRunner(LocustRunner):
             self.log_exception("local", str(exception), formatted_tb)
         events.locust_error += on_locust_error
 
-    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False):
-        self.hatching_greenlet = gevent.spawn(lambda: super(LocalLocustRunner, self).start_hatching(locust_count, hatch_rate, wait=wait))
+    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False, locust_class=None):
+        self.hatching_greenlet = gevent.spawn(lambda: super(LocalLocustRunner, self).start_hatching(locust_count, hatch_rate, wait=wait, locust_class=locust_class))
         self.greenlet = self.hatching_greenlet
+
 
 class DistributedLocustRunner(LocustRunner):
     def __init__(self, locust_classes, options):
@@ -218,11 +246,13 @@ class DistributedLocustRunner(LocustRunner):
         """ Used to link() greenlets to in order to be compatible with gevent 1.0 """
         pass
 
+
 class SlaveNode(object):
     def __init__(self, id, state=STATE_INIT):
         self.id = id
         self.state = state
         self.user_count = 0
+
 
 class MasterLocustRunner(DistributedLocustRunner):
     def __init__(self, *args, **kwargs):
@@ -267,7 +297,7 @@ class MasterLocustRunner(DistributedLocustRunner):
     def user_count(self):
         return sum([c.user_count for c in six.itervalues(self.clients)])
     
-    def start_hatching(self, locust_count, hatch_rate):
+    def start_hatching(self, locust_count, hatch_rate, locust_class=None):
         num_slaves = len(self.clients.ready) + len(self.clients.running)
         if not num_slaves:
             logger.warning("You are running in distributed mode but have no slave servers connected. "
@@ -288,10 +318,11 @@ class MasterLocustRunner(DistributedLocustRunner):
         
         for client in six.itervalues(self.clients):
             data = {
-                "hatch_rate":slave_hatch_rate,
-                "num_clients":slave_num_clients,
-                "host":self.host,
-                "stop_timeout":None
+                "hatch_rate": slave_hatch_rate,
+                "num_clients": slave_num_clients,
+                "host": self.host,
+                "stop_timeout": None,
+                "locust_class": locust_class,
             }
 
             if remaining > 0:
@@ -349,6 +380,7 @@ class MasterLocustRunner(DistributedLocustRunner):
     def slave_count(self):
         return len(self.clients.ready) + len(self.clients.hatching) + len(self.clients.running)
 
+
 class SlaveLocustRunner(DistributedLocustRunner):
     def __init__(self, *args, **kwargs):
         super(SlaveLocustRunner, self).__init__(*args, **kwargs)
@@ -391,7 +423,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
                 self.hatch_rate = job["hatch_rate"]
                 #self.num_clients = job["num_clients"]
                 self.host = job["host"]
-                self.hatching_greenlet = gevent.spawn(lambda: self.start_hatching(locust_count=job["num_clients"], hatch_rate=job["hatch_rate"]))
+                self.hatching_greenlet = gevent.spawn(lambda: self.start_hatching(locust_count=job["num_clients"], hatch_rate=job["hatch_rate"], locust_class=job["locust_class"]))
             elif msg.type == "stop":
                 self.stop()
                 self.client.send(Message("client_stopped", None, self.client_id))

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -180,7 +180,7 @@ a:hover {
     margin-top: 20px;
     font-size: 16px;
 }
-.start input.val, .edit input.val {
+.start input.val, .edit input.val, select.val {
     border: none;
     background: #fff;
     height: 52px;
@@ -188,6 +188,11 @@ a:hover {
     font-size: 24px;
     padding-left: 10px;
 }
+
+select.val {
+    width: 338px;
+}
+
 .start button,
 .edit button {
     margin-top: 20px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -57,6 +57,13 @@
             <div class="padder">
                 <h2>Start new Locust swarm</h2>
                 <form action="/swarm" method="POST" id="swarm_form">
+                    <label for="locust_class">Locust to run</label>
+                    <select name="locust_class" id="locust_class" class="val">
+                        <option value="all" selected>All</option>
+                        {% for class in locust_class_names %}
+                            <option value="{{ class }}">{{ class }}</option>
+                        {% endfor %}
+                    </select>
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
@@ -74,6 +81,13 @@
             <div class="padder">
                 <h2>Change the locust count</h2>
                 <form action="/swarm" method="POST" id="edit_form">
+                    <label for="locust_class">Locust to run</label>
+                    <select name="locust_class" id="locust_class" class="val">
+                        <option value="all" selected>All</option>
+                        {% for class in locust_class_names %}
+                        <option value="{{ class }}">{{ class }}</option>
+                        {% endfor %}
+                    </select>
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="new_locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -10,7 +10,7 @@ from locust.core import Locust, TaskSet, task
 from locust.exception import LocustError
 from locust.main import parse_options
 from locust.rpc import Message
-from locust.runners import LocalLocustRunner, MasterLocustRunner
+from locust.runners import LocustRunner, LocalLocustRunner, MasterLocustRunner
 from locust.stats import global_stats, RequestStats
 from locust.test.testcases import LocustTestCase
 
@@ -36,6 +36,66 @@ def mocked_rpc_server():
             self.outbox.append(message.serialize())
     
     return MockedRpcServer
+
+
+class TestBaseLocustRunner(LocustTestCase):
+    locust_classes = []
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBaseLocustRunner, cls).setUpClass()
+
+        class MyTestLocust(Locust):
+            pass
+
+        class MyTestLocustTwo(Locust):
+            pass
+
+        cls.locust_classes = [MyTestLocust, MyTestLocustTwo]
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestBaseLocustRunner, cls).tearDownClass()
+        cls.locust_classes = []
+
+    def setUp(self):
+        global_stats.reset_all()
+        self._slave_report_event_handlers = [h for h in events.slave_report._handlers]
+
+        parser, _, _ = parse_options()
+        args = [
+            "--clients", "10",
+            "--hatch-rate", "10"
+        ]
+        opts, _ = parser.parse_args(args)
+        self.options = opts
+
+    def tearDown(self):
+        events.slave_report._handlers = self._slave_report_event_handlers
+
+    def test_locust_classes_by_name_single(self):
+        """ Assert that locust_classes_by_name functions with a single type """
+        runner = LocustRunner(self.locust_classes[0], self.options)
+        self.assertEqual({self.locust_classes[0].__name__: self.locust_classes[0]}, runner.locust_classes_by_name)
+
+    def test_locust_classes_by_name_iterable(self):
+        """ Assert that locust_classes_by_name functions with multiple types """
+        runner = LocustRunner(self.locust_classes, self.options)
+        self.assertEqual({self.locust_classes[0].__name__: self.locust_classes[0],
+                          self.locust_classes[1].__name__: self.locust_classes[1]},
+                         runner.locust_classes_by_name)
+
+    def test_locust_classes_by_name_not_a_type(self):
+        """ Assert that locust_classes_by_name functions with None """
+        runner = LocustRunner(None, self.options)
+        self.assertEqual({}, runner.locust_classes_by_name)
+
+    def test_filter_locusts_by_name(self):
+        """ Assert that filter_locusts_by_name functions correctly"""
+        runner = LocustRunner(self.locust_classes, self.options)
+        self.assertEqual(self.locust_classes, runner.filter_locusts_by_name(None))
+        self.assertEqual([self.locust_classes[0]], runner.filter_locusts_by_name(self.locust_classes[0].__name__))
+        self.assertEqual(self.locust_classes, runner.filter_locusts_by_name('foo'))
 
 
 class TestMasterRunner(LocustTestCase):
@@ -173,7 +233,26 @@ class TestMasterRunner(LocustTestCase):
                 }, "fake_client"))
                 self.assertEqual(30, master.stats.total.get_current_response_time_percentile(0.5))
                 self.assertEqual(3000, master.stats.total.get_current_response_time_percentile(0.95))
-    
+
+    def test_spawn_with_locust_class(self):
+        """
+        Tests that passing locust class to slaves works correctly
+        """
+        import mock
+
+        class MyTestLocust(Locust):
+            pass
+
+        with mock.patch("locust.rpc.rpc.Server", mocked_rpc_server()) as server:
+            master = MasterLocustRunner(MyTestLocust, self.options)
+            for i in range(10):
+                server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
+
+            master.start_hatching(10, 10, locust_class=MyTestLocust.__name__)
+
+            for msg in server.outbox:
+                self.assertEqual(MyTestLocust.__name__, Message.unserialize(msg).data["locust_class"])
+
     def test_spawn_zero_locusts(self):
         class MyTaskSet(TaskSet):
             @task

--- a/locust/web.py
+++ b/locust/web.py
@@ -49,7 +49,8 @@ def index():
         is_distributed=is_distributed,
         user_count=runners.locust_runner.user_count,
         version=version,
-        host=host
+        host=host,
+        locust_class_names=runners.locust_runner.locust_classes_by_name.keys(),
     )
 
 @app.route('/swarm', methods=["POST"])
@@ -58,7 +59,11 @@ def swarm():
 
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
-    runners.locust_runner.start_hatching(locust_count, hatch_rate)
+    locust_class = request.form.get("locust_class", 'all')
+    if locust_class == 'all':
+        locust_class = None
+
+    runners.locust_runner.start_hatching(locust_count, hatch_rate, locust_class=locust_class)
     response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
     response.headers["Content-type"] = "application/json"
     return response


### PR DESCRIPTION
I would like to be able to choose which Locust to run through the UI. This would make it very easy to support having a large corpus of tests and have the option to only run a single one when it suits the user. 

The core of this feature relies on the Locust class's `__name__` property. The `LocustRunner` holds a dict of `class.__name__` to `class` in `locust_classes_by_name` and provides a method to building that dict and a way of picking one with `filter_locusts_by_name`.

Right now this only supports running a single Locust or all of them. The web UI has a select that defaults to "All":

![image](https://user-images.githubusercontent.com/2565265/33097052-f373ee02-ced6-11e7-90cc-92c7ab5abc79.png)

And has a list of Locusts to run:

![image](https://user-images.githubusercontent.com/2565265/33097105-0dfca764-ced7-11e7-8b03-b402f19a1c67.png)

The URL `/swarm` accepts `locust_class` in the POST body but defaults it to `all`. `all` in this case will be converted to `None` when passed to the `LocustRunner`.

Let me know what you think, I'd be happy to make any changes you recommend. 
 