### PR TITLE
Fix deprecation warnings

### DIFF
--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -6,11 +6,11 @@ class Message(object):
         self.type = message_type
         self.data = data
         self.node_id = node_id
-    
+
     def serialize(self):
         return msgpack.dumps((self.type, self.data, self.node_id))
-    
+
     @classmethod
     def unserialize(cls, data):
-        msg = cls(*msgpack.loads(data, encoding='utf-8'))
+        msg = cls(*msgpack.loads(data, raw=False))
         return msg

--- a/locust/test/test_task_sequence_class.py
+++ b/locust/test/test_task_sequence_class.py
@@ -37,7 +37,7 @@ class TestTaskSet(LocustTestCase):
             tasks = [t1, t2, t3]
 
         l = MyTaskSequence(self.locust)
-        
+
         self.assertRaises(RescheduleTask, lambda: l.run())
         self.assertTrue(l.t1_executed)
         self.assertTrue(l.t2_executed)
@@ -48,7 +48,7 @@ class TestTaskSet(LocustTestCase):
             t1_executed = 0
             t2_executed = 0
             t3_executed = 0
-            
+
             @seq_task(1)
             def t1(self):
               if self._index == 1:
@@ -69,6 +69,6 @@ class TestTaskSet(LocustTestCase):
         l = MyTaskSequence(self.locust)
 
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEquals(l.t1_executed, 1)
-        self.assertEquals(l.t2_executed, 3)
-        self.assertEquals(l.t3_executed, 1)
+        self.assertEqual(l.t1_executed, 1)
+        self.assertEqual(l.t2_executed, 3)
+        self.assertEqual(l.t3_executed, 1)


### PR DESCRIPTION
this PR fixes 2 deprecation warnings:

* `/locust/rpc/protocol.py:15: PendingDeprecationWarning: encoding is deprecated, Use raw=False instead.`

* `/locust/test/test_task_sequence_class.py:72: DeprecationWarning: Please use assertEqual instead.`