### PR TITLE
Statistics: Provide distribution trend over time in CSV format

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -18,7 +18,7 @@ from .inspectlocust import get_task_ratio_dict, print_task_ratio
 from .log import console_logger, setup_logging
 from .runners import LocalLocustRunner, MasterLocustRunner, SlaveLocustRunner
 from .stats import (print_error_report, print_percentile_stats, print_stats,
-                    stats_printer, stats_writer, write_stat_csvs)
+                    stats_printer, stats_writer, trend_writer, write_stat_csvs)
 from .util.time import parse_timespan
 
 _internals = [Locust, HttpLocust]
@@ -71,6 +71,16 @@ def parse_options():
         dest='csvfilebase',
         default=None,
         help="Store current request stats to files in CSV format.",
+    )
+
+    # A file for storing trend data in CSV format
+    parser.add_option(
+        '--trend',
+        action='store',
+        type='str',
+        dest='trendfilename',
+        default=None,
+        help="Store response time distributions and other statistics trends to this file in CSV format.",
     )
 
     # if locust should be run in distributed mode as master
@@ -533,6 +543,9 @@ def main():
 
     if options.csvfilebase:
         gevent.spawn(stats_writer, options.csvfilebase)
+
+    if options.trendfilename:
+        gevent.spawn(trend_writer, options.trendfilename)
 
     
     def shutdown(code=0):

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -764,8 +764,9 @@ def failures_csv():
 # The percentiles which will be written to the trend file
 TREND_PERCENTILES = (
     0.00,
+    0.005,
     0.01,
-    0.02,
+    0.025,
     0.05,
     0.10,
     0.20,
@@ -777,8 +778,9 @@ TREND_PERCENTILES = (
     0.80,
     0.90,
     0.95,
-    0.98,
+    0.975,
     0.99,
+    0.995,
     1.00,
 )
 
@@ -791,7 +793,7 @@ def trend_csv_header():
         '"# requests"',
         '"# failures"',
         '"Requests/s"',
-    )) + ''.join([',"%i%%"' % (int(x * 100),) for x in TREND_PERCENTILES]) + '\n'
+    )) + ''.join([',"%g%%"' % (x * 100,) for x in TREND_PERCENTILES]) + '\n'
 
 def trend_csv():
     """Produce a row in the trends table"""

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -18,6 +18,9 @@ STATS_NAME_WIDTH = 60
 is configured."""
 CSV_STATS_INTERVAL_SEC = 2
 
+"""Default interval for how frequently the trend CSV file is written if enabled."""
+TREND_INTERVAL_SEC = 2
+
 """Default interval for how frequently results are written to console."""
 CONSOLE_STATS_INTERVAL_SEC = 2
 
@@ -656,13 +659,19 @@ def stats_printer():
 
 def stats_writer(base_filepath):
     """Writes the csv files for the locust run."""
-    with open(base_filepath + '_trend.csv', 'w') as f:
-        f.write(trend_csv_header())
 
     while True:
         write_stat_csvs(base_filepath)
         gevent.sleep(CSV_STATS_INTERVAL_SEC)
 
+def trend_writer(trend_filename):
+    """Periodically add new stats for the current locust run to the trend CSV."""
+    with open(trend_filename, 'w') as f:
+        f.write(trend_csv_header())
+    while True:
+        with open(trend_filename, 'a') as f:
+            f.write(trend_csv())
+        gevent.sleep(TREND_INTERVAL_SEC)
 
 def write_stat_csvs(base_filepath):
     """Writes the requests and distribution csvs."""
@@ -671,9 +680,6 @@ def write_stat_csvs(base_filepath):
 
     with open(base_filepath + '_distribution.csv', 'w') as f:
         f.write(distribution_csv())
-
-    with open(base_filepath + '_trend.csv', 'a') as f:
-        f.write(trend_csv())
 
 
 def sort_stats(stats):


### PR DESCRIPTION
### Summary 
Add a new command line option `--trend` which will produce a CSV file that can be used to examine the response time trends over time during a run. Useful in CI server usage for headless plotting instead of having to keep a browser window open for collecting trend charts.
The percentiles for the distributions are chosen so that it should be easy to plot the most common choices for confidence bands (50%, 95%, 98%, 99%), both symmetric or upper bound, min/max, median etc.

### Example usage

```
locust -f locustfile.py --host=http://127.0.0.1:8180 -c 200 -r 30 -t 60m --no-web --print-stats --trend="loadtest-$(date +'%Y-%m-%d_%H.%M.%S')-trend.csv"
```


### Example output

```csv
"Name","Timestamp","# clients","# requests","# failures","Requests/s","0%","0.5%","1%","2.5%","5%","10%","20%","25%","33%","50%","66%","75%","80%","90%","95%","97.5%","99%","99.5%","100%"
"Total",1556780909,1,0,0,0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
"Total",1556780911,59,0,0,0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
"/some/endpoint",1556780913,116,210,0,0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
"Total",1556780913,116,210,0,0,40,45,59,66,70,77,100,110,140,190,300,790,1100,1900,2300,2400,2500,2700,2700
"/some/endpoint",1556780915,169,531,0,29,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
"Total",1556780915,169,531,0,29,27,33,35,44,49,55,66,70,78,110,150,180,210,700,1700,2200,2400,2500,2700
"/some/endpoint",1556780917,200,949,0,67.8333,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
"Total",1556780917,200,949,0,67.8333,27,35,38,45,52,59,72,77,85,100,130,150,160,220,960,1800,2300,2400,2700
"/some/endpoint",1556780919,200,1424,0,99.75,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
```

### Example plot

An example graph plotted in LibreOffice Calc

![image](https://user-images.githubusercontent.com/317506/57062008-3ed1c900-6cbf-11e9-80e2-4d62764854c5.png)
