### PR TITLE
update Makefile so build also creates a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	tox
 
 build:
-	rm -f dist/* && python setup.py sdist
+	rm -f dist/* && python setup.py sdist bdist_wheel
 
 release: build
 	twine upload dist/*


### PR DESCRIPTION
This PR updates the `Makefile` so `make build` command will also create a wheel for distribution.

see: https://pythonwheels.com/