### PR TITLE
drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 3.4
-      env: TOXENV=py34
     - python: 2.7
       env: TOXENV=py27
     - stage: Verify Docker image builds

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Open source licensed under the MIT license (see _LICENSE_ file for details).
 
 ## Supported Python Versions
 
-Locust is supported on Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Locust is supported on Python 2.7, 3.5, 3.6, 3.7.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ To see available options, run:
 Supported Python Versions
 -------------------------
 
-Locust is supported on Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Locust is supported on Python 2.7, 3.5, 3.6, 3.7.
 
 
 Installing Locust on Windows

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR drops Python 3.4 support from our testing and documentation.  Nothing here actually breaks compatibility with Python 3.4, but this removes it from our tests (tox tests, travis-ci matrix), the setup.py classifier, and all references in the docs.

Python 3.4 has been deprecated for several months by the Python Core maintainers, newest versions of pip no longer work with it, and new versions of gevent have already dropped python 3.4 support.