### PR TITLE
Drop Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py35
     - python: 3.4
       env: TOXENV=py34
-    - python: 3.3
-      env: TOXENV=py33
     - python: 2.7
       env: TOXENV=py27
 addons:

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Open source licensed under the MIT license (see _LICENSE_ file for details).
 
 ## Supported Python Versions
 
-Locust supports Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+Locust supports Python 2.7, 3.4, 3.5, and 3.6.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ To see available options, run:
 Supported Python Versions
 -------------------------
 
-Locust supports Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+Locust supports Python 2.7, 3.4, 3.5, and 3.6.
 
 
 Installing Locust on Windows

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -6,7 +6,7 @@ import traceback
 
 import gevent
 import requests
-from gevent import wsgi
+from gevent import pywsgi
 
 from locust import events, runners, stats, web
 from locust.main import parse_options
@@ -27,7 +27,7 @@ class TestWebUI(LocustTestCase):
         
         web.request_stats.clear_cache()
         
-        self._web_ui_server = wsgi.WSGIServer(('127.0.0.1', 0), web.app, log=None)
+        self._web_ui_server = pywsgi.WSGIServer(('127.0.0.1', 0), web.app, log=None)
         gevent.spawn(lambda: self._web_ui_server.serve_forever())
         gevent.sleep(0.01)
         self.web_port = self._web_ui_server.server_port

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
* Dropping support for python 3.3 as discussed in #799 
* Fixing test_web.py, wsgi has been superceded with pywsgi