### PR TITLE
Remove compatibility workarounds for Python 2.6

### DIFF
--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -16,22 +16,6 @@ from locust import events
 from locust.stats import global_stats
 
 
-def safe_repr(obj, short=False):
-    """
-    Function from python 2.7's unittest.util. Used in methods that is copied 
-    from 2.7's unittest.TestCase to work in python 2.6.
-    """
-    _MAX_LENGTH = 80
-    try:
-        result = repr(obj)
-    except Exception:
-        result = object.__repr__(obj)
-    if not short or len(result) < _MAX_LENGTH:
-        return result
-    return result[:_MAX_LENGTH] + ' [truncated]...'
-
-
-
 app = Flask(__name__)
 
 @app.route("/ultra_fast")
@@ -153,42 +137,8 @@ class LocustTestCase(unittest.TestCase):
     def tearDown(self):
         for event, handlers in six.iteritems(self._event_handlers):
             event._handlers = handlers
-    
-    def assertIn(self, member, container, msg=None):
-        """
-        Just like self.assertTrue(a in b), but with a nicer default message.
-        Implemented here to work with Python 2.6
-        """
-        if member not in container:
-            standardMsg = '%s not found in %s' % (safe_repr(member),
-                                                  safe_repr(container))
-            self.fail(self._formatMessage(msg, standardMsg))
-    
-    def assertLess(self, a, b, msg=None):
-        """Just like self.assertTrue(a < b), but with a nicer default message."""
-        if not a < b:
-            standardMsg = '%s not less than %s' % (safe_repr(a), safe_repr(b))
-            self.fail(self._formatMessage(msg, standardMsg))
 
-    def assertLessEqual(self, a, b, msg=None):
-        """Just like self.assertTrue(a <= b), but with a nicer default message."""
-        if not a <= b:
-            standardMsg = '%s not less than or equal to %s' % (safe_repr(a), safe_repr(b))
-            self.fail(self._formatMessage(msg, standardMsg))
 
-    def assertGreater(self, a, b, msg=None):
-        """Just like self.assertTrue(a > b), but with a nicer default message."""
-        if not a > b:
-            standardMsg = '%s not greater than %s' % (safe_repr(a), safe_repr(b))
-            self.fail(self._formatMessage(msg, standardMsg))
-
-    def assertGreaterEqual(self, a, b, msg=None):
-        """Just like self.assertTrue(a >= b), but with a nicer default message."""
-        if not a >= b:
-            standardMsg = '%s not greater than or equal to %s' % (safe_repr(a), safe_repr(b))
-            self.fail(self._formatMessage(msg, standardMsg))
-
-            
 class WebserverTestCase(LocustTestCase):
     """
     Test case class that sets up an HTTP server which can be used within the tests


### PR DESCRIPTION
Support for Python 2.6 was removed in 33a9a1a7da509d1202bf0787c9f0ead6b4aa12f5. As it is no longer supported, can remove compatibility workarounds that were put in place to Python 2.6's outdated unittest.