### PR TITLE
Remove unused environment variables form tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27, py33, py34, py35, py36
 
 [testenv]
-passenv = CI TRAVIS TRAVIS_* TOXENV
 deps =
     codecov
     mock


### PR DESCRIPTION
The environment variables, `CI` `TRAVIS` `TRAVIS_*` `TOXENV`, do not influence locust nor its tests. Keep the tox configuration minimal by excluding them. Avoids any future unexpected differences between CI and local test runs.