### PR TITLE
Fix RPS graph

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -153,7 +153,7 @@ function updateStats() {
             // get total stats row
             var total = report.stats[report.stats.length-1];
             // update charts
-            rpsChart.addValue([total.current_rps]);
+            rpsChart.addValue([report.total_rps]);
             responseTimeChart.addValue([report.current_response_time_percentile_50, report.current_response_time_percentile_95]);
             usersChart.addValue([report.user_count]);
         }


### PR DESCRIPTION
Use "report.total_rps" instead of "total.current_rps", to get the same value for RPS as displayed on header. "total.current_rps" is not always available.

#889 