### PR TITLE
Fix for the examples regarding semaphore_wait.py

### DIFF
--- a/examples/semaphore_wait.py
+++ b/examples/semaphore_wait.py
@@ -1,6 +1,7 @@
 from locust import HttpLocust, TaskSet, task, events
 
-from gevent.coros import Semaphore
+from gevent.lock import Semaphore
+
 all_locusts_spawned = Semaphore()
 all_locusts_spawned.acquire()
 


### PR DESCRIPTION
Module has changed to `gevent.lock` from `gevent.coros`