### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/examples/custom_xmlrpc_client/server.py
+++ b/examples/custom_xmlrpc_client/server.py
@@ -12,7 +12,7 @@ def get_random_number(low, high):
     return random.randint(low, high)
 
 server = SimpleXMLRPCServer(("localhost", 8877))
-print "Listening on port 8877..."
+print("Listening on port 8877...")
 server.register_function(get_time, "get_time")
 server.register_function(get_random_number, "get_random_number")
 server.serve_forever()


### PR DESCRIPTION
Discovered via: __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.