### PR TITLE
Add heartbeat to detect down slaves

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = locust
+concurrency = gevent
 
 [report]
 exclude_lines =

--- a/locust/main.py
+++ b/locust/main.py
@@ -128,6 +128,20 @@ def parse_options():
     )
 
     parser.add_option(
+        '--heartbeat-liveness',
+        action='store',
+        type='int',
+        help="set number of seconds before failed heartbeat from slave"
+    )
+
+    parser.add_option(
+        '--heartbeat-interval',
+        action='store',
+        type='int',
+        help="set number of seconds delay between slave heartbeats to master"
+    )
+
+    parser.add_option(
         '--expect-slaves',
         action='store',
         type='int',

--- a/locust/main.py
+++ b/locust/main.py
@@ -131,6 +131,7 @@ def parse_options():
         '--heartbeat-liveness',
         action='store',
         type='int',
+        default=3,
         help="set number of seconds before failed heartbeat from slave"
     )
 
@@ -138,6 +139,7 @@ def parse_options():
         '--heartbeat-interval',
         action='store',
         type='int',
+        default=1,
         help="set number of seconds delay between slave heartbeats to master"
     )
 

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -20,13 +20,10 @@ class BaseSocket(object):
         return msg
 
     def recv_from_client(self):
-        try:
-            data = self.socket.recv_multipart()
-            addr = data[0]
-            msg = Message.unserialize(data[1])
-            return addr, msg
-        except Exception:
-            raise
+        data = self.socket.recv_multipart()
+        addr = data[0]
+        msg = Message.unserialize(data[1])
+        return addr, msg
 
 class Server(BaseSocket):
     def __init__(self, host, port):

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -4,30 +4,39 @@ from .protocol import Message
 
 
 class BaseSocket(object):
+    def __init__(self, sock_type):
+        context = zmq.Context()
+        self.socket = context.socket(sock_type)
 
     def send(self, msg):
-        self.sender.send(msg.serialize())
+        self.socket.send(msg.serialize())
     
-    def recv(self):
-        data = self.receiver.recv()
-        return Message.unserialize(data)
+    def send_multipart(self, client_id, msg):
+        print 'sending %s to %s' % (msg, client_id)
+        self.socket.send_multipart([client_id, msg.serialize()])
 
+    def recv(self):
+        data = self.socket.recv()
+        msg = Message.unserialize(data)
+        return msg
+
+    def recv_multipart(self):
+        try:
+            data = self.socket.recv_multipart()
+            addr = data[0]
+            msg = Message.unserialize(data[1])
+            return addr, msg
+        except Exception:
+            raise
 
 class Server(BaseSocket):
     def __init__(self, host, port):
-        context = zmq.Context()
-        self.receiver = context.socket(zmq.PULL)
-        self.receiver.bind("tcp://%s:%i" % (host, port))
-        
-        self.sender = context.socket(zmq.PUSH)
-        self.sender.bind("tcp://%s:%i" % (host, port+1))
-    
+        BaseSocket.__init__(self, zmq.ROUTER)
+        self.socket.bind("tcp://%s:%i" % (host, port))
 
 class Client(BaseSocket):
-    def __init__(self, host, port):
-        context = zmq.Context()
-        self.receiver = context.socket(zmq.PULL)
-        self.receiver.connect("tcp://%s:%i" % (host, port+1))
+    def __init__(self, host, port, identity):
+        BaseSocket.__init__(self, zmq.DEALER)
+        self.socket.setsockopt(zmq.IDENTITY, identity)
+        self.socket.connect("tcp://%s:%i" % (host, port))
         
-        self.sender = context.socket(zmq.PUSH)
-        self.sender.connect("tcp://%s:%i" % (host, port))

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -12,7 +12,7 @@ class BaseSocket(object):
         self.socket.send(msg.serialize())
 
     def send_to_client(self, msg):
