### PR TITLE
Allow running tests programmatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
       env: TOXENV=py35
     - python: 3.4
       env: TOXENV=py34
-    - python: 3.3
-      env: TOXENV=py33
     - python: 2.7
       env: TOXENV=py27
 addons:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,8 @@
 # serve to show the default value.
 
 import os
+import sys
+sys.path.insert(0, os.path.abspath('../'))
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
@@ -21,7 +23,7 @@ from locust import __version__
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.napoleon"]
 
 # autoclass options
 #autoclass_content = "both"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Locust Documentation
 
     running-locust-distributed
     running-locust-without-web-ui
+    running-locust-programmatically
 
 .. toctree ::
     :maxdepth: 4

--- a/docs/running-locust-programmatically.rst
+++ b/docs/running-locust-programmatically.rst
@@ -1,0 +1,17 @@
+.. _running-locust-programmatically:
+
+===============================
+Running Locust programmatically
+===============================
+
+All of the options for running locust from the command-line can be used
+programmatically within Python using the `locust.run_locust` function.
+
+`locust.create_options()` will set up an options object with default 
+values filled in. See below for API reference.
+
+API Reference
+=============
+
+.. automodule:: locust.main
+	:members: run_locust, create_options

--- a/examples/run_programmatically.py
+++ b/examples/run_programmatically.py
@@ -1,0 +1,28 @@
+from locust import HttpLocust, TaskSet, task, create_options, run_locust
+
+def index(l):
+    l.client.get("/")
+
+def stats(l):
+    l.client.get("/stats/requests")
+
+class UserTasks(TaskSet):
+    # one can specify tasks like this
+    tasks = [index, stats]
+    
+    # but it might be convenient to use the @task decorator
+    @task
+    def page404(self):
+        self.client.get("/does_not_exist")
+    
+class WebsiteUser(HttpLocust):
+    """
+    Locust user class that does requests to the locust web server running on localhost
+    """
+    host = "http://127.0.0.1:8089"
+    min_wait = 2000
+    max_wait = 5000
+    task_set = UserTasks
+
+options = create_options(locust_classes = [WebsiteUser])
+run_locust(options)

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,4 +1,6 @@
+__version__ = "0.8.1"
+
 from .core import HttpLocust, Locust, TaskSet, task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
-
-__version__ = "0.8.1"
+from .parser import create_options, parse_options
+from .main import run_locust

--- a/locust/main.py
+++ b/locust/main.py
@@ -343,8 +343,8 @@ def run_locust(options, arguments=[], cli_mode=False):
 
 
 def main():
-    _, settings, arguments = parse_options(sys.argv)
-    run_locust(True, settings, arguments)
+    _, options, arguments = parse_options(sys.argv)
+    run_locust(options=options, arguments=arguments, cli_mode=True)
 
 if __name__ == '__main__':
     main()

--- a/locust/main.py
+++ b/locust/main.py
@@ -191,6 +191,9 @@ def run_locust(options, arguments=[], cli_mode=False):
     # Either there is a locustfile, there are locust_classes, or both.
     locustfile = find_locustfile(options.locustfile)
 
+    if not hasattr(options,'locust_classes'):
+        options.locust_classes=[]
+
     locusts = {}
     if locustfile:
         if locustfile == "locust.py":
@@ -201,12 +204,11 @@ def run_locust(options, arguments=[], cli_mode=False):
     else:
         pass
 
-    if hasattr(options,'locust_classes'):
-        for x in options.locust_classes:
-            name = x.__name__
-            if name in locusts:
-                locust_error("Duplicate locust name {}.".format(name))
-            locusts[name] = x
+    for x in options.locust_classes:
+        name = x.__name__
+        if name in locusts:
+            locust_error("Duplicate locust name {}.".format(name))
+        locusts[name] = x
 
     if options.list_commands:
         console_logger.info("Available Locusts:")

--- a/locust/main.py
+++ b/locust/main.py
@@ -159,7 +159,7 @@ def load_tasksetfile(path):
 
 default_options = create_options()
 
