### PR TITLE
Add errors grouping for dynamic endpoint

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -131,6 +131,9 @@ class HttpSession(requests.Session):
             return ResponseContextManager(response)
         else:
             try:
+                if name:
+                    orig_url = response.url
+                    response.url = name
                 response.raise_for_status()
             except RequestException as e:
                 events.request_failure.fire(
@@ -146,6 +149,8 @@ class HttpSession(requests.Session):
                     response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
                 )
+            if name:
+                response.url = orig_url
             return response
     
     def _send_request_safe_mode(self, method, url, **kwargs):

--- a/locust/test/test_client.py
+++ b/locust/test/test_client.py
@@ -1,9 +1,9 @@
 from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
                                  RequestException)
 
+from locust import events
 from locust.clients import HttpSession
 from locust.stats import global_stats
-
 from .testcases import WebserverTestCase
 
 
@@ -97,3 +97,17 @@ class TestHttpSession(WebserverTestCase):
             set(["OPTIONS", "DELETE", "PUT", "GET", "POST", "HEAD"]),
             set(r.headers["allow"].split(", ")),
         )
+
+    def test_error_message_with_name_replacment(self):
+        s = HttpSession("http://127.0.0.1:%i" % self.port)
+        my_event = events.EventHook()
+        kwargs = {}
+        def on_my_event(**kw):
+            kwargs.update(kw)
+
+        my_event += on_my_event
+        orig_events = events.request_failure
+        events.request_failure = my_event
+        s.request('get', '/wrong_url/01', name='replaced_url_name')
+        events.request_failure = orig_events
+        self.assertIn('for url: replaced_url_name', str(kwargs['exception']))


### PR DESCRIPTION
* currentlly there is option to group urls name for dynamic endpoint
  * adding name parameter to request
* this commit group error messages for dynamic endpoints
  * if name parameter was provided