### PR TITLE
add retry in zmqrpc

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,24 +1,28 @@
 import zmq.green as zmq
 
 from .protocol import Message
-
+from locust.util.exception_handler import retry
 
 class BaseSocket(object):
     def __init__(self, sock_type):
         context = zmq.Context()
         self.socket = context.socket(sock_type)
-
+    
+    @retry()
     def send(self, msg):
         self.socket.send(msg.serialize())
 
+    @retry()
     def send_to_client(self, msg):
         self.socket.send_multipart([msg.node_id.encode(), msg.serialize()])
 
+    @retry()
     def recv(self):
         data = self.socket.recv()
         msg = Message.unserialize(data)
         return msg
 
+    @retry()
     def recv_from_client(self):
         data = self.socket.recv_multipart()
         addr = data[0]

--- a/locust/util/exception_handler.py
+++ b/locust/util/exception_handler.py
@@ -1,0 +1,23 @@
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+def retry(delays=(1, 3, 5),
+          exception=Exception):
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            cnt = 0
+            for delay in delays + (None,):
+                try:
+                    return function(*args, **kwargs)
+                except exception:
+                    if delay is None:
+                        logger.info("Retry failed after %d times." % ( cnt ) )
+                        raise
+                    else:
+                        cnt += 1
+                        logger.info("Exception found on retry %d: -- retry after %ds" % ( cnt, delay ) )
+                        time.sleep(delay)
+        return wrapper
+    return decorator


### PR DESCRIPTION
When I'm running Locust in distributed mode, I've noticed an exception thrown from slave agent "AssertionError: Only one greenlet can be waiting on this event".

On investigating this issue, I find out that there're multiple greenlets in SlaveLocustRunner as shown in https://github.com/locustio/locust/blob/87a9aa1cb937c68e4456cafd23f3c42f25023931/locust/runners.py#L384-L388

and they're talking to Locust master with the same zmq socket, so there might be concurrent calls to self.client.send, then the exception above will be thrown.

We can leverage semaphore to avoid the concurrent calls, but there will be a performance cost. Since these concurrent situations are not very likely, it's better to simply add a retry for socket communication and makes Locust more robust.