### PR TITLE
Both succeeded and failed requests are counted in total number of requests

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -558,6 +558,7 @@ def on_request_success(request_type, name, response_time, response_length, **kwa
     global_stats.log_request(request_type, name, response_time, response_length)
 
 def on_request_failure(request_type, name, response_time, exception, **kwargs):
+    global_stats.log_request(request_type, name, response_time, 0)
     global_stats.log_error(request_type, name, exception)
 
 def on_report_to_master(client_id, data):

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -311,7 +311,7 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
         response = locust.client.get("/", timeout=0.1)
         self.assertEqual(response.status_code, 0)
         self.assertEqual(1, global_stats.get("/", "GET").num_failures)
-        self.assertEqual(0, global_stats.get("/", "GET").num_requests)
+        self.assertEqual(1, global_stats.get("/", "GET").num_requests)
 
 
 class MyTaskSet(TaskSet):


### PR DESCRIPTION
Following up on @cgoldberg 's comment in https://github.com/locustio/locust/pull/884, the logic for counting requests is modified so that # requests include both failed and succeeded requests.

This PR superseeds https://github.com/locustio/locust/pull/884