### PR TITLE
Distribute package as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE
+
 [nosetests]
 match = ^test
 nocapture = 1


### PR DESCRIPTION
Wheels are the new standard of Python distribution. Advantages of wheels includes:

- Faster installation
- Avoids arbitrary code execution for installation by avoiding `setup.py`
- Allows better caching for testing and continuous integration
- Creates `.pyc` files as part of installation to ensure they match the
  python interpreter used
- More consistent installs across platforms and machines

As locust is a pure Python package (no C files) for both Python 2 & 3, the wheel can be distributed as universal.

When you wouldd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.

The wheel includes the `LICENSE` file through the `[metadata]` attribute `license_file`.

For additional information on Python wheels, see:

https://pythonwheels.com/

For the detailed PEP, see:

https://www.python.org/dev/peps/pep-0427/