### PR TITLE
Add basic auth capabilities

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,4 +1,4 @@
 from .core import HttpLocust, Locust, TaskSet, TaskSequence, task, seq_task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/locust/main.py
+++ b/locust/main.py
@@ -57,6 +57,14 @@ def parse_options():
     )
     
     parser.add_option(
+        '-B', '--web-auth',
+        type="str",
+        dest='web_auth',
+        default=None,
+        help="Set the Basic Auth for the UI (fmt: username:password )"
+    )
+    
+    parser.add_option(
         '-f', '--locustfile',
         dest='locustfile',
         default='locustfile',

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -24,3 +24,10 @@ class TestParser(unittest.TestCase):
         ]
         opts, _ = self.parser.parse_args(args)
         self.assertEqual(opts.reset_stats, False)
+        
+    def test_web_auth(self):
+        args = [
+            "--web-auth", "john:doe"
+        ]
+        opts, _ = self.parser.parse_args(args)
+        self.assertEqual(opts.web_auth, "john:doe")

--- a/locust/web.py
+++ b/locust/web.py
@@ -10,6 +10,8 @@ from time import time
 
 import six
 from flask import Flask, make_response, jsonify, render_template, request
+from flask_basicauth import BasicAuth
+
 from gevent import pywsgi
 
 from locust import __version__ as version
@@ -164,5 +166,12 @@ def exceptions_csv():
     return response
 
 def start(locust, options):
+    if options.web_auth is not None:
+        credentials = options.web_auth.split(":")
+        if len(credentials) == 2:
+            app.config["BASIC_AUTH_USERNAME"] = credentials[0]
+            app.config["BASIC_AUTH_PASSWORD"] = credentials[1]
+            app.config["BASIC_AUTH_FORCE"] = True
+            BasicAuth(app)
     pywsgi.WSGIServer((options.web_host, options.port),
                       app, log=None).serve_forever()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(exclude=['examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2"],
+    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2", "Flask-BasicAuth==0.2.0"],
     test_suite="locust.test",
     tests_require=['mock'],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,6 @@ envlist = py27, py34, py35, py36, py37
 deps =
     codecov
     mock
+    flask_basicauth
 commands =
     coverage run -m unittest discover []


### PR DESCRIPTION
Added basic auth flags '-B' and '--web-auth' to the command line arguments
Enabled basic-auth on the flask application for basic security to the UI