### PR TITLE
Add tasks sequence support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,16 @@ task decorator
 
 .. autofunction:: locust.core.task
 
+TaskSequence class
+==================
+
+.. autoclass:: locust.core.TaskSequence
+	:members: locust, parent, min_wait, max_wait, wait_function, client, tasks, interrupt, schedule_task
+
+seq_task decorator
+==============
+
+.. autofunction:: locust.core.seq_task
 
 HttpSession class
 =================

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -255,6 +255,31 @@ its Locust instance, and the attribute :py:attr:`parent <locust.core.TaskSet.par
 parent TaskSet (it will point to the Locust instance, in the base TaskSet).
 
 
+TaskSequence class
+==================
+
+TaskSequence class is a TaskSet but its tasks will be executed in order.
+To define this order you should do the following:
+
+.. code-block:: python
+
+    class MyTaskSequence(TaskSequence):
+        @seq_task(1)
+        def first_task(self):
+            pass
+
+        @seq_task(2)
+        def second_task(self):
+            pass
+
+        @seq_task(3)
+        @task(10)
+        def third_task(self):
+            pass
+
+In the above example, the order is defined to execute first_task, then second_task and lastly the third_task for 10 times.
+As you can see, you can compose :py:meth:`@seq_task <locust.core.seq_task>` with :py:meth:`@task <locust.core.task>` decorator, and of course you can also nest TaskSets within TaskSequences and vice versa.
+
 Setups, Teardowns, on_start, and on_stop
 ========================================
 

--- a/examples/browse_docs_sequence_test.py
+++ b/examples/browse_docs_sequence_test.py
@@ -1,0 +1,50 @@
+# This locust test script example will simulate a user
+# browsing the Locust documentation on https://docs.locust.io/
+
+import random
+from locust import HttpLocust, TaskSquence, seq_task, task
+from pyquery import PyQuery
+
+
+class BrowseDocumentationSequence(TaskSquence):
+    def on_start(self):
+        self.urls_on_current_page = self.toc_urls
+
+    # assume all users arrive at the index page
+    @seq_task(1)
+    def index_page(self):
+        r = self.client.get("/")
+        pq = PyQuery(r.content)
+        link_elements = pq(".toctree-wrapper a.internal")
+        self.toc_urls = [
+            l.attrib["href"] for l in link_elements
+        ]
+
+    @seq_task(2)
+    @task(50)
+    def load_page(self, url=None):
+        url = random.choice(self.toc_urls)
+        r = self.client.get(url)
+        pq = PyQuery(r.content)
+        link_elements = pq("a.internal")
+        self.urls_on_current_page = [
+            l.attrib["href"] for l in link_elements
+        ]
+
+    @seq_task(3)
+    @task(30)
+    def load_sub_page(self):
+        url = random.choice(self.urls_on_current_page)
+        r = self.client.get(url)
+
+
+class AwesomeUser(HttpLocust):
+    task_set = BrowseDocumentationSequence
+    host = "https://docs.locust.io/en/latest/"
+
+    # we assume someone who is browsing the Locust docs,
+    # generally has a quite long waiting time (between
+    # 20 and 600 seconds), since there's a bunch of text
+    # on each page
+    min_wait = 20 * 1000
+    max_wait = 600 * 1000

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,4 +1,4 @@
-from .core import HttpLocust, Locust, TaskSet, task
+from .core import HttpLocust, Locust, TaskSet, TaskSequence, task, seq_task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 
 __version__ = "0.8.1"

--- a/locust/test/test_task_sequence_class.py
+++ b/locust/test/test_task_sequence_class.py
@@ -1,0 +1,74 @@
+import six
+
+from locust import InterruptTaskSet, ResponseError
+from locust.core import HttpLocust, Locust, TaskSequence, events, seq_task, task
+from locust.exception import (CatchResponseError, LocustError, RescheduleTask,
+                              RescheduleTaskImmediately)
+
+from .testcases import LocustTestCase, WebserverTestCase
+
+
+class TestTaskSet(LocustTestCase):
+    def setUp(self):
+        super(TestTaskSet, self).setUp()
+
+        class User(Locust):
+            host = "127.0.0.1"
+        self.locust = User()
+
+    def test_task_sequence_with_list(self):
+        def t1(l):
+          if l._index == 1:
+            l.t1_executed = True
+
+        def t2(l):
+          if l._index == 2:
+            l.t2_executed = True
+
+        def t3(l):
+          if l._index == 0:
+            l.t3_executed = True
+          raise InterruptTaskSet(reschedule=False)
+
+        class MyTaskSequence(TaskSequence):
+            t1_executed = False
+            t2_executed = False
+            t3_executed = False
+            tasks = [t1, t2, t3]
+
+        l = MyTaskSequence(self.locust)
+        
+        self.assertRaises(RescheduleTask, lambda: l.run())
+        self.assertTrue(l.t1_executed)
+        self.assertTrue(l.t2_executed)
+        self.assertTrue(l.t3_executed)
+
+    def test_task_with_decorator(self):
+        class MyTaskSequence(TaskSequence):
+            t1_executed = 0
+            t2_executed = 0
+            t3_executed = 0
+            
+            @seq_task(1)
+            def t1(self):
+              if self._index == 1:
+                self.t1_executed += 1
+
+            @seq_task(2)
+            @task(3)
+            def t2(self):
+              if self._index == 2 or self._index == 3 or self._index == 4:
+                l.t2_executed += 1
+
+            @seq_task(3)
+            def t3(self):
+              if self._index == 0:
+                self.t3_executed += 1
+              raise InterruptTaskSet(reschedule=False)
+
+        l = MyTaskSequence(self.locust)
+
+        self.assertRaises(RescheduleTask, lambda: l.run())
+        self.assertEquals(l.t1_executed, 1)
+        self.assertEquals(l.t2_executed, 3)
+        self.assertEquals(l.t3_executed, 1)


### PR DESCRIPTION
This pr is related to [this issue](https://github.com/locustio/locust/issues/311).

As I said In slack, I know there is an easy workaround of defining only one task in the TaskSet and defining all the behavior there. The problem with the workaround is that it is a bit hacky, since you have to do `self.wait()` whenever it's needed instead of letting the framework handle it.

# If accepted this pr will
Introduce a new class: `TaskSequence` which accepts a new decorator @seq_task(int) to define the order of the tasks.

For example:
```python
class BrowseDocumentationSequence(TaskSquence):
    def on_start(self):
        self.urls_on_current_page = self.toc_urls

    # assume all users arrive at the index page
    @seq_task(1)
    def index_page(self):
        r = self.client.get("/")
        pq = PyQuery(r.content)
        link_elements = pq(".toctree-wrapper a.internal")
        self.toc_urls = [
            l.attrib["href"] for l in link_elements
        ]

    @seq_task(2)
    @task(50)
    def load_page(self, url=None):
        url = random.choice(self.toc_urls)
        r = self.client.get(url)
        pq = PyQuery(r.content)
        link_elements = pq("a.internal")
        self.urls_on_current_page = [
            l.attrib["href"] for l in link_elements
        ]

    @seq_task(3)
    @task(30)
    def load_sub_page(self):
        url = random.choice(self.urls_on_current_page)
        r = self.client.get(url)
```

In the example above, index_page/1 will be executed first, then load_page/1 fifty times, and then load_sub_page/1 thirty times.

`@seq_task(int)` doesn't have a default parameter because I found that if I set the same order value to every task, the final order ends up being kind of random.