### PR TITLE
Fixed #903 to allow requests/sec UI column to display.

### DIFF
--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -143,7 +143,7 @@ a:hover {
 .stopped .boxes .box_stop {display: none;}
 
 .container {
-    max-width: 1200px;
+    max-width: 1800px;
     min-width: 1000px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
Fixed #903 to allow requests/sec UI column to display. Currently styling seems to allow min browser width of 1125px+ without clipping column now.