### PR TITLE
Support horizontal scrolling for the stats table

### DIFF
--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -258,7 +258,9 @@ a:hover {
 }
 
 .status table {
+    display: block;
     width: 100%;
+    overflow-x: auto;
     border-radius: 3px;
     border: 2px solid #11251c;
     border-spacing: 0;


### PR DESCRIPTION
I can't see the last column in the stat table when the name is long. So I think locust web should support the horizontal scrolling on the stats table.