### PR TITLE
Ensure median does not have impossible values

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -294,8 +294,12 @@ class StatsEntry(object):
     def median_response_time(self):
         if not self.response_times:
             return 0
-
-        return median_from_dict(self.num_requests, self.response_times)
+        median = median_from_dict(self.num_requests, self.response_times)
+        if median > self.max_response_time:
+            median = self.max_response_time
+        elif median < self.min_response_time:
+            median = self.min_response_time
+        return median
 
     @property
     def current_rps(self):


### PR DESCRIPTION
This is a fix to limit the scope of the problem described in issue #565
Rounding still exists, but at least median won't show impossible values.