### PR TITLE
Remove test dependency unittest2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ locust.egg-info/**
 locustio.egg-info/**
 docs/_build/**
 mock.*.egg
-unittest2-*.egg/
 dist/**
 .idea/**
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 coverage:
-	coverage run -m unittest2 discover
+	coverage run -m unittest discover
 
 test:
 	unit2 discover

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack-python>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2"],
     test_suite="locust.test",
-    tests_require=['unittest2', 'mock'],
+    tests_require=['mock'],
     entry_points={
         'console_scripts': [
             'locust = locust.main:main',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,5 @@ deps =
     codecov
     mock
     pyzmq
-    unittest2
 commands =
-    coverage run -m unittest2 discover []
+    coverage run -m unittest discover []


### PR DESCRIPTION
As locust no longer support Python 2.6, there is no need to install unittest2. The unittest shipped with the Python 2.7+ stdlib is the same as unittest2.

Results in fewer dependencies and slightly faster installation during testing.

Python support was removed in version 0.8.