### PR TITLE
Adding TCP Keep Alive to guarantee master-slave communication

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -17,9 +17,13 @@ class Server(BaseSocket):
     def __init__(self, host, port):
         context = zmq.Context()
         self.receiver = context.socket(zmq.PULL)
+        self.receiver.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.receiver.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
         self.receiver.bind("tcp://%s:%i" % (host, port))
         
         self.sender = context.socket(zmq.PUSH)
+        self.sender.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.sender.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
         self.sender.bind("tcp://%s:%i" % (host, port+1))
     
 


### PR DESCRIPTION
I am running distributed Locust behind a firewall that closes idle connections.

When I run tests for a long time, eventually the firewall detects that master is not sending new commands to slaves and decides to close the connection on that port.

Unfortunately, that makes me effectively lose control of the slaves and the only way to be able to gain control back is by restarting (not ideal)

I have solved this by adding TCP Keep Alive to ZMQ communications.

I recognized that it might sound a bit too specific for my case (specially if you look at the idle time value that I used). However, it is also true that Locust should do its best on preventing communication between Master and Slave from breaking. 

Please share your thoughts on this!