### PR TITLE
Separate release into build and release steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ coverage:
 test:
 	tox
 
-release:
-	rm dist/* && python setup.py sdist && twine upload dist/*
+build:
+	rm -f dist/* && python setup.py sdist
+
+release: build
+	twine upload dist/*
 
 build_docs:
 	sphinx-build -b html docs/ docs/_build/


### PR DESCRIPTION
This allows developers to build the project without publishing it to pypi.

Also add the -f tag to the cleanup bit so it doesn't bail when `dist/` is missing.