### PR TITLE
Official Docker image and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TOXENV=py34
     - python: 2.7
       env: TOXENV=py27
+    - stage: Verify Docker image builds
+      script: docker build -t locustio/locust .
 addons:
   apt:
     packages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+
+RUN pip install locustio pyzmq
+
+ADD docker_start.sh /usr/bin/docker_start
+RUN chmod 755 /usr/bin/docker_start
+
+EXPOSE 8089 5557 5558
+
+CMD ["docker_start"]

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [ -z "${TARGET_URL}" ]; then
+  echo "ERROR: TARGET_URL not configured" >&2
+  exit 1
+fi
+
+LOCUST_MODE="${LOCUST_MODE:=standalone}"
+LOCUST_OPTS="-f ${LOCUSTFILE_PATH:-/locustfile.py} -H ${TARGET_URL}"
+
+if [ "${LOCUST_MODE}" = "master" ]; then
+    LOCUST_OPTS="${LOCUST_OPTS} --master"
+elif [ "${LOCUST_MODE}" = "slave" ]; then
+    if [ -z "${LOCUST_MASTER_HOST}" ]; then
+        echo "ERROR: MASTER_HOST is empty. Slave mode requires a master" >&2
+        exit 1
+    fi
+
+    LOCUST_OPTS="${LOCUST_OPTS} --slave --master-host=${LOCUST_MASTER_HOST} --master-port=${LOCUST_MASTER_PORT:-5557}"
+fi
+
+echo "Starting Locust..."
+echo "$ locust ${LOCUST_OPTS}"
+
+locust ${LOCUST_OPTS}

--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -81,6 +81,12 @@ Used when starting the master node with ``--no-web``. The master node will then 
 nodes has connected before the test is started.
 
 
+Running distributed with Docker
+=============================================
+
+See :ref:`running-locust-docker`
+
+
 Running Locust distributed without the web UI
 =============================================
 

--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -41,17 +41,3 @@ ADD locustfile.py locustfile.py
 You'll need to push the built image to a Docker repository such as Dockerhub, AWS ECR, or GCR in order for
 distributed infrastructure to be able to pull the image. See your chosen repository's documentation on how
 to authenticate with the repository to pull the image.
-
-
-Running in Docker Compose
----------------------------------------------
-
-While developing your locustfile it can be helpful to run it locally. Here's an example of a basic Docker Compose file showing Locust running distributed:
-
-.. literalinclude:: ../examples/docker-compose/docker-compose.yml
-
-When running in Docker Compose you'll probably want the locust containers to be placed in the same Docker network as your application. If you already have a ``docker-compose.yml`` for your application you could copy the example compose file into the same directory named ``docker-compose.locust.yml`` and then start your stack with: 
-
-``docker-compose -f docker-compose.yml -f docker-compose.locust.yml up``
-
-This will ensure that your application and the locust containers are placed in the same network and can easily communicate.

--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -1,0 +1,57 @@
+.. _running-locust-docker:
+
+=================================
+Running Locust with Docker
+=================================
+
+To keep things simple we provide a single Docker image that can run standalone, as a master, or as a slave. 
+
+
+Environment Variables
+---------------------------------------------
+
+- ``LOCUST_MODE``
+
+One of 'standalone', 'master', or 'slave'. Defaults to 'standalone'.
+
+- ``LOCUSTFILE_PATH``
+
+The path inside the container to the locustfile. Defaults to '/locustfile.py`
+
+- ``LOCUST_MASTER_HOST``
+
+The hostname of the master.
+
+- ``LOCUST_MASTER_PORT``
+
+The port used to communicate with the master. Defaults to 5557.
+
+
+Add your tests
+---------------------------------------------
+
+The easiest way to get your tests running is to build an image with your test file built in. Once you've 
+written your locustfile you can bake it into a Docker image with a simple ``Dockerfile``:
+
+```
+FROM locustio/locust
+ADD locustfile.py locustfile.py
+```
+
+You'll need to push the built image to a Docker repository such as Dockerhub, AWS ECR, or GCR in order for
+distributed infrastructure to be able to pull the image. See your chosen repository's documentation on how
+to authenticate with the repository to pull the image.
+
+
+Running in Docker Compose
+---------------------------------------------
+
+While developing your locustfile it can be helpful to run it locally. Here's an example of a basic Docker Compose file showing Locust running distributed:
+
+.. literalinclude:: ../examples/docker-compose/docker-compose.yml
+
+When running in Docker Compose you'll probably want the locust containers to be placed in the same Docker network as your application. If you already have a ``docker-compose.yml`` for your application you could copy the example compose file into the same directory named ``docker-compose.locust.yml`` and then start your stack with: 
+
+``docker-compose -f docker-compose.yml -f docker-compose.locust.yml up``
+
+This will ensure that your application and the locust containers are placed in the same network and can easily communicate.

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.4"
+
+x-common: &common
+  image: locustio/locust
+  environment: &common-env
+    TARGET_URL: http://locust-master:8089
+    LOCUSTFILE_PATH: /tests/basic.py
+  volumes:
+    - ../:/tests
+
+services:
+  locust-master:
+    <<: *common
+    ports:
+      - 8089:8089
+    environment:
+      <<: *common-env
+      LOCUST_MODE: master
+  
+  locust-slave:
+    <<: *common
+    environment:
+      <<: *common-env
+      LOCUST_MODE: slave
+      LOCUST_MASTER_HOST: locust-master


### PR DESCRIPTION
For #849 :)

Adds a basic `Dockerfile` that starts from `python:3.6` and a includes custom startup script that allows you to start in any mode.

Includes a first attempt at documentation.

I added a Travis stage to build the image but for releasing I think the better approach is for someone to create a DockerHub account for locustio and set up an [automated build](https://docs.docker.com/docker-hub/builds/) for the repository. I believe they do security scanning on the resulting image as well.

Let me know if there's any docs changes, extra features, etc you'd like to see or if I can help with the DockerHub setup. I'm hanging around the Slack server as @JDiPierro as well :D