### PR TITLE
Specify seconds for the `timeout` parameter

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -90,7 +90,7 @@ class HttpSession(requests.Session):
         :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
         :param files: (optional) Dictionary of ``'filename': file-like-objects`` for multipart encoding upload.
         :param auth: (optional) Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth.
-        :param timeout: (optional) How long to wait for the server to send data before giving up, as a float, 
+        :param timeout: (optional) How long in seconds to wait for the server to send data before giving up, as a float, 
             or a (`connect timeout, read timeout <user/advanced.html#timeouts>`_) tuple.
         :type timeout: float or tuple
         :param allow_redirects: (optional) Set to True by default.


### PR DESCRIPTION
Tiny doc change - The Requests module's docstrings mention that `timeout` should be in seconds, but it's unclear here.