-def run_locust(options, cli_mode=False, *arguments):
+def run_locust(options, arguments=[], cli_mode=False):
     """Run Locust programmatically.
 
     A default set of options can be acquired using the `create_options` function with no arguments.

--- a/locust/main.py
+++ b/locust/main.py
@@ -5,14 +5,14 @@ import signal
 import socket
 import sys
 import time
-from optparse import OptionParser
 
 import gevent
 
 import locust
 
 from . import events, runners, web
-from .core import HttpLocust, Locust
+from .parser import parse_options, create_options
+from .core import HttpLocust, Locust, TaskSet
 from .inspectlocust import get_task_ratio_dict, print_task_ratio
 from .log import console_logger, setup_logging
 from .runners import LocalLocustRunner, MasterLocustRunner, SlaveLocustRunner
@@ -22,252 +22,6 @@ from .util.time import parse_timespan
 
 _internals = [Locust, HttpLocust]
 version = locust.__version__
-
-def parse_options():
-    """
-    Handle command-line options with optparse.OptionParser.
-
-    Return list of arguments, largely for use in `parse_arguments`.
-    """
-
-    # Initialize
-    parser = OptionParser(usage="locust [options] [LocustClass [LocustClass2 ... ]]")
-
-    parser.add_option(
-        '-H', '--host',
-        dest="host",
-        default=None,
-        help="Host to load test in the following format: http://10.21.32.33"
-    )
-
-    parser.add_option(
-        '--web-host',
-        dest="web_host",
-        default="",
-        help="Host to bind the web interface to. Defaults to '' (all interfaces)"
-    )
-    
-    parser.add_option(
-        '-P', '--port', '--web-port',
-        type="int",
-        dest="port",
-        default=8089,
-        help="Port on which to run web host"
-    )
-    
-    parser.add_option(
-        '-f', '--locustfile',
-        dest='locustfile',
-        default='locustfile',
-        help="Python module file to import, e.g. '../other.py'. Default: locustfile"
-    )
-
-    # A file that contains the current request stats.
-    parser.add_option(
-        '--csv', '--csv-base-name',
-        action='store',
-        type='str',
-        dest='csvfilebase',
-        default=None,
-        help="Store current request stats to files in CSV format.",
-    )
-
-    # if locust should be run in distributed mode as master
-    parser.add_option(
-        '--master',
-        action='store_true',
-        dest='master',
-        default=False,
-        help="Set locust to run in distributed mode with this process as master"
-    )
-
-    # if locust should be run in distributed mode as slave
-    parser.add_option(
-        '--slave',
-        action='store_true',
-        dest='slave',
-        default=False,
-        help="Set locust to run in distributed mode with this process as slave"
-    )
-    
-    # master host options
-    parser.add_option(
-        '--master-host',
-        action='store',
-        type='str',
-        dest='master_host',
-        default="127.0.0.1",
-        help="Host or IP address of locust master for distributed load testing. Only used when running with --slave. Defaults to 127.0.0.1."
-    )
-    
-    parser.add_option(
-        '--master-port',
-        action='store',
-        type='int',
-        dest='master_port',
-        default=5557,
-        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --slave. Defaults to 5557. Note that slaves will also connect to the master node on this port + 1."
-    )
-
-    parser.add_option(
-        '--master-bind-host',
-        action='store',
-        type='str',
-        dest='master_bind_host',
-        default="*",
-        help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces)."
-    )
-    
-    parser.add_option(
-        '--master-bind-port',
-        action='store',
-        type='int',
-        dest='master_bind_port',
-        default=5557,
-        help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557. Note that Locust will also use this port + 1, so by default the master node will bind to 5557 and 5558."
-    )
-
-    parser.add_option(
-        '--expect-slaves',
-        action='store',
-        type='int',
-        dest='expect_slaves',
-        default=1,
-        help="How many slaves master should expect to connect before starting the test (only when --no-web used)."
-    )
-
-    # if we should print stats in the console
-    parser.add_option(
-        '--no-web',
-        action='store_true',
-        dest='no_web',
-        default=False,
-        help="Disable the web interface, and instead start running the test immediately. Requires -c and -r to be specified."
-    )
-
-    # Number of clients
-    parser.add_option(
-        '-c', '--clients',
-        action='store',
-        type='int',
-        dest='num_clients',
-        default=1,
-        help="Number of concurrent Locust users. Only used together with --no-web"
-    )
-
-    # Client hatch rate
-    parser.add_option(
-        '-r', '--hatch-rate',
-        action='store',
-        type='float',
-        dest='hatch_rate',
-        default=1,
-        help="The rate per second in which clients are spawned. Only used together with --no-web"
-    )
-    
-    # Time limit of the test run
-    parser.add_option(
-        '-t', '--run-time',
-        action='store',
-        type='str',
-        dest='run_time',
-        default=None,
-        help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --no-web"
-    )
-    
-    # log level
-    parser.add_option(
-        '--loglevel', '-L',
-        action='store',
-        type='str',
-        dest='loglevel',
-        default='INFO',
-        help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
-    )
-    
-    # log file
-    parser.add_option(
-        '--logfile',
-        action='store',
-        type='str',
-        dest='logfile',
-        default=None,
-        help="Path to log file. If not set, log will go to stdout/stderr",
-    )
-    
-    # if we should print stats in the console
-    parser.add_option(
-        '--print-stats',
-        action='store_true',
-        dest='print_stats',
-        default=False,
-        help="Print stats in the console"
-    )
-
-    # only print summary stats
-    parser.add_option(
-       '--only-summary',
-       action='store_true',
-       dest='only_summary',
-       default=False,
-       help='Only print the summary stats'
-    )
-
-    parser.add_option(
-        '--no-reset-stats',
-        action='store_true',
-        help="[DEPRECATED] Do not reset statistics once hatching has been completed. This is now the default behavior. See --reset-stats to disable",
-    )
-
-    parser.add_option(
-        '--reset-stats',
-        action='store_true',
-        dest='reset_stats',
-        default=False,
-        help="Reset statistics once hatching has been completed. Should be set on both master and slaves when running in distributed mode",
-    )
-    
-    # List locust commands found in loaded locust files/source files
-    parser.add_option(
-        '-l', '--list',
-        action='store_true',
-        dest='list_commands',
-        default=False,
-        help="Show list of possible locust classes and exit"
-    )
-    
-    # Display ratio table of all tasks
-    parser.add_option(
-        '--show-task-ratio',
-        action='store_true',
-        dest='show_task_ratio',
-        default=False,
-        help="print table of the locust classes' task execution ratio"
-    )
-    # Display ratio table of all tasks in JSON format
-    parser.add_option(
-        '--show-task-ratio-json',
-        action='store_true',
-        dest='show_task_ratio_json',
-        default=False,
-        help="print json data of the locust classes' task execution ratio"
-    )
-    
-    # Version number (optparse gives you --version but we have to do it
-    # ourselves to get -V too. sigh)
-    parser.add_option(
-        '-V', '--version',
-        action='store_true',
-        dest='show_version',
-        default=False,
-        help="show program's version number and exit"
-    )
-
-    # Finalize
-    # Return three-tuple of parser + the output from parse_args (opt obj, args)
-    opts, args = parser.parse_args()
-    return parser, opts, args
-
 
 def _is_package(path):
     """
