### PR TITLE
Fixed issue with Total Requests Per Second plot

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -123,6 +123,8 @@ def request_stats():
     # Truncate the total number of stats and errors displayed since a large number of rows will cause the app
     # to render extremely slowly. Aggregate stats should be preserved.
     report = {"stats": stats[:500], "errors": errors[:500]}
+    if len(stats) > 500:
+        report["stats"] += [stats[-1]]
 
     if stats:
         report["total_rps"] = stats[len(stats)-1]["current_rps"]


### PR DESCRIPTION
Fixes the plot when there are too many unique urls.

#1059 
#889 

The total stats block, which is usually located at the end of the list of stats, was getting truncated whenever there were too many URLs that were being requested.  Here I add the total stats back to the end of the report.