### PR TITLE
Add command line argument to specify exit code on response errors

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -282,12 +282,14 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # set the exit code to post on errors
     parser.add_option(
-        '--exit-code-on-fail',
-        action='store_false',
-        dest='exit_code_on_fail',
-        default=True,
-        help="post exit code 1 on error"
+        '--exit-code-on-error',
+        action='store',
+        type="int",
+        dest='exit_code_on_error',
+        default=1,
+        help="sets the exit code to post on error"
     )
 
     # Finalize
@@ -561,8 +563,8 @@ def main():
         logger.info("Starting Locust %s" % version)
         main_greenlet.join()
         code = 0
-        if len(runners.locust_runner.errors) and options.exit_code_on_fail:
-            code = 1
+        if len(runners.locust_runner.errors):
+            code = options.exit_code_on_error
         shutdown(code=code)
     except KeyboardInterrupt as e:
         shutdown(0)

--- a/locust/main.py
+++ b/locust/main.py
@@ -282,6 +282,14 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    parser.add_option(
+        '--no-exit-code-on-fail',
+        action='store_true',
+        dest='no_exit_code_on_fail',
+        default=False,
+        help="disable exit codes on failure"
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -553,7 +561,7 @@ def main():
         logger.info("Starting Locust %s" % version)
         main_greenlet.join()
         code = 0
-        if len(runners.locust_runner.errors):
+        if len(runners.locust_runner.errors) and not options.no_exit_code_on_fail:
             code = 1
         shutdown(code=code)
     except KeyboardInterrupt as e:

--- a/locust/main.py
+++ b/locust/main.py
@@ -283,11 +283,11 @@ def parse_options():
     )
 
     parser.add_option(
-        '--no-exit-code-on-fail',
-        action='store_true',
-        dest='no_exit_code_on_fail',
-        default=False,
-        help="disable exit codes on failure"
+        '--exit-code-on-fail',
+        action='store_false',
+        dest='exit_code_on_fail',
+        default=True,
+        help="post exit code 1 on error"
     )
 
     # Finalize
@@ -561,7 +561,7 @@ def main():
         logger.info("Starting Locust %s" % version)
         main_greenlet.join()
         code = 0
-        if len(runners.locust_runner.errors) and not options.no_exit_code_on_fail:
+        if len(runners.locust_runner.errors) and options.exit_code_on_fail:
             code = 1
         shutdown(code=code)
     except KeyboardInterrupt as e:


### PR DESCRIPTION
Fixes #560. Give an option to disable it. It's probably too late to change the functionality to an opt-in, but exit codes should only post if there's actually a problem with the binary, not because there was an error in a test.