### PR TITLE
Added user-defined wait_function to locust and TaskSet

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,20 +7,20 @@ Locust class
 ============
 
 .. autoclass:: locust.core.Locust
-	:members: min_wait, max_wait, task_set, weight
+	:members: min_wait, max_wait, wait_function, task_set, weight
 
 HttpLocust class
 ================
 
 .. autoclass:: locust.core.HttpLocust
-	:members: min_wait, max_wait, task_set, client
+	:members: min_wait, max_wait, wait_function, task_set, client
 
 
 TaskSet class
 =============
 
 .. autoclass:: locust.core.TaskSet
-	:members: locust, parent, min_wait, max_wait, client, tasks, interrupt, schedule_task
+	:members: locust, parent, min_wait, max_wait, wait_function, client, tasks, interrupt, schedule_task
 
 task decorator
 ==============

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -82,8 +82,15 @@ Another way we could declare tasks, which is usually more convenient, is to use 
         max_wait = 9000
 
 The :py:class:`Locust <locust.core.Locust>` class (as well as :py:class:`HttpLocust <locust.core.HttpLocust>`
-since it's a subclass) also allows one to specify minimum and maximum wait time—per simulated
+since it's a subclass) also allows one to specify minimum and maximum wait time in milliseconds—per simulated
 user—between the execution of tasks (*min_wait* and *max_wait*) as well as other user behaviours.
+By default the time is randomly chosen uniformly between *min_wait* and *max_wait*, but any user-defined
+time distributions can be used by setting *wait_function* to any arbitrary function. 
+For example, for an exponentially distributed wait time with average of 1 second:
+
+    class WebsiteUser(HttpLocust):
+        task_set = UserBehaviour
+        wait_function = lambda self: random.expovariate(1)*1000
 
 
 Start Locust

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -88,6 +88,8 @@ By default the time is randomly chosen uniformly between *min_wait* and *max_wai
 time distributions can be used by setting *wait_function* to any arbitrary function. 
 For example, for an exponentially distributed wait time with average of 1 second:
 
+    import random
+    
     class WebsiteUser(HttpLocust):
         task_set = UserBehaviour
         wait_function = lambda self: random.expovariate(1)*1000

--- a/examples/custom_wait_function.py
+++ b/examples/custom_wait_function.py
@@ -23,7 +23,7 @@ class WebsiteUser(HttpLocust):
     host = "http://127.0.0.1:8089"
     # Most task inter-arrival times approximate to exponential distributions
     # We will model this wait time as exponentially distributed with a mean of 1 second
-    wait_function = lambda: random.expovariate(1)*1000 # *1000 to convert to milliseconds
+    wait_function = lambda self: random.expovariate(1)*1000 # *1000 to convert to milliseconds
     task_set = UserTasks
 
 def strictExp(min_wait,max_wait,mu=1):

--- a/examples/custom_wait_function.py
+++ b/examples/custom_wait_function.py
@@ -1,0 +1,51 @@
+from locust import HttpLocust, TaskSet, task
+import random
+
+def index(l):
+    l.client.get("/")
+
+def stats(l):
+    l.client.get("/stats/requests")
+
+class UserTasks(TaskSet):
+    # one can specify tasks like this
+    tasks = [index, stats]
+    
+    # but it might be convenient to use the @task decorator
+    @task
+    def page404(self):
+        self.client.get("/does_not_exist")
+    
+class WebsiteUser(HttpLocust):
+    """
+    Locust user class that does requests to the locust web server running on localhost
+    """
+    host = "http://127.0.0.1:8089"
+    # Most task inter-arrival times approximate to exponential distributions
+    # We will model this wait time as exponentially distributed with a mean of 1 second
+    wait_function = lambda: random.expovariate(1)*1000 # *1000 to convert to milliseconds
+    task_set = UserTasks
+
+def strictExp(min_wait,max_wait,mu=1):
+    """
+    Returns an exponentially distributed time strictly between two bounds.
+    """
+    while True:
+        x = random.expovariate(mu)
+        increment = (max_wait-min_wait)/(mu*6.0)
+        result = min_wait + (x*increment)
+        if result<max_wait:
+            break
+    return result
+
+class StrictWebsiteUser(HttpLocust):
+    """
+    Locust user class that makes exponential requests but strictly between two bounds.
+    """
+    host = "http://127.0.0.1:8089"
+    wait_function = lambda self: strictExp(self.min_wait, self.max_wait)*1000
+    task_set = UserTasks
+
+
+
+

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -177,6 +177,14 @@ class TestTaskSet(LocustTestCase):
         taskset = MyTaskSet3(self.locust)
         self.assertEqual(len(taskset.tasks), 3)
     
+    def test_wait_function(self):
+        class MyTaskSet(TaskSet):
+            min_wait = 1000
+            max_wait = 2000
+            wait_function = lambda self: 1000 + (self.max_wait-self.min_wait)
+        taskset = MyTaskSet(self.locust)
+        self.assertEqual(taskset.get_wait_secs(), 2.0)
+    
     def test_sub_taskset(self):
         class MySubTaskSet(TaskSet):
             min_wait = 1


### PR DESCRIPTION
Most real-world inter-arrival times are exponentially distributed so it would be nice to be able to model that using locust. I've added the possibility for a user-defined wait_function, so *any* desired inter-arrival time can be modelled. Added some [examples](https://github.com/ps-george/locust/blob/df89db25a3444bc41a5c00b252f581156e80f405/examples/custom_wait_function.py) of exponential wait times I'd like to be able to model. If `wait_function` is not set, it will default to exactly as before, i.e. `random.randint(self.min_wait,self.max_wait)`

Change-log needs updating if merging this.