### PR TITLE
fix inconsistency in zmqrpc

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -21,7 +21,7 @@ class BaseSocket(object):
 
     def recv_from_client(self):
         data = self.socket.recv_multipart()
-        addr = data[0]
+        addr = data[0].decode()
         msg = Message.unserialize(data[1])
         return addr, msg
 

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -17,12 +17,12 @@ class ZMQRPC_tests(unittest.TestCase):
     def test_client_send(self):
         self.client.send(Message('test', 'message', 'identity'))
         addr, msg = self.server.recv_from_client()
-        self.assertEqual(addr, b'identity')
+        self.assertEqual(addr, 'identity')
         self.assertEqual(msg.type, 'test')
         self.assertEqual(msg.data, 'message')
 
     def test_client_recv(self):
-        sleep(0.01)
+        sleep(0.1)
         # We have to wait for the client to finish connecting 
         # before sending a msg to it.
         self.server.send_to_client(Message('test', 'message', 'identity'))


### PR DESCRIPTION
From zmqrpc.py, there're two new added methods send_to_client and recv_from_client for the messaging with client.
https://github.com/locustio/locust/blob/87a9aa1cb937c68e4456cafd23f3c42f25023931/locust/rpc/zmqrpc.py#L14-L27

In method send_to_client **msg.node_id** is supposed to be a str object, while in the context of zmqrpc **msg.node_id** will be assigned with the **addr** from the return tuple of recv_from_client, which was a bytes object.

This consistency will cause the encoding issue of **addr** where it's referenced, including the example below            https://github.com/locustio/locust/blob/87a9aa1cb937c68e4456cafd23f3c42f25023931/locust/web.py#L126-L134 
the **slave.id** is also assigned with **addr** and it will be a bytes object which will cause an exception thrown from jsonify: "TypeError: Object of type 'bytes' is not JSON serializable".
