### PR TITLE
response time doesn't need to be cast to int, as this is implicit in …

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -114,7 +114,7 @@ class HttpSession(requests.Session):
         response = self._send_request_safe_mode(method, url, **kwargs)
         
         # record the consumed time
-        request_meta["response_time"] = int((time.time() - request_meta["start_time"]) * 1000)
+        request_meta["response_time"] = (time.time() - request_meta["start_time"]) * 1000
         
     
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url


### PR DESCRIPTION
response time doesn't need to be cast to int, as this is implicit in stats.py:263. It also allows for sub-millisecond response time in case someone implements their own event handlers and metric collection (influxdb for example).