### PR TITLE
Make stdout/stderr wrappers identify themselves as not being a tty

### DIFF
--- a/locust/log.py
+++ b/locust/log.py
@@ -8,10 +8,10 @@ def setup_logging(loglevel, logfile):
     numeric_level = getattr(logging, loglevel.upper(), None)
     if numeric_level is None:
         raise ValueError("Invalid log level: %s" % loglevel)
-    
+
     log_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(host)
     logging.basicConfig(level=numeric_level, filename=logfile, format=log_format)
-    
+
     sys.stderr = StdErrWrapper()
     sys.stdout = StdOutWrapper()
 
@@ -25,6 +25,9 @@ class StdOutWrapper(object):
     def write(self, s):
         stdout_logger.info(s.strip())
 
+    def isatty(self):
+        return False
+
     def flush(self, *args, **kwargs):
         """No-op for wrapper"""
         pass
@@ -35,6 +38,9 @@ class StdErrWrapper(object):
     """
     def write(self, s):
         stderr_logger.error(s.strip())
+
+    def isatty(self):
+        return False
 
     def flush(self, *args, **kwargs):
         """No-op for wrapper"""


### PR DESCRIPTION
Calling `isatty()` on `sys.stderr`/`sys.stdout` inside locust will currently raise an exception (AttributeError: 'StdOutWrapper' object has no attribute 'isatty'), this PR just makes it so that it definitely identifies itself as not being connected to a tty.