### PR TITLE
balance/recover the load distribution when new slave joins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.6.6-alpine3.8
 
 RUN apk --no-cache add g++ \ 
+      && apk --no-cache add zeromq-dev \
       && pip install locustio pyzmq
 
 EXPOSE 8089 5557 5558

--- a/locust/main.py
+++ b/locust/main.py
@@ -132,6 +132,7 @@ def parse_options():
         '--heartbeat-liveness',
         action='store',
         type='int',
+        dest='heartbeat_liveness',
         default=3,
         help="set number of seconds before failed heartbeat from slave"
     )
@@ -140,6 +141,7 @@ def parse_options():
         '--heartbeat-interval',
         action='store',
         type='int',
+        dest='heartbeat_interval',
         default=1,
         help="set number of seconds delay between slave heartbeats to master"
     )


### PR DESCRIPTION
With Locust master and slave agents running in Kubernetes, Kubernetes will guarantee the availability of Locust agents. 

But when a slave agent crashes and restarts, it will have a different client id and it has no idea of the user load that master assigned to it previously. And the total number of running locusts will not be as many as expected. 

So it might be a better way to balance the user load when new client joins, and the total number of running locusts will still be the same as we specified in the swarm request. 

also this PR fixes some issue I noticed when running in Python 3 with web mode, it turns out to be the inconsistency introduced in recv_from_client and send_to_client

Any thought or comment?