-        self.socket.send_multipart([msg.node_id, msg.serialize()])
+        self.socket.send_multipart([msg.node_id.encode(), msg.serialize()])
 
     def recv(self):
         data = self.socket.recv()
@@ -33,6 +33,6 @@ class Server(BaseSocket):
 class Client(BaseSocket):
     def __init__(self, host, port, identity):
         BaseSocket.__init__(self, zmq.DEALER)
-        self.socket.setsockopt(zmq.IDENTITY, identity)
+        self.socket.setsockopt(zmq.IDENTITY, identity.encode())
         self.socket.connect("tcp://%s:%i" % (host, port))
         

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -10,17 +10,16 @@ class BaseSocket(object):
 
     def send(self, msg):
         self.socket.send(msg.serialize())
-    
-    def send_multipart(self, client_id, msg):
-        print 'sending %s to %s' % (msg, client_id)
-        self.socket.send_multipart([client_id, msg.serialize()])
+
+    def send_to_client(self, msg):
+        self.socket.send_multipart([msg.node_id, msg.serialize()])
 
     def recv(self):
         data = self.socket.recv()
         msg = Message.unserialize(data)
         return msg
 
-    def recv_multipart(self):
+    def recv_from_client(self):
         try:
             data = self.socket.recv_multipart()
             addr = data[0]

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -324,7 +324,7 @@ class MasterLocustRunner(DistributedLocustRunner):
     def heartbeat_worker(self):
         while True:
             gevent.sleep(HEARTBEAT_INTERVAL)
-            for client in six.viewvalues(self.clients):
+            for client in self.clients.all:
                 if client.heartbeat < 0 and client.state != STATE_MISSING:
                     logger.warning('Slave %s failed to send heartbeat, setting state to missing.' % str(client.id))
                     client.state = STATE_MISSING

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -326,7 +326,7 @@ class MasterLocustRunner(DistributedLocustRunner):
             gevent.sleep(HEARTBEAT_INTERVAL)
             for client in self.clients.all:
                 if client.heartbeat < 0 and client.state != STATE_MISSING:
-                    logger.warning('Slave %s failed to send heartbeat, setting state to missing.' % str(client.id))
+                    logger.info('Slave %s failed to send heartbeat, setting state to missing.' % str(client.id))
                     client.state = STATE_MISSING
                 else:
                     client.heartbeat -= 1

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -276,7 +276,7 @@ class MasterLocustRunner(DistributedLocustRunner):
         return sum([c.user_count for c in six.itervalues(self.clients)])
     
     def start_hatching(self, locust_count, hatch_rate):
-        num_slaves = len(self.clients.ready) + len(self.clients.running)
+        num_slaves = len(self.clients.ready) + len(self.clients.running) + len(self.clients.hatching)
         if not num_slaves:
             logger.warning("You are running in distributed mode but have no slave servers connected. "
                            "Please connect slaves prior to swarming.")
@@ -294,7 +294,7 @@ class MasterLocustRunner(DistributedLocustRunner):
             self.exceptions = {}
             events.master_start_hatching.fire()
         
