### PR TITLE
Fix the issue that num_locusts could be 0

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -80,7 +80,7 @@ class LocustRunner(object):
 
             # create locusts depending on weight
             percent = locust.weight / float(weight_sum)
-            num_locusts = int(round(amount * percent))
+            num_locusts = int(round(amount * percent)) or 1
             bucket.extend([locust for x in xrange(0, num_locusts)])
         return bucket
 


### PR DESCRIPTION
When running locust with -c 1 on 3 locust clients, locust exit silently.

Not sure about the original design, so just add a simple fix to set
num_locusts to 1 when it was 0 on round()

ISSUE - https://github.com/locustio/locust/issues/989