### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+cache: pip
 matrix:
   include:
     - python: 3.6


### PR DESCRIPTION
Slightly speed up builds and reduce load on PyPI servers.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache