### PR TITLE
Speed up task sequence tests

### DIFF
--- a/locust/test/test_task_sequence_class.py
+++ b/locust/test/test_task_sequence_class.py
@@ -14,6 +14,8 @@ class TestTaskSet(LocustTestCase):
 
         class User(Locust):
             host = "127.0.0.1"
+            min_wait = 1
+            max_wait = 10
         self.locust = User()
 
     def test_task_sequence_with_list(self):


### PR DESCRIPTION
The default min and max wait time between tasks result in these two tests taking a combined ~6 seconds of run time. With these new values the total run time for the entire test suite is reduced by about 68%.