### PR TITLE
Fix bytes/text confusion with response objects

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -342,7 +342,7 @@ class::
 
     response = self.client.get("/about")
     print("Response status code:", response.status_code)
-    print("Response content:", response.content)
+    print("Response content:", response.text)
 
 And here's an example making a POST request::
 
@@ -369,7 +369,7 @@ One can mark requests as failed, even when the response code is OK, by using the
 *catch_response* argument and a with statement::
 
     with client.get("/", catch_response=True) as response:
-        if response.content != "Success":
+        if response.content != b"Success":
             response.failure("Got wrong response")
 
 Just as one can mark requests with OK response codes as failures, one can also use **catch_response** 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -124,7 +124,7 @@ class HttpSession(requests.Session):
         if kwargs.get("stream", False):
             request_meta["content_size"] = int(response.headers.get("content-length") or 0)
         else:
-            request_meta["content_size"] = len(response.content or "")
+            request_meta["content_size"] = len(response.content or b"")
         
         if catch_response:
             response.locust_request_meta = request_meta
@@ -233,7 +233,7 @@ class ResponseContextManager(LocustResponse):
         Example::
         
             with self.client.get("/", catch_response=True) as response:
-                if response.content == "":
+                if response.content == b"":
                     response.failure("No data")
         """
         if isinstance(exc, six.string_types):

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -85,7 +85,7 @@ class TestWebUI(LocustTestCase):
         stats.global_stats.log_request("GET", "/test2", 1200, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/distribution/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-        rows = str(response.content.decode("utf-8")).split("\n")
+        rows = response.text.split("\n")
         # check that /test2 is present in stats
         row = rows[len(rows)-2].split(",")
         self.assertEqual('"GET /test2"', row[0])
@@ -100,7 +100,7 @@ class TestWebUI(LocustTestCase):
         stats.global_stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-        self.assertIn("Error1337", str(response.content))
+        self.assertIn("Error1337", response.text)
     
     def test_exceptions(self):
         try:
@@ -112,7 +112,7 @@ class TestWebUI(LocustTestCase):
         
         response = requests.get("http://127.0.0.1:%i/exceptions" % self.web_port)
         self.assertEqual(200, response.status_code)
-        self.assertIn("A cool test exception", str(response.content))
+        self.assertIn("A cool test exception", response.text)
         
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
`response.content` is a byte string. It should be compared against other byte strings. To examine the response content as text, use the `response.text` attribute.

Fixes warnings when Python is passed the `-b` argument (Issue warnings about `str(bytes_instance)`, `str(bytearray_instance)` and comparing bytes/bytearray with str.)

```
BytesWarning: str() on a bytes instance
```

For additional information on the `-b` argument, see:

https://docs.python.org/3/using/cmdline.html#cmdoption-b

For additional information on response.text, see:

http://docs.python-requests.org/en/master/api/#requests.Response.text