### PR TITLE
Remove repeated imports of mock

### DIFF
--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -55,8 +55,6 @@ class TestMasterRunner(LocustTestCase):
         events.slave_report._handlers = self._slave_report_event_handlers
     
     def test_slave_connect(self):
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         
@@ -74,8 +72,6 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(3, len(master.clients))
     
     def test_slave_stats_report_median(self):
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         
@@ -96,8 +92,6 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(700, s.median_response_time)
     
     def test_master_total_stats(self):
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         
@@ -124,8 +118,6 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(700, master.stats.total.median_response_time)
     
     def test_master_current_response_times(self):
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         
@@ -203,8 +195,6 @@ class TestMasterRunner(LocustTestCase):
         Tests that we can accurately spawn a certain number of locusts, even if it's not an 
         even number of the connected slaves
         """
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         
@@ -223,8 +213,6 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(7, num_clients, "Total number of locusts that would have been spawned is not 7")
     
     def test_spawn_fewer_locusts_than_slaves(self):
-        import mock
-        
         class MyTestLocust(Locust):
             pass
         


### PR DESCRIPTION
I am not sure why mock is imported multiple times but the tests pass even without them. If there is a good reason to keep them then this could be closed. Otherwise for readability I think they should be removed.