### PR TITLE
Include LICENSE in the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 recursive-include locust/static *
 recursive-include locust/templates *


### PR DESCRIPTION
The locustio sdist doesn't actually include the LICENSE:
```
$ curl https://files.pythonhosted.org/packages/e6/88/2d56405c715df8c4c94850857c581007d39fe50dfe9dbcac91e378a8f24f/locustio-0.9.0.tar.gz -L | tar tz | grep LICENSE
$
```

This fixes #788.