### PR TITLE
expand and re-order documentation index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,26 +15,26 @@ Locust Documentation
 
 
 .. toctree ::
-    :maxdepth: 1
+    :maxdepth: 4
 
     what-is-locust
     installation
     quickstart
 
 .. toctree ::
-    :maxdepth: 2
+    :maxdepth: 4
 
     writing-a-locustfile
 
 .. toctree ::
-    :maxdepth: 1
+    :maxdepth: 4
 
     running-locust-distributed
     running-locust-without-web-ui
 
 .. toctree ::
-    :maxdepth: 1
-    
+    :maxdepth: 4
+
     retrieving-stats
     testing-other-systems
     api
@@ -42,6 +42,6 @@ Locust Documentation
     changelog
 
 .. toctree ::
-    :maxdepth: 3
-    
+    :maxdepth: 4
+
     third-party-tools

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,9 +39,13 @@ Locust Documentation
     testing-other-systems
     api
     extending-locust
-    changelog
 
 .. toctree ::
     :maxdepth: 4
 
     third-party-tools
+
+.. toctree ::
+    :maxdepth: 4
+
+    changelog


### PR DESCRIPTION
this PR enhances the docs by:

* expands the index page entries in the Documentation
* re-orders the index so changelog is after third party tools

expanding the index is a huge improvement (IMO).

![docs](https://user-images.githubusercontent.com/1113081/39084096-8c1adf26-453d-11e8-9f26-d3cd573753b7.png)
