### PR TITLE
Per locust hatching

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -32,6 +32,12 @@ SLAVE_REPORT_INTERVAL = 3.0
 
 class LocustRunner(object):
     def __init__(self, locust_classes, options):
+        # handle case of single locust class
+        try:
+            iter(locust_classes)
+        except TypeError:
+            locust_classes = [locust_classes]
+
         self.options = options
         self.locust_classes_by_name = {
             locust.__name__: locust for locust in locust_classes

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -158,8 +158,7 @@ var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Ti
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
 function updateStats() {
-    $.get('/stats/requests', function (data) {
-        report = JSON.parse(data);
+    $.get('/stats/requests', function (report) {
         $("#total_rps").html(Math.round(report.total_rps*100)/100);
         //$("#fail_ratio").html(Math.round(report.fail_ratio*10000)/100);
         $("#fail_ratio").html(Math.round(report.fail_ratio*100));

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -52,10 +52,40 @@ var errors_tpl = $('#errors-template');
 var exceptions_tpl = $('#exceptions-template');
 var slaves_tpl = $('#slave-template');
 
+function buildSwarmPostData(form) {
+    var postdata = {};
+
+    $(form).find("input.locust_count, input.hatch_rate").each(
+        function (idx, input) {
+            var locust = $(input).data("locust")
+            var value_str = $(input).val();
+
+            var value;
+            var param_type;
+
+            if ($(input).hasClass("locust_count")) {
+                param_type = "locust_count";
+                value = parseInt(value_str);
+            } else {
+                param_type = "hatch_rate";
+                value = parseFloat(value_str);
+            }
+
+            postdata[locust] = postdata[locust] || {};
+            postdata[locust][param_type] = value;
+        });
+
+    return JSON.stringify(postdata);
+}
+
 $('#swarm_form').submit(function(event) {
     event.preventDefault();
-    $.post($(this).attr("action"), $(this).serialize(),
-        function(response) {
+
+    $.ajax({
+        type: "post",
+        url: $(this).attr("action"),
+        data: buildSwarmPostData(this),
+        success: function(response) {
             if (response.success) {
                 $("body").attr("class", "hatching");
                 $("#start").fadeOut();
@@ -65,20 +95,25 @@ $('#swarm_form').submit(function(event) {
                 $("a.edit_test").fadeIn();
                 $(".user_count").fadeIn();
             }
-        }
-    );
+        },
+        contentType: "application/json"
+    });
 });
 
 $('#edit_form').submit(function(event) {
     event.preventDefault();
-    $.post($(this).attr("action"), $(this).serialize(),
-        function(response) {
+    $.ajax({
+        type: "post",
+        url: $(this).attr("action"),
+        data: buildSwarmPostData(this),
+        success: function(response) {
             if (response.success) {
                 $("body").attr("class", "hatching");
                 $("#edit").fadeOut();
             }
-        }
-    );
+        },
+        contentType: "application/json"
+    });
 });
 
 var sortBy = function(field, reverse, primer){

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -183,9 +183,9 @@ a:hover {
 .start input.val, .edit input.val {
     border: none;
     background: #fff;
-    height: 52px;
-    width: 328px;
-    font-size: 24px;
+    height: 38px;
+    width: 155px;
+    font-size: 12px;
     padding-left: 10px;
 }
 .start button,

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -57,10 +57,15 @@
             <div class="padder">
                 <h2>Start new Locust swarm</h2>
                 <form action="/swarm" method="POST" id="swarm_form">
-                    <label for="locust_count">Number of users to simulate</label>
-                    <input type="text" name="locust_count" id="locust_count" class="val" /><br>
-                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
-                    <input type="text" name="hatch_rate" id="hatch_rate" class="val" /><br>
+                    {% for cls in locust_classes %}
+                        <label for="locust_count_{{cls}}">{{cls}}</label>
+                        <input type="text" class="val locust_count" placeholder="Number of users"
+                               name="locust_count__{{cls}}" id="locust_count__{{cls}}"
+                               data-locust="{{cls}}" />
+                        <input type="text" class="val hatch_rate" placeholder="Hatch rate (users/sec)"
+                               name="hatch_rate__{{cls}}" id="hatch_rate__{{cls}}"
+                               data-locust="{{cls}}" />
+                    {% endfor %}
                     <button type="submit">Start swarming</button>
                 </form>
                 <div style="clear:right;"></div>
@@ -74,10 +79,15 @@
             <div class="padder">
                 <h2>Change the locust count</h2>
                 <form action="/swarm" method="POST" id="edit_form">
-                    <label for="locust_count">Number of users to simulate</label>
-                    <input type="text" name="locust_count" id="new_locust_count" class="val" /><br>
-                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
-                    <input type="text" name="hatch_rate" id="new_hatch_rate" class="val" /><br>
+                    {% for cls in locust_classes %}
+                        <label for="locust_count_{{cls}}">{{cls}}</label>
+                        <input type="text" class="val locust_count" placeholder="Number of users"
+                               name="locust_count__{{cls}}" id="new_locust_count__{{cls}}"
+                               data-locust="{{cls}}" />
+                        <input type="text" class="val hatch_rate" placeholder="Hatch rate (users/sec)"
+                               name="hatch_rate__{{cls}}" id="new_hatch_rate__{{cls}}"
+                               data-locust="{{cls}}" />
+                    {% endfor %}
                     <button type="submit">Start swarming</button>
                 </form>
                 <div style="clear:right;"></div>

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3,6 +3,7 @@ import unittest
 import gevent
 from gevent import sleep
 from gevent.queue import Queue
+import six
 
 import mock
 from locust import events
@@ -218,7 +219,7 @@ class TestMasterRunner(LocustTestCase):
             
             num_clients = 0
             for msg in server.outbox:
-                num_clients += Message.unserialize(msg).data["num_clients"]
+                num_clients += sum(six.itervalues(Message.unserialize(msg).data["num_clients"]))
             
             self.assertEqual(7, num_clients, "Total number of locusts that would have been spawned is not 7")
     
@@ -238,7 +239,7 @@ class TestMasterRunner(LocustTestCase):
             
             num_clients = 0
             for msg in server.outbox:
-                num_clients += Message.unserialize(msg).data["num_clients"]
+                num_clients += sum(six.itervalues(Message.unserialize(msg).data["num_clients"]))
             
             self.assertEqual(2, num_clients, "Total number of locusts that would have been spawned is not 2")
     

--- a/locust/web.py
+++ b/locust/web.py
@@ -9,7 +9,7 @@ from itertools import chain
 from time import time
 
 import six
-from flask import Flask, make_response, render_template, request
+from flask import Flask, make_response, jsonify, render_template, request
 from gevent import pywsgi
 
 from locust import __version__ as version
@@ -77,16 +77,12 @@ def swarm():
         return "Invalid format for swarm parameters", 400
 
     runners.locust_runner.start_hatching(locust_count, hatch_rate)
-    response = make_response(json.dumps({'success':True, 'message': 'Swarming started'}))
-    response.headers["Content-type"] = "application/json"
-    return response
+    return jsonify({'success': True, 'message': 'Swarming started'})
 
 @app.route('/stop')
 def stop():
     runners.locust_runner.stop()
-    response = make_response(json.dumps({'success':True, 'message': 'Test stopped'}))
-    response.headers["Content-type"] = "application/json"
-    return response
+    return jsonify({'success':True, 'message': 'Test stopped'})
 
 @app.route("/stats/reset")
 def reset_stats():
@@ -153,22 +149,20 @@ def request_stats():
     report["state"] = runners.locust_runner.state
     report["user_count"] = runners.locust_runner.user_count
 
-    return json.dumps(report)
+    return jsonify(report)
 
 @app.route("/exceptions")
 def exceptions():
-    response = make_response(json.dumps({
+    return jsonify({
         'exceptions': [
             {
-                "count": row["count"], 
-                "msg": row["msg"], 
-                "traceback": row["traceback"], 
+                "count": row["count"],
+                "msg": row["msg"],
+                "traceback": row["traceback"],
                 "nodes" : ", ".join(row["nodes"])
             } for row in six.itervalues(runners.locust_runner.exceptions)
         ]
-    }))
-    response.headers["Content-type"] = "application/json"
-    return response
+    })
 
 @app.route("/exceptions/csv")
 def exceptions_csv():

--- a/locust/web.py
+++ b/locust/web.py
@@ -49,7 +49,9 @@ def index():
         is_distributed=is_distributed,
         user_count=runners.locust_runner.user_count,
         version=version,
-        host=host
+        host=host,
+        locust_classes=map(
+            lambda cls: cls.__name__, runners.locust_runner.locust_classes)
     )
 
 @app.route('/swarm', methods=["POST"])

--- a/locust/web.py
+++ b/locust/web.py
@@ -50,8 +50,8 @@ def index():
         user_count=runners.locust_runner.user_count,
         version=version,
         host=host,
-        locust_classes=map(
-            lambda cls: cls.__name__, runners.locust_runner.locust_classes)
+        locust_classes=sorted(map(
+            lambda cls: cls.__name__, runners.locust_runner.locust_classes))
     )
 
 @app.route('/swarm', methods=["POST"])


### PR DESCRIPTION
Fixes: #683 

This PR changes `LocustRunner` to use per-locust structures internally and extends the `/swarm` interface to accept an `application/json` of the following format, in addition to the old `locust_count=1234&hatch_rate=10` style for backward compatibility:

```json
{
    "FooLocust": { "locust_count": 1234, "hatch_rate": 10.0 },
    "BarLocust": { "locust_count": 123, "hatch_rate": 5.5 }
}
```

In `LocustRunner`, the following attributes have been renamed, with properties added for the old names to maintain backward compatibility with existing locustfiles that use these attributes:

 - `hatch_rate` (`float``) -> `hatch_rates` (`dict` of classes -> `float`)
 - `num_clients` (`int`) -> `num_clients_by_class` (`dict` of classes -> `int`)
 - `locust_classes` (`list`) -> `locust_classes_by_name` (`dict` of `str` -> locust class)

The following `LocustRunner` methods have been extended to accept `dict` of classes -> `float/int` for their locust count and hatch rate parameters. They'll still work with the old `int` or `float` parameters though.

 - `spawn_locusts`
 - `start_hatching`
 - `kill_locusts`