### PR TITLE
drop unitt2 and use tox in 'make test' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ coverage:
 	coverage run -m unittest discover
 
 test:
-	unit2 discover
+	tox
 
 release:
 	rm dist/* && python setup.py sdist && twine upload dist/*


### PR DESCRIPTION
since #755 removed the dependency on unittest2,
this PR changes the `make test` target so it calls `tox` instead of `unit2`