@@ -283,6 +37,8 @@ def find_locustfile(locustfile):
     """
     Attempt to locate a locustfile, either explicitly or by searching parent dirs.
     """
+    if locustfile is None:
+        return None
     # Obtain env value
     names = [locustfile]
     # Create .py version if necessary
@@ -313,7 +69,7 @@ def find_locustfile(locustfile):
     # Implicit 'return None' if nothing was found
 
 
-def is_locust(tup):
+def is_locust(tup, ignore_prefix='_'):
     """
     Takes (name, object) tuple, returns True if it's a public Locust subclass.
     """
@@ -323,20 +79,32 @@ def is_locust(tup):
         and issubclass(item, Locust)
         and hasattr(item, "task_set")
         and getattr(item, "task_set")
-        and not name.startswith('_')
+        and not name.startswith(ignore_prefix)
     )
 
 
-def load_locustfile(path):
-    """
-    Import given locustfile path and return (docstring, callables).
+def is_taskset(tup, ignore_prefix='_'):
+    """Takes (name, object) tuple, returns True if it's a public TaskSet subclass."""
+    name, item = tup
+    return bool(
+        inspect.isclass(item)
+        and issubclass(item, TaskSet)
+        and hasattr(item, "tasks")
+        and not name.startswith(ignore_prefix)
+        and name != 'TaskSet'
+    )
 
-    Specifically, the locustfile's ``__doc__`` attribute (a string) and a
+
+def load_filterfile(path, filter_function):
+    """
+    Import given path and return (docstring, callables) of all clases that pass the test.
+
+    Specifically, the classfile's ``__doc__`` attribute (a string) and a
     dictionary of ``{'name': callable}`` containing all callables which pass
-    the "is a Locust" test.
+    the `filter_function` test.
     """
     # Get directory and locustfile name
-    directory, locustfile = os.path.split(path)
+    directory, filterfile = os.path.split(path)
     # If the directory isn't in the PYTHONPATH, add it so our import will work
     added_to_path = False
     index = None
@@ -355,7 +123,7 @@ def load_locustfile(path):
             sys.path.insert(0, directory)
             del sys.path[i + 1]
     # Perform the import (trimming off the .py)
-    imported = __import__(os.path.splitext(locustfile)[0])
+    imported = __import__(os.path.splitext(filterfile)[0])
     # Remove directory from path if we added it ourselves (just to be neat)
     if added_to_path:
         del sys.path[0]
@@ -364,48 +132,98 @@ def load_locustfile(path):
         sys.path.insert(index + 1, directory)
         del sys.path[0]
     # Return our two-tuple
-    locusts = dict(filter(is_locust, vars(imported).items()))
-    return imported.__doc__, locusts
+    classes = dict(filter(filter_function, vars(imported).items()))
+    return imported.__doc__, classes
 
-def main():
-    parser, options, arguments = parse_options()
 
