### PR TITLE
Fix Sphinx build warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ TaskSequence class
 	:members: locust, parent, min_wait, max_wait, wait_function, client, tasks, interrupt, schedule_task
 
 seq_task decorator
-==============
+==================
 
 .. autofunction:: locust.core.seq_task
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,12 +1,12 @@
-##########
+####################
 Changelog Highlights
-##########
+####################
 
 For full details of the Locust changelog, please see https://github.com/locustio/locust/CHANGELOG.md
 
 
 0.9.0
-====
+=====
 
 * Added detailed changelog (https://github.com/locustio/locust/CHANGELOG.md)
 * Numerous bugfixes (see detailed changelog)


### PR DESCRIPTION
WARNING: Title underline too short.
WARNING: Title overline too short.