### PR TITLE
Instead of measuring response time in Locust, it's better to use elapsed time from requests.

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -114,7 +114,7 @@ class HttpSession(requests.Session):
         response = self._send_request_safe_mode(method, url, **kwargs)
         
         # record the consumed time
-        request_meta["response_time"] = int((time.time() - request_meta["start_time"]) * 1000)
+        request_meta["response_time"] = int(response.elapsed.total_seconds() * 1000)
         
     
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url


### PR DESCRIPTION
# Reason
I noticed that average response time wasn't really accurate, and it grows as the number of the users grows in some cases. I would understand if average response time is getting longer if RPS is getting higher. But, during test, RPS was almost same.

So, I tried to use elapsed time from `requests`, because it takes start time right before send the request, and end time right after it received the response.
ref: https://github.com/requests/requests/blob/master/requests/sessions.py#L623

# Difference
I've run exactly same test before and after I made this change.

### [BEFORE] Measuring response time in Locust
You can see, as the number of users grows, average response time grows. It doesn't make sense, because RPS is almost same during test. And, it grows until 6000ms when the number of users reaches 1000.

<img width="1105" alt="screen shot 2018-02-20 at 1 06 41 am" src="https://user-images.githubusercontent.com/1836721/36402216-1e77fd12-15dd-11e8-9d3c-ffab3715f430.png">

### [AFTER] Using elapsed time from `requests` as response time
You can see, number of users and average response time are not correlated, and average response time stabilized after 50 seconds at 1500ms.

<img width="1088" alt="screen shot 2018-02-20 at 1 09 02 am" src="https://user-images.githubusercontent.com/1836721/36402212-18aa6500-15dd-11e8-9619-054ff2e364db.png">

