### PR TITLE
Update tox.ini so as to not respecify package dependency pyzmq

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,5 @@ passenv = CI TRAVIS TRAVIS_* TOXENV
 deps =
     codecov
     mock
-    pyzmq
 commands =
     coverage run -m unittest discover []


### PR DESCRIPTION
The dependency pyzmq is listed in `setup.py`. Tox will install all package dependencies by default. The dependencies do not need to be respecified in `tox.ini`. Remove the redundant dependency specification.