### PR TITLE
Added a log handler to write metrics for all the requests into a specific file.

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -145,11 +145,6 @@ class HttpSession(requests.Session):
                     url=request_meta["url"],
                     response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
-                    #start_time=request_meta["start_time"],
-                    #request_type=request_meta["method"],
-                    #name=request_meta["name"],
-                    #response_time=request_meta["response_time"],
-                    #response_length=request_meta["content_size"],
                 )
             else:
                 events.request_success.fire(

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -110,6 +110,7 @@ class HttpSession(requests.Session):
         # set up pre_request hook for attaching meta data to the request object
         request_meta["method"] = method
         request_meta["start_time"] = time.time()
+        request_meta["url"] = url
         
         response = self._send_request_safe_mode(method, url, **kwargs)
         
@@ -134,18 +135,19 @@ class HttpSession(requests.Session):
                 response.raise_for_status()
             except RequestException as e:
                 events.request_failure.fire(
+                    start_time=request_meta["start_time"],
                     request_type=request_meta["method"],
-                    #start_time=request_meta["start_time"],
-                    name=request_meta["name"], 
-                    response_time=request_meta["response_time"], 
-                    exception=e, 
+                    name=request_meta["name"],
+                    #response_time=request_meta["response_time"],
+                    #response_length=request_meta["content_size"],
+                    exception=e,
                 )
             else:
                 events.request_success.fire(
-                    request_type=request_meta["method"],
                     start_time=request_meta["start_time"],
+                    request_type=request_meta["method"],
                     name=request_meta["name"],
-                    #request_url=request_meta["name"],
+                    url=request_meta["url"],
                     response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
                 )

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -146,6 +146,7 @@ class HttpSession(requests.Session):
                 events.request_success.fire(
                     start_time=request_meta["start_time"],
                     request_type=request_meta["method"],
+                    status_code=response.status_code,
                     name=request_meta["name"],
                     url=request_meta["url"],
                     response_time=request_meta["response_time"],

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -134,7 +134,8 @@ class HttpSession(requests.Session):
                 response.raise_for_status()
             except RequestException as e:
                 events.request_failure.fire(
-                    request_type=request_meta["method"], 
+                    request_type=request_meta["method"],
+                    #start_time=request_meta["start_time"],
                     name=request_meta["name"], 
                     response_time=request_meta["response_time"], 
                     exception=e, 
@@ -142,7 +143,9 @@ class HttpSession(requests.Session):
             else:
                 events.request_success.fire(
                     request_type=request_meta["method"],
+                    start_time=request_meta["start_time"],
                     name=request_meta["name"],
+                    #request_url=request_meta["name"],
                     response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
                 )

--- a/locust/log.py
+++ b/locust/log.py
@@ -20,7 +20,7 @@ def setup_resplogging(resploglevel, resplogfile):
     if numeric_level is None:
         raise ValueError("Invalid log level: %s" % resploglevel)
 
-    resplog_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s %(message)s".format(host)
+    resplog_format = "[%(asctime)s]\t{0}/%(levelname)s/%(name)s %(message)s".format(host)
     resplog_fh = logging.FileHandler(resplogfile)
     resplog_fh.setLevel(numeric_level)
     resplog_fh.setFormatter(logging.Formatter(resplog_format))

--- a/locust/log.py
+++ b/locust/log.py
@@ -8,15 +8,31 @@ def setup_logging(loglevel, logfile):
     numeric_level = getattr(logging, loglevel.upper(), None)
     if numeric_level is None:
         raise ValueError("Invalid log level: %s" % loglevel)
-    
+
     log_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(host)
     logging.basicConfig(level=numeric_level, filename=logfile, format=log_format)
-    
+
     sys.stderr = StdErrWrapper()
     sys.stdout = StdOutWrapper()
 
+def setup_resplogging(resploglevel, resplogfile):
+    numeric_level = getattr(logging, resploglevel.upper(), None)
+    if numeric_level is None:
+        raise ValueError("Invalid log level: %s" % resploglevel)
+
+    resplog_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s %(message)s".format(host)
+    resplog_fh = logging.FileHandler(resplogfile)
+    resplog_fh.setLevel(numeric_level)
+    resplog_fh.setFormatter(logging.Formatter(resplog_format))
+    resp_logger.addHandler(resplog_fh)
+
+
+
 stdout_logger = logging.getLogger("stdout")
 stderr_logger = logging.getLogger("stderr")
+resp_logger = logging.getLogger("resplog")
+resp_logger.propagate = False
+
 
 class StdOutWrapper(object):
     """
@@ -39,6 +55,7 @@ class StdErrWrapper(object):
     def flush(self, *args, **kwargs):
         """No-op for wrapper"""
         pass
+
 
 # set up logger for the statistics tables
 console_logger = logging.getLogger("console_logger")

--- a/locust/main.py
+++ b/locust/main.py
@@ -14,7 +14,7 @@ import locust
 from . import events, runners, web
 from .core import HttpLocust, Locust
 from .inspectlocust import get_task_ratio_dict, print_task_ratio
-from .log import console_logger, setup_logging
+from .log import console_logger, setup_logging, setup_resplogging
 from .runners import LocalLocustRunner, MasterLocustRunner, SlaveLocustRunner
 from .stats import (print_error_report, print_percentile_stats, print_stats,
                     stats_printer, stats_writer, write_stat_csvs)
@@ -72,14 +72,27 @@ def parse_options():
         help="Store current request stats to files in CSV format.",
     )
 
-    # A file that contains every requests stats.
+    # A file that contains response's
+    #   timestamp, name, status code, url,
+    #   response time and content_size
+    # for every request sent
     parser.add_option(
-        '--reqfile', '--requests-file-name',
+        '--resplogfile',
         action='store',
         type='str',
-        dest='requestsfile',
+        dest='resplogfile',
         default=None,
-        help="Store every requests stats to a specific log file",
+        help="Store response's ts, req_name, http_code, url, resp_time, content_size for every request to a specific log file",
+    )
+
+    # Log level for --resplogfile 
+    parser.add_option(
+        '--resploglevel',
+        action='store',
+        type='str',
+        dest='resploglevel',
+        default='INFO',
+        help="Log level for --respfile option (default=INFO)",
     )
 
     # if locust should be run in distributed mode as master
@@ -382,6 +395,7 @@ def main():
 
     # setup logging
     setup_logging(options.loglevel, options.logfile)
+    setup_resplogging(options.resploglevel, options.resplogfile)
     logger = logging.getLogger(__name__)
     
     if options.show_version:

--- a/locust/main.py
+++ b/locust/main.py
@@ -72,6 +72,16 @@ def parse_options():
         help="Store current request stats to files in CSV format.",
     )
 
+    # A file that contains every requests stats.
+    parser.add_option(
+        '--reqfile', '--requests-file-name',
+        action='store',
+        type='str',
+        dest='requestsfile',
+        default=None,
+        help="Store every requests stats to a specific log file",
+    )
+
     # if locust should be run in distributed mode as master
     parser.add_option(
         '--master',

--- a/locust/main.py
+++ b/locust/main.py
@@ -395,9 +395,12 @@ def main():
 
     # setup logging
     setup_logging(options.loglevel, options.logfile)
-    setup_resplogging(options.resploglevel, options.resplogfile)
+
+    if options.resplogfile:
+		setup_resplogging(options.resploglevel, options.resplogfile)
+
     logger = logging.getLogger(__name__)
-    
+
     if options.show_version:
         print("Locust %s" % (version,))
         sys.exit(0)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -572,10 +572,12 @@ def on_request_success(start_time, request_type, status_code, name, url, respons
 #def on_request_failure(start_time, request_type, name, exception):
 #    global_stats.log_error(request_type, name, exception)
 #    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
-
+# TODO: remove deadcode before merge request
 #def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length, exception):
+
 def on_request_failure(start_time, request_type, name, exception, status_code, url, response_time, response_length):
-    global_stats.log_request(request_type, name, response_time, response_length)
+    #global_stats.log_request(request_type, name, response_time, response_length)
+    global_stats.log_error(request_type, name, exception)
     resp_logger.error("\t{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 def on_report_to_master(client_id, data):

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -569,13 +569,13 @@ def on_request_success(start_time, request_type, status_code, name, url, respons
     global_stats.log_request(request_type, name, response_time, response_length)
     resp_logger.info("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
-def on_request_failure(start_time, request_type, name, exception):
-    global_stats.log_error(request_type, name, exception)
-    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
+#def on_request_failure(start_time, request_type, name, exception):
+#    global_stats.log_error(request_type, name, exception)
+#    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
 
-#def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length):
-#    global_stats.log_request(request_type, name, response_time, response_length)
-#    resp_logger.error("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
+def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length):
+    global_stats.log_request(request_type, name, response_time, response_length)
+    resp_logger.error("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 def on_report_to_master(client_id, data):
     data["stats"] = global_stats.serialize_stats()

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -567,15 +567,16 @@ A global instance for holding the statistics. Should be removed eventually.
 
 def on_request_success(start_time, request_type, status_code, name, url, response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
-    resp_logger.info("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
+    resp_logger.info("\t{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 #def on_request_failure(start_time, request_type, name, exception):
 #    global_stats.log_error(request_type, name, exception)
 #    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
 
-def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length):
+#def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length, exception):
+def on_request_failure(start_time, request_type, name, exception, status_code, url, response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
-    resp_logger.error("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
+    resp_logger.error("\t{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 def on_report_to_master(client_id, data):
     data["stats"] = global_stats.serialize_stats()

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -10,8 +10,9 @@ from six.moves import xrange
 
 from . import events
 from .exception import StopLocust
-from .log import console_logger
+from .log import console_logger, resp_logger
 
+from datetime import datetime as dt
 import logging
 
 STATS_NAME_WIDTH = 60
@@ -557,18 +558,24 @@ A global instance for holding the statistics. Should be removed eventually.
 """
 
 # setup logging
-reqlogger = logging.getLogger("stdout")
-reqlogger_fh = logging.FileHandler('/var/tmp/locust-reqs.log')
-reqlogger_fh.setLevel(logging.INFO)
-reqlogger.addHandler(reqlogger_fh)
+#reqlogger = logging.getLogger("stdout")
+#resplogger = logging.getLogger("responses")
+#reqlogger_fh = logging.FileHandler('/var/tmp/locust-reqs.log')
+#reqlogger_fh.setLevel(logging.INFO)
+#reqlogger.addHandler(reqlogger_fh)
+#requests_log.addHandler(reqlogger_fh)
 
-def on_request_success(start_time, request_type, name, url, response_time, response_length):
+def on_request_success(start_time, request_type, status_code, name, url, response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
-    reqlogger.info("########### INFO : {},{},{},{},{},{}".format(start_time, request_type, name, url, response_time, response_length))
+    resp_logger.info("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 def on_request_failure(start_time, request_type, name, exception):
     global_stats.log_error(request_type, name, exception)
-    reqlogger.error("########### ERROR : {},{},{},{}".format(start_time, request_type, name, exception))
+    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
+
+#def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length):
+#    global_stats.log_request(request_type, name, response_time, response_length)
+#    resp_logger.error("{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 
 def on_report_to_master(client_id, data):
     data["stats"] = global_stats.serialize_stats()

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -12,6 +12,8 @@ from . import events
 from .exception import StopLocust
 from .log import console_logger
 
+import logging
+
 STATS_NAME_WIDTH = 60
 
 """Default interval for how frequently the CSV file is written if this option
@@ -554,8 +556,15 @@ global_stats = RequestStats()
 A global instance for holding the statistics. Should be removed eventually.
 """
 
-def on_request_success(request_type, name, response_time, response_length):
+# setup logging
+reqlogger = logging.getLogger("stdout")
+reqlogger_fh = logging.FileHandler('/var/tmp/locust-reqs.log')
+reqlogger_fh.setLevel(logging.DEBUG)
+reqlogger.addHandler(reqlogger_fh)
+
+def on_request_success(start_time, request_type, name,  response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
+    reqlogger.info("  ########### INFO : {},{},{},{},{}".format(start_time, request_type, name, response_time, response_length))
 
 def on_request_failure(request_type, name, response_time, exception):
     global_stats.log_error(request_type, name, exception)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -559,15 +559,16 @@ A global instance for holding the statistics. Should be removed eventually.
 # setup logging
 reqlogger = logging.getLogger("stdout")
 reqlogger_fh = logging.FileHandler('/var/tmp/locust-reqs.log')
-reqlogger_fh.setLevel(logging.DEBUG)
+reqlogger_fh.setLevel(logging.INFO)
 reqlogger.addHandler(reqlogger_fh)
 
-def on_request_success(start_time, request_type, name,  response_time, response_length):
+def on_request_success(start_time, request_type, name, url, response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
-    reqlogger.info("  ########### INFO : {},{},{},{},{}".format(start_time, request_type, name, response_time, response_length))
+    reqlogger.info("########### INFO : {},{},{},{},{},{}".format(start_time, request_type, name, url, response_time, response_length))
 
-def on_request_failure(request_type, name, response_time, exception):
+def on_request_failure(start_time, request_type, name, exception):
     global_stats.log_error(request_type, name, exception)
+    reqlogger.error("########### ERROR : {},{},{},{}".format(start_time, request_type, name, exception))
 
 def on_report_to_master(client_id, data):
     data["stats"] = global_stats.serialize_stats()

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -557,14 +557,6 @@ global_stats = RequestStats()
 A global instance for holding the statistics. Should be removed eventually.
 """
 
-# setup logging
-#reqlogger = logging.getLogger("stdout")
-#resplogger = logging.getLogger("responses")
-#reqlogger_fh = logging.FileHandler('/var/tmp/locust-reqs.log')
-#reqlogger_fh.setLevel(logging.INFO)
-#reqlogger.addHandler(reqlogger_fh)
-#requests_log.addHandler(reqlogger_fh)
-
 def on_request_success(start_time, request_type, status_code, name, url, response_time, response_length):
     global_stats.log_request(request_type, name, response_time, response_length)
     resp_logger.info("\t{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
@@ -573,10 +565,8 @@ def on_request_success(start_time, request_type, status_code, name, url, respons
 #    global_stats.log_error(request_type, name, exception)
 #    resp_logger.error("{}\t{}\t{}".format(name, request_type, exception))
 # TODO: remove deadcode before merge request
-#def on_request_failure(start_time, request_type, status_code, name, url, response_time, response_length, exception):
 
 def on_request_failure(start_time, request_type, name, exception, status_code, url, response_time, response_length):
-    #global_stats.log_request(request_type, name, response_time, response_length)
     global_stats.log_error(request_type, name, exception)
     resp_logger.error("\t{}\t{}\t{}\t{}\t{}\t{}".format(name, request_type, status_code, url, response_time, response_length))
 


### PR DESCRIPTION
We use Locust at mappy.fr for performance testing.

For monitoring or dataviz purposes, Locust should be able to write the usual metrics in a specific file for *every* requests sent against the target server (option --resplogfile=).

The resplog impements the following format:
`[YYYY-mm-DD HH:MM:SS,sss]   hostname/loglevel/resplog   NAME   HTTP_METHOD   HTTP_CODE   URL   RESP_TIME   CONTENT_LENGTH`

We're aware that this feature could be easily implemented within the locust files through an event listener. But we are actually working on a Locust plugin for [Yandex Tank](https://yandextank.readthedocs.io/en/latest/) which requires the feature (with the objective of having all the tech teams in the company use this solution).
Having that PR merged will make things much easier for further maintenance and distribution across the teams + it would be a nice opportunity for Yandex Tank users to discover Locust when the plugin is complete.