-        for client in (self.clients.ready + self.clients.running):
+        for client in (self.clients.ready + self.clients.running + self.clients.hatching):
             data = {
                 "hatch_rate":slave_hatch_rate,
                 "num_clients":slave_num_clients,

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -302,24 +302,24 @@ class MasterLocustRunner(DistributedLocustRunner):
                 data["num_clients"] += 1
                 remaining -= 1
 
-            self.server.send_multipart(client.id, Message("hatch", data, None))
+            self.server.send_to_client(Message("hatch", data, client.id))
         
         self.stats.start_time = time()
         self.state = STATE_HATCHING
 
     def stop(self):
         for client in self.clients.all:
-            self.server.send_multipart(client.id, Message("stop", None, None))
+            self.server.send_to_client(Message("stop", None, client.id))
         events.master_stop_hatching.fire()
     
     def quit(self):
         for client in self.clients.all:
-            self.server.send_multipart(client.id, Message("quit", None, None))
+            self.server.send_to_client(Message("quit", None, client.id))
         self.greenlet.kill(block=True)
     
     def client_listener(self):
         while True:
-            client_id, msg = self.server.recv_multipart()
+            client_id, msg = self.server.recv_from_client()
             msg.node_id = client_id
             if msg.type == "client_ready":
                 id = msg.node_id

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -215,6 +215,7 @@ class DistributedLocustRunner(LocustRunner):
         self.master_port = options.master_port
         self.master_bind_host = options.master_bind_host
         self.master_bind_port = options.master_bind_port
+        self.heartbeat_interval = options.heartbeat_interval
     
     def noop(self, *args, **kwargs):
         """ Used to link() greenlets to in order to be compatible with gevent 1.0 """
@@ -323,7 +324,7 @@ class MasterLocustRunner(DistributedLocustRunner):
     
     def heartbeat_worker(self):
         while True:
-            gevent.sleep(HEARTBEAT_INTERVAL)
+            gevent.sleep(self.heartbeat_interval)
             for client in self.clients.all:
                 if client.heartbeat < 0 and client.state != STATE_MISSING:
                     logger.info('Slave %s failed to send heartbeat, setting state to missing.' % str(client.id))

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -225,8 +225,8 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(5, len(server.outbox))
             
             num_clients = 0
-            for msg in server.outbox:
-                num_clients += Message.unserialize(msg[1]).data["num_clients"]
+            for _, msg in server.outbox:
+                num_clients += Message.unserialize(msg).data["num_clients"]
             
             self.assertEqual(7, num_clients, "Total number of locusts that would have been spawned is not 7")
     
@@ -245,8 +245,8 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(5, len(server.outbox))
             
             num_clients = 0
-            for msg in server.outbox:
-                num_clients += Message.unserialize(msg[1]).data["num_clients"]
+            for _, msg in server.outbox:
+                num_clients += Message.unserialize(msg).data["num_clients"]
             
             self.assertEqual(2, num_clients, "Total number of locusts that would have been spawned is not 2")
     

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -110,8 +110,6 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(700, s.median_response_time)
 
     def test_master_marks_downed_slaves_as_missing(self):
-        import mock
-
         class MyTestLocust(Locust):
             pass
 
@@ -203,8 +201,6 @@ class TestMasterRunner(LocustTestCase):
     
     def test_sends_hatch_data_to_ready_running_hatching_slaves(self):
         '''Sends hatch job to running, ready, or hatching slaves'''
-        import mock
-
         class MyTestLocust(Locust):
             pass
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -8,7 +8,6 @@ import mock
 from locust import events
 from locust.core import Locust, TaskSet, task
 from locust.exception import LocustError
-from locust.main import parse_options
 from locust.rpc import Message
 from locust.runners import LocalLocustRunner, MasterLocustRunner
 from locust.stats import global_stats, RequestStats
@@ -45,19 +44,22 @@ def mocked_rpc_server():
 
     return MockedRpcServer
 
+class mocked_options(object):
+    def __init__(self):
+        self.hatch_rate = 5
+        self.num_clients = 5
+        self.host = '/'
+        self.master_host = 'localhost'
+        self.master_port = 5557
+        self.master_bind_host = '*'
+        self.master_bind_port = 5557
 
 class TestMasterRunner(LocustTestCase):
     def setUp(self):
         global_stats.reset_all()
         self._slave_report_event_handlers = [h for h in events.slave_report._handlers]
+        self.options = mocked_options()
 
-        parser, _, _ = parse_options()
-        args = [
-            "--clients", "10",
-            "--hatch-rate", "10"
-        ]
-        opts, _ = parser.parse_args(args)
-        self.options = opts
         
     def tearDown(self):
         events.slave_report._handlers = self._slave_report_event_handlers

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -52,6 +52,7 @@ class mocked_options(object):
         self.master_port = 5557
         self.master_bind_host = '*'
         self.master_bind_port = 5557
+        self.heartbeat_liveness = 3
         self.heartbeat_interval = 0.01
 
     def reset_stats(self):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -35,6 +35,14 @@ def mocked_rpc_server():
         def send(self, message):
             self.outbox.append(message.serialize())
     
+        def send_to_client(self, message):
+            self.outbox.append([message.node_id, message.serialize()])
+
+        def recv_from_client(self):
+            results = self.queue.get()
+            msg = Message.unserialize(results)
+            return msg.node_id, msg
+
     return MockedRpcServer
 
 
@@ -218,7 +226,7 @@ class TestMasterRunner(LocustTestCase):
             
             num_clients = 0
             for msg in server.outbox:
-                num_clients += Message.unserialize(msg).data["num_clients"]
+                num_clients += Message.unserialize(msg[1]).data["num_clients"]
             
             self.assertEqual(7, num_clients, "Total number of locusts that would have been spawned is not 7")
     
@@ -238,7 +246,7 @@ class TestMasterRunner(LocustTestCase):
             
             num_clients = 0
             for msg in server.outbox:
-                num_clients += Message.unserialize(msg).data["num_clients"]
+                num_clients += Message.unserialize(msg[1]).data["num_clients"]
             
             self.assertEqual(2, num_clients, "Total number of locusts that would have been spawned is not 2")
     

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -17,9 +17,9 @@ class ZMQRPC_tests(unittest.TestCase):
     def test_client_send(self):
         self.client.send(Message('test', 'message', 'identity'))
         addr, msg = self.server.recv_from_client()
-        assert addr == 'identity'
-        assert msg.type == 'test'
-        assert msg.data == 'message'
+        self.assertEqual(addr, 'identity')
+        self.assertEqual(msg.type, 'test')
+        self.assertEqual(msg.data, 'message')
 
     def test_client_recv(self):
         sleep(0.01)
@@ -27,6 +27,6 @@ class ZMQRPC_tests(unittest.TestCase):
         # before sending a msg to it.
         self.server.send_to_client(Message('test', 'message', 'identity'))
         msg = self.client.recv()
-        assert msg.type == 'test'
-        assert msg.data == 'message'
-        assert msg.node_id == 'identity'
+        self.assertEqual(msg.type, 'test')
+        self.assertEqual(msg.data, 'message')
+        self.assertEqual(msg.node_id, 'identity')

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -1,0 +1,35 @@
+import unittest
+from time import sleep
+# import gevent
+# import zmq.green as zmq
+import zmq
+from locust.rpc import zmqrpc, Message
+
+PORT = 5557
+
+class ZMQRPC_tests(unittest.TestCase):
+
+    def test_server(self):
+        server = zmqrpc.Server('*', PORT)
+        server.socket.close()
+
+    def test_client(self):
+        client = zmqrpc.Client('localhost', PORT, 'identity')
+        client.socket.close()
+
+    def test_client_send(self):
+        server = zmqrpc.Server('*', PORT)
+        client = zmqrpc.Client('localhost', PORT, 'identity')
+        client.send(Message('test', None, None))
+        server.recv_from_client()
+        server.socket.close()
+        client.socket.close()
+
+    def test_client_recv(self):
+        server = zmqrpc.Server('*', PORT)
+        client = zmqrpc.Client('localhost', PORT, 'identity')
+        sleep(0.01)
+        server.send_to_client(Message('test', None, 'identity'))
+        client.recv()
+        server.socket.close()
+        client.socket.close()

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -6,30 +6,25 @@ from locust.rpc import zmqrpc, Message
 PORT = 5557
 
 class ZMQRPC_tests(unittest.TestCase):
+    def setUp(self):
+        self.server = zmqrpc.Server('*', PORT)
+        self.client = zmqrpc.Client('localhost', PORT, 'identity')
 
-    def test_server(self):
-        server = zmqrpc.Server('*', PORT)
-        server.socket.close()
-
-    def test_client(self):
-        client = zmqrpc.Client('localhost', PORT, 'identity')
-        client.socket.close()
+    def tearDown(self):
+        self.server.socket.close()
+        self.client.socket.close()
 
     def test_client_send(self):
-        server = zmqrpc.Server('*', PORT)
-        client = zmqrpc.Client('localhost', PORT, 'identity')
-        client.send(Message('test', None, None))
-        server.recv_from_client()
-        server.socket.close()
-        client.socket.close()
+        self.client.send(Message('test', None, None))
+        self.server.recv_from_client()
+        self.server.socket.close()
+        self.client.socket.close()
 
     def test_client_recv(self):
-        server = zmqrpc.Server('*', PORT)
-        client = zmqrpc.Client('localhost', PORT, 'identity')
         sleep(0.01)
         # We have to wait for the client to finish connecting 
         # before sending a msg to it.
-        server.send_to_client(Message('test', None, 'identity'))
-        client.recv()
-        server.socket.close()
-        client.socket.close()
+        self.server.send_to_client(Message('test', None, 'identity'))
+        self.client.recv()
+        self.server.socket.close()
+        self.client.socket.close()

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -15,16 +15,18 @@ class ZMQRPC_tests(unittest.TestCase):
         self.client.socket.close()
 
     def test_client_send(self):
-        self.client.send(Message('test', None, None))
-        self.server.recv_from_client()
-        self.server.socket.close()
-        self.client.socket.close()
+        self.client.send(Message('test', 'message', 'identity'))
+        addr, msg = self.server.recv_from_client()
+        assert addr == 'identity'
+        assert msg.type == 'test'
+        assert msg.data == 'message'
 
     def test_client_recv(self):
         sleep(0.01)
         # We have to wait for the client to finish connecting 
         # before sending a msg to it.
-        self.server.send_to_client(Message('test', None, 'identity'))
-        self.client.recv()
-        self.server.socket.close()
-        self.client.socket.close()
+        self.server.send_to_client(Message('test', 'message', 'identity'))
+        msg = self.client.recv()
+        assert msg.type == 'test'
+        assert msg.data == 'message'
+        assert msg.node_id == 'identity'

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -1,7 +1,5 @@
 import unittest
 from time import sleep
-# import gevent
-# import zmq.green as zmq
 import zmq
 from locust.rpc import zmqrpc, Message
 
@@ -29,6 +27,8 @@ class ZMQRPC_tests(unittest.TestCase):
         server = zmqrpc.Server('*', PORT)
         client = zmqrpc.Client('localhost', PORT, 'identity')
         sleep(0.01)
+        # We have to wait for the client to finish connecting 
+        # before sending a msg to it.
         server.send_to_client(Message('test', None, 'identity'))
         client.recv()
         server.socket.close()

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -17,7 +17,7 @@ class ZMQRPC_tests(unittest.TestCase):
     def test_client_send(self):
         self.client.send(Message('test', 'message', 'identity'))
         addr, msg = self.server.recv_from_client()
-        self.assertEqual(addr, 'identity')
+        self.assertEqual(addr, b'identity')
         self.assertEqual(msg.type, 'test')
         self.assertEqual(msg.data, 'message')
 


### PR DESCRIPTION
I have noticed some issues bringing up master and slave nodes within Kubernetes. I noticed in some other github issues for Locust that some of the issues may be solved by adding a heartbeat between the nodes.

The changes include the addition of a heartbeat thread on the master. The slaves check in with the master by means of their own heartbeat worker thread. There is also a new state (missing) that will show in the UI if a slave fails to check in with the heartbeat to the master.

I also think that it prevents some stale state by having the slaves also send their current state to the master. Reason being that if a slave fails to check in and goes missing, how else would the master know what the slave is doing after it continues to check in.

I got my inspiration from the ZMQ guide, specifically this pattern...
http://zguide.zeromq.org/page:all#Robust-Reliable-Queuing-Paranoid-Pirate-Pattern

Thoughts, comments?