### PR TITLE
Add grpc compatibility.

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -16,6 +16,9 @@ from six.moves import xrange
 # See: https://github.com/requests/requests/issues/3752#issuecomment-294608002
 monkey.patch_all()
 
+import grpc.experimental.gevent as grpc_gevent
+grpc_gevent.init_gevent()
+
 from . import events
 from .clients import HttpSession
 from .exception import (InterruptTaskSet, LocustError, RescheduleTask,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(exclude=['examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2"],
+    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2", "grpc>=1.12.0"],
     test_suite="locust.test",
     tests_require=['mock'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(exclude=['examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2", "grpc>=1.12.0"],
+    install_requires=["gevent>=1.2.2", "flask>=0.10.1", "requests>=2.9.1", "msgpack>=0.4.2", "six>=1.10.0", "pyzmq>=16.0.2", "grpcio>=1.12.0"],
     test_suite="locust.test",
     tests_require=['mock'],
     entry_points={


### PR DESCRIPTION
Add grpc compatibility so that custom load tests work with grpc.

Found that locust can't work with grpc because gevent is not compatible with grpc. This pull request is to add grpc compatibility to custom locust test. More information can be found [here](https://github.com/grpc/grpc/issues/4629)