+def load_locustfile(path):
+    """
+    Import given locustfile path and return (docstring, callables).
+
+    Specifically, the locustfile's ``__doc__`` attribute (a string) and a
+    dictionary of ``{'name': callable}`` containing all callables which pass
+    the "is a Locust" test.
+    """
+    return load_filterfile(path, is_locust)
+
+
+def load_tasksetfile(path):
+    """
+    Import given tasksetfile path and return (docstring, callables).
+
+    Specifically, the tasksetfile's ``__doc__`` attribute (a string) and a
+    dictionary of ``{'name': callable}`` containing all callables which pass
+    the "is a TaskSet" test (`is_taskset`).
+    """
+    return load_filterfile(path, is_taskset)
+
+default_options = create_options()
+
+def run_locust(options, cli_mode=False, *arguments):
+    """Run Locust programmatically.
+
+    A default set of options can be acquired using the `create_options` function with no arguments.
+    
+    Arguments:
+        options (OptionParser): OptionParser object for defining Locust options. Obtain
+            by either using the `create_options` function or running `parse_options` on 
+            an argv-style list using the locust command-line format. Recommended to use
+            `create_options`.
+        arguments (list)): List of Locust classes to include from those found.
+    """
     # setup logging
     setup_logging(options.loglevel, options.logfile)
     logger = logging.getLogger(__name__)
+
+    def locust_error(message, err_type=ValueError, exit_type=1):
+        logger.error(message)
+        if not cli_mode:
+            raise err_type(message)
+        sys.exit(exit_type)
     
     if options.show_version:
-        print("Locust %s" % (version,))
+        version_text = "Locust %s" % (version,)
+        print(version_text)
+        if not cli_mode:
+            return 0
         sys.exit(0)
 
+    # Either there is a locustfile, there are locust_classes, or both.
     locustfile = find_locustfile(options.locustfile)
 
-    if not locustfile:
-        logger.error("Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.")
-        sys.exit(1)
+    locusts = {}
+    if locustfile:
+        if locustfile == "locust.py":
+            locust_error("The locustfile must not be named `locust.py`. Please rename the file and try again.")
+        docstring, locusts = load_locustfile(locustfile)
+    elif not options.locust_classes:
+        locust_error("Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.")
+    else:
+        pass
 
-    if locustfile == "locust.py":
-        logger.error("The locustfile must not be named `locust.py`. Please rename the file and try again.")
-        sys.exit(1)
-
-    docstring, locusts = load_locustfile(locustfile)
+    if options.locust_classes:
+        for x in options.locust_classes:
+            name = x.__name__
+            if name in locusts:
+                locust_error("Duplicate locust name {}.".format(name))
+            locusts[name] = x
 
     if options.list_commands:
         console_logger.info("Available Locusts:")
         for name in locusts:
             console_logger.info("    " + name)
+        if not cli_mode:
+            return [name for name in locusts]
         sys.exit(0)
 
     if not locusts:
-        logger.error("No Locust class found!")
-        sys.exit(1)
+        locust_error("No Locust class found!")
 
     # make sure specified Locust exists
     if arguments:
         missing = set(arguments) - set(locusts.keys())
         if missing:
-            logger.error("Unknown Locust(s): %s\n" % (", ".join(missing)))
-            sys.exit(1)
+            locust_error("Unknown Locust(s): %s\n" % (", ".join(missing)))
         else:
             names = set(arguments) & set(locusts.keys())
             locust_classes = [locusts[n] for n in names]
@@ -420,6 +238,8 @@ def main():
         console_logger.info("\n Total task ratio")
         console_logger.info("-" * 80)
         print_task_ratio(locust_classes, total=True)
+        if not cli_mode:
+            return 0
         sys.exit(0)
     if options.show_task_ratio_json:
         from json import dumps
@@ -432,13 +252,11 @@ def main():
     
     if options.run_time:
         if not options.no_web:
-            logger.error("The --run-time argument can only be used together with --no-web")
-            sys.exit(1)
+            locust_error("The --run-time argument can only be used together with --no-web")
         try:
             options.run_time = parse_timespan(options.run_time)
         except ValueError:
-            logger.error("Valid --run-time formats are: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
-            sys.exit(1)
+            locust_error("Valid --run-time formats are: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
         def spawn_run_time_limit_greenlet():
             logger.info("Run time limit set to %s seconds" % options.run_time)
             def timelimit_stop():
@@ -473,14 +291,13 @@ def main():
                 spawn_run_time_limit_greenlet()
     elif options.slave:
         if options.run_time:
-            logger.error("--run-time should be specified on the master node, and not on slave nodes")
-            sys.exit(1)
+            locust_error("--run-time should be specified on the master node, and not on slave nodes")
         try:
             runners.locust_runner = SlaveLocustRunner(locust_classes, options)
             main_greenlet = runners.locust_runner.greenlet
         except socket.error as e:
-            logger.error("Failed to connect to the Locust master: %s", e)
-            sys.exit(-1)
+            socket_err = "Failed to connect to the Locust master: {}".format(e)
+            locust_error(socket_err, err_type=socket.error, exit_type=-1)
     
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
@@ -489,7 +306,7 @@ def main():
     if options.csvfilebase:
         gevent.spawn(stats_writer, options.csvfilebase)
 
-    
+
     def shutdown(code=0):
         """
         Shut down locust by firing quitting event, printing/writing stats and exiting
@@ -523,6 +340,11 @@ def main():
         shutdown(code=code)
     except KeyboardInterrupt as e:
         shutdown(0)
+
+
+def main():
+    _, settings, arguments = parse_options(sys.argv)
+    run_locust(True, settings, arguments)
 
 if __name__ == '__main__':
     main()

--- a/locust/main.py
+++ b/locust/main.py
@@ -201,7 +201,7 @@ def run_locust(options, arguments=[], cli_mode=False):
     else:
         pass
 
-    if options.locust_classes:
+    if hasattr(options,'locust_classes'):
         for x in options.locust_classes:
             name = x.__name__
             if name in locusts:
@@ -344,7 +344,8 @@ def run_locust(options, arguments=[], cli_mode=False):
 
 def main():
     _, options, arguments = parse_options(sys.argv)
-    run_locust(options=options, arguments=arguments, cli_mode=True)
+    args = arguments[1:]
+    run_locust(options=options, arguments=args, cli_mode=True)
 
 if __name__ == '__main__':
     main()

--- a/locust/parser.py
+++ b/locust/parser.py
@@ -1,0 +1,359 @@
+from optparse import OptionParser
+import sys
+
+def create_parser():
+    """Create parser object used for defining all options for Locust.
+    
+    Returns:
+        OptionParser: OptionParser object used in *parse_options*.
+    """
+
+    # Initialize
+    parser = OptionParser(usage="locust [options] [LocustClass [LocustClass2 ... ]]")
+
+    parser.add_option(
+        '-H', '--host',
+        dest="host",
+        default=None,
+        help="Host to load test in the following format: http://10.21.32.33"
+    )
+
+    parser.add_option(
+        '--web-host',
+        dest="web_host",
+        default="",
+        help="Host to bind the web interface to. Defaults to '' (all interfaces)"
+    )
+    
+    parser.add_option(
+        '-P', '--port', '--web-port',
+        type="int",
+        dest="port",
+        default=8089,
+        help="Port on which to run web host"
+    )
+    
+    parser.add_option(
+        '-f', '--locustfile',
+        dest='locustfile',
+        default='locustfile',
+        help="Python module file to import, e.g. '../other.py'. Default: locustfilePython module file to import, e.g. '../other.py'. Default: locustfile"
+    )
+
+    # A file that contains the current request stats.
+    parser.add_option(
+        '--csv', '--csv-base-name',
+        action='store',
+        type='str',
+        dest='csvfilebase',
+        default=None,
+        help="Store current request stats to files in CSV format.",
+    )
+
+    # if locust should be run in distributed mode as master
+    parser.add_option(
+        '--master',
+        action='store_true',
+        dest='master',
+        default=False,
+        help="Set locust to run in distributed mode with this process as master"
+    )
+
+    # if locust should be run in distributed mode as slave
+    parser.add_option(
+        '--slave',
+        action='store_true',
+        dest='slave',
+        default=False,
+        help="Set locust to run in distributed mode with this process as slave"
+    )
+    
+    # master host options
+    parser.add_option(
+        '--master-host',
+        action='store',
+        type='str',
+        dest='master_host',
+        default="127.0.0.1",
+        help="Host or IP address of locust master for distributed load testing. Only used when running with:slave. Defaults to 127.0.0.1."
+    )
+    
+    parser.add_option(
+        '--master-port',
+        action='store',
+        type='int',
+        dest='master_port',
+        default=5557,
+        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with:slave. Defaults to 5557. Note that slaves will also connect to the master node on this port + 1."
+    )
+
+    parser.add_option(
+        '--master-bind-host',
+        action='store',
+        type='str',
+        dest='master_bind_host',
+        default="*",
+        help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with:master. Defaults to * (all available interfaces)."
+    )
+    
+    parser.add_option(
+        '--master-bind-port',
+        action='store',
+        type='int',
+        dest='master_bind_port',
+        default=5557,
+        help="Port that locust master should bind to. Only used when running with:master. Defaults to 5557. Note that Locust will also use this port + 1, so by default the master node will bind to 5557 and 5558."
+    )
+
+    parser.add_option(
+        '--expect-slaves',
+        action='store',
+        type='int',
+        dest='expect_slaves',
+        default=1,
+        help="How many slaves master should expect to connect before starting the test (only when:no-web used)."
+    )
+
+    # if we should print stats in the console
+    parser.add_option(
+        '--no-web',
+        action='store_true',
+        dest='no_web',
+        default=False,
+        help="Disable the web interface, and instead start running the test immediately. Requires -c and -r to be specified."
+    )
+
+    # Number of clients
+    parser.add_option(
+        '-c', '--clients',
+        action='store',
+        type='int',
+        dest='num_clients',
+        default=1,
+        help="Number of concurrent Locust users. Only used together with:no-web"
+    )
+
+    # Client hatch rate
+    parser.add_option(
+        '-r', '--hatch-rate',
+        action='store',
+        type='float',
+        dest='hatch_rate',
+        default=1,
+        help="The rate per second in which clients are spawned. Only used together with:no-web"
+    )
+    
+    # Time limit of the test run
+    parser.add_option(
+        '-t', '--run-time',
+        action='store',
+        type='str',
+        dest='run_time',
+        default=None,
+        help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with:no-web"
+    )
+    
+    # log level
+    parser.add_option(
+        '--loglevel', '-L',
+        action='store',
+        type='str',
+        dest='loglevel',
+        default='INFO',
+        help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
+    )
+    
+    # log file
+    parser.add_option(
+        '--logfile',
+        action='store',
+        type='str',
+        dest='logfile',
+        default=None,
+        help="Path to log file. If not set, log will go to stdout/stderr",
+    )
+    
+    # if we should print stats in the console
+    parser.add_option(
+        '--print-stats',
+        action='store_true',
+        dest='print_stats',
+        default=False,
+        help="Print stats in the console"
+    )
+
+    # only print summary stats
+    parser.add_option(
+       '--only-summary',
+       action='store_true',
+       dest='only_summary',
+       default=False,
+       help="Only print the summary stats"
+    )
+
+    parser.add_option(
+        '--no-reset-stats',
+        action='store_true',
+        help="[DEPRECATED] Do not reset statistics once hatching has been completed. This is now the default behavior. See:reset-stats to disable",
+    )
+
+    parser.add_option(
+        '--reset-stats',
+        action='store_true',
+        dest='reset_stats',
+        default=False,
+        help="Reset statistics once hatching has been completed. Should be set on both master and slaves when running in distributed mode",
+    )
+    
+    # List locust commands found in loaded locust files/source files
+    parser.add_option(
+        '-l', '--list',
+        action='store_true',
+        dest='list_commands',
+        default=False,
+        help="Show list of possible locust classes and exit"
+    )
+    
+    # Display ratio table of all tasks
+    parser.add_option(
+        '--show-task-ratio',
+        action='store_true',
+        dest='show_task_ratio',
+        default=False,
+        help="print table of the locust classes' task execution ratio"
+    )
+    # Display ratio table of all tasks in JSON format
+    parser.add_option(
+        '--show-task-ratio-json',
+        action='store_true',
+        dest='show_task_ratio_json',
+        default=False,
+        help="print json data of the locust classes' task execution ratio"
+    )
+    
+    # Version number (optparse gives you:version but we have to do it
+    # ourselves to get -V too. sigh)
+    parser.add_option(
+        '-V', '--version',
+        action='store_true',
+        dest='show_version',
+        default=False,
+        help="show program's version number and exit"
+    )
+    return parser
+
+
+def create_options(
+        locustfile='locustfile',
+        host=None,
+        locust_classes=[], 
+        port=8089,
+        web_host='',
+        no_reset_stats=None,
+        reset_stats=False,
+        no_web=False,
+        run_time=None,
+        num_clients=1,
+        hatch_rate=1,
+        master=False,
+        expect_slaves=1,
+        master_bind_host='*',
+        master_bind_port=5557,
+        slave=False,
+        master_host='127.0.0.1',
+        master_port=5557,
+        csvfilebase=None,
+        print_stats=False,
+        only_summary=False,
+        show_task_ratio=False,
+        show_task_ratio_json=False,
+        logfile=None,
+        loglevel='INFO',
+        show_version=False,
+        list_commands=False):
+    """Create options objects for passing to `run_locust` when running Locust programmatically.
+    
+    Keyword Arguments:
+        locustfile (str): Python module file to import, e.g. '../other.py'. (default 'locustfile')
+        host (str): Host to load test in the following format: http://10.21.32.33 (default: None)
+        locust_classes (list): Locust class callables if not importing from file (default: [])
+        port (int): Port on which to run web host (default: 8089)
+        web_host (str): Host to bind the web interface to. (default: '' (all interfaces))
+        reset_stats (bool): Reset statistics once hatching has been completed. Should be set on both master and slaves when running in distributed mode (default: False)
+        no_web (bool): Disable the web interface, and instead start running the test immediately. Requires num_clients and hatch_rate to be specified. (default: False)
+        run_time (str): Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with:no-web (default: None)
+        num_clients (int): Number of concurrent Locust users. Only used together with no_web (default: 1)
+        hatch_rate (int): The rate per second in which clients are spawned. Only used together with:no-web (default: 1)
+        master (bool): Set locust to run in distributed mode with this process as master (default: False)
+        expect_slaves (int): How many slaves master should expect to connect before starting the test (only when no_web used). (default: 1)
+        master_bind_host (str): Interfaces (hostname, ip) that locust master should bind to. Only used when running with master. Defaults all available interfaces. (default: '*')
+        master_bind_port (int): Port that locust master should bind to. Only used when running with:master. Note that Locust will also use this port + 1, so by default the master node will bind to 5557 and 5558. (default: 5557)
+        slave (bool): Set locust to run in distributed mode with this process as slave (default: False)
+        master_host (str): Host or IP address of locust master for distributed load testing. Only used when running with slave. (default: '127.0.0.1')
+        master_port (int): The port to connect to that is used by the locust master for distributed load testing. Only used when running with:slave. Note that slaves will also connect to the master node on this port + 1. (default: 5557)
+        csvfilebase (str): Store current request stats to files in CSV format. (default: None)
+        print_stats (bool): Print stats in the console (default: False)
+        only_summary (bool): Only print the summary stats (default: False)
+        show_task_ratio (bool): print table of the locust classes' task execution ratio (default: False)
+        show_task_ratio_json (bool): print json data of the locust classes' task execution ratio (default: False)
+        logfile (str): Path to log file. If not set, log will go to stdout/stderr (default: None)
+        loglevel (str): Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. (default: 'INFO')
+        show_version (bool): show program's version number and exit (default: False)
+        list_commands (bool): Return list of possible locust classes and exit (default: False)
+    
+    """
+
+
+    opts,_ = create_parser().parse_args([])
+    opts.locustfile = locustfile
+    opts.host=host
+    opts.locust_classes=locust_classes # Locust class {name:callables, ...} if not loading from file path
+
+    # web interface
+    opts.port=port
+    opts.web_host=web_host
+
+    # No web
+    opts.no_web=no_web
+    opts.run_time=run_time
+    opts.num_clients=num_clients
+    opts.hatch_rate=hatch_rate
+
+    # Distributed settings
+    # Master settings
+    opts.master=master
+    opts.expect_slaves=expect_slaves
+    opts.master_bind_host=master_bind_host
+    opts.master_bind_port=master_bind_port
+    # Slave settings
+    opts.slave=slave
+    opts.master_host=master_host
+    opts.master_port=master_port
+
+    # Output settings
+    opts.reset_stats=reset_stats
+    opts.csvfilebase=csvfilebase
+    opts.print_stats=print_stats
+    opts.only_summary=only_summary
+    opts.show_task_ratio=show_task_ratio
+    opts.show_task_ratio_json=show_task_ratio_json
+    opts.logfile=logfile
+    opts.loglevel=loglevel
+
+    # Miscellaneous
+    opts.show_version=show_version
+    opts.list_commands=list_commands
+
+    return opts
+
+
+def parse_options(args=sys.argv):
+    """
+    Handle command-line options with optparse.OptionParser.
+
+    Return list of arguments, largely for use in `parse_arguments`.
+    """
+    parser = create_parser()
+    # Return three-tuple of parser + the output from parse_args (opt obj, args)
+    opts, args = parser.parse_args(args)
+    return parser, opts, args

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -184,7 +184,7 @@ class TestTaskSet(LocustTestCase):
             wait_function = lambda self: 1000 + (self.max_wait-self.min_wait)
         taskset = MyTaskSet(self.locust)
         self.assertEqual(taskset.get_wait_secs(), 2.0)
-    
+        
     def test_sub_taskset(self):
         class MySubTaskSet(TaskSet):
             min_wait = 1

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -6,11 +6,6 @@ from .testcases import LocustTestCase
 
 class TestTaskSet(LocustTestCase):
     def test_is_locust(self):
-        self.assertFalse(main.is_locust(("Locust", Locust)))
-        self.assertFalse(main.is_locust(("HttpLocust", HttpLocust)))
-        self.assertFalse(main.is_locust(("random_dict", {})))
-        self.assertFalse(main.is_locust(("random_list", [])))
-        
         class MyTaskSet(TaskSet):
             pass
         
@@ -19,6 +14,11 @@ class TestTaskSet(LocustTestCase):
         
         class MyLocust(Locust):
             task_set = MyTaskSet
+
+        self.assertFalse(main.is_locust(("Locust", Locust)))
+        self.assertFalse(main.is_locust(("HttpLocust", HttpLocust)))
+        self.assertFalse(main.is_locust(("random_dict", {})))
+        self.assertFalse(main.is_locust(("random_list", [])))
         
         self.assertTrue(main.is_locust(("MyHttpLocust", MyHttpLocust)))
         self.assertTrue(main.is_locust(("MyLocust", MyLocust)))
@@ -27,3 +27,43 @@ class TestTaskSet(LocustTestCase):
             pass
         
         self.assertFalse(main.is_locust(("ThriftLocust", ThriftLocust)))
+
+    def test_run_programmatically(self):
+        class MyTaskSet(TaskSet):
+            pass
+        
+        class MyHttpLocust(HttpLocust):
+            task_set = MyTaskSet
+        
+        class MyLocust(Locust):
+            task_set = MyTaskSet
+
+        default_options = main.create_options(list_commands=True, locustfile="locustfile_test.py")
+        # Test that it runs with locustfile
+        self.assertEqual(set(main.run_locust(default_options)), set(["LocustfileHttpLocust","LocustfileLocust"]))
+
+        # Test locustfile conflicts with locust_classes
+        class LocustfileLocust(Locust):
+            task_set = MyTaskSet
+        conflict_options = default_options
+        conflict_options.locust_classes=[LocustfileLocust]
+        self.assertRaises(ValueError,lambda: main.run_locust(conflict_options))
+
+        # Test that it runs with locustfile and locust options
+        locustfile_and_classes = default_options
+        locustfile_and_classes.locust_classes=[MyLocust, MyHttpLocust]
+
+        self.assertEqual(
+                set(main.run_locust(locustfile_and_classes)), 
+                set(["LocustfileHttpLocust", "LocustfileLocust", "MyLocust", "MyHttpLocust"]))
+
+        # Test that it runs without locustfile
+        no_locustfile = locustfile_and_classes
+        no_locustfile.locustfile=None
+        main.run_locust(no_locustfile)
+        self.assertEqual(set(main.run_locust(no_locustfile)), set(["MyLocust", "MyHttpLocust"]))
+
+        # Test that arguments and locust_classes work correctly
+        # main.run_locust(no_locustfile, 'MyLocust')
+
+

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -64,6 +64,7 @@ class TestTaskSet(LocustTestCase):
         self.assertEqual(set(main.run_locust(no_locustfile)), set(["MyLocust", "MyHttpLocust"]))
 
         # Test that arguments and locust_classes work correctly
-        # main.run_locust(no_locustfile, 'MyLocust')
+        self.assertEqual(set(main.run_locust(no_locustfile, arguments=["MyLocust"])),set(["MyLocust", "MyHttpLocust"]))
+
 
 

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -1,6 +1,6 @@
 import unittest
 
-from locust.main import parse_options
+from locust.parser import parse_options
 
 
 class TestParser(unittest.TestCase):

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -6,7 +6,7 @@ import traceback
 
 import gevent
 import requests
-from gevent import wsgi
+from gevent import pywsgi
 
 from locust import events, runners, stats, web
 from locust.main import parse_options
@@ -27,7 +27,7 @@ class TestWebUI(LocustTestCase):
         
         web.request_stats.clear_cache()
         
-        self._web_ui_server = wsgi.WSGIServer(('127.0.0.1', 0), web.app, log=None)
+        self._web_ui_server = pywsgi.WSGIServer(('127.0.0.1', 0), web.app, log=None)
         gevent.spawn(lambda: self._web_ui_server.serve_forever())
         gevent.sleep(0.01)
         self.web_port = self._web_ui_server.server_port

--- a/locustfile_test.py
+++ b/locustfile_test.py
@@ -1,0 +1,10 @@
+from locust import HttpLocust, Locust, TaskSet
+
+class MyTaskSet(TaskSet):
+    pass
+        
+class LocustfileHttpLocust(HttpLocust):
+    task_set = MyTaskSet
+        
+class LocustfileLocust(Locust):
+    task_set = MyTaskSet

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #222 

- Added main code into a function called `run_locust` that takes OptionParser object and additional arguments.
- Moved parser code into a file called `parser.py`
- Added tests to `test_main.py` for new changes.
- Added example file to demonstrate new functionality
- Added new docs for running locust programmatically
- Changed `from gevent import wsgi` in `test_web.py` to `from gevent import pywsgi` because it was throwing an error (also all uses of wsgi to pywsgi)
- Added Napoleon to Sphinx conf.py for sane parsing of function docstrings.
- Added functions `is_taskset` and `load_tasksetfile` since would be useful and minimal effort to add.
- Added create_options function to create default options for new mode