### PR TITLE
Allow options to be passed to locust in docker, update docs

### DIFF
--- a/docker_start.sh
+++ b/docker_start.sh
@@ -6,20 +6,20 @@ if [ -z "${TARGET_URL}" ]; then
 fi
 
 LOCUST_MODE="${LOCUST_MODE:=standalone}"
-LOCUST_OPTS="-f ${LOCUSTFILE_PATH:-/locustfile.py} -H ${TARGET_URL}"
+_LOCUST_OPTS="-f ${LOCUSTFILE_PATH:-/locustfile.py} -H ${TARGET_URL}"
 
 if [ "${LOCUST_MODE}" = "master" ]; then
-    LOCUST_OPTS="${LOCUST_OPTS} --master"
+    _LOCUST_OPTS="${_LOCUST_OPTS} --master"
 elif [ "${LOCUST_MODE}" = "slave" ]; then
     if [ -z "${LOCUST_MASTER_HOST}" ]; then
         echo "ERROR: MASTER_HOST is empty. Slave mode requires a master" >&2
         exit 1
     fi
 
-    LOCUST_OPTS="${LOCUST_OPTS} --slave --master-host=${LOCUST_MASTER_HOST} --master-port=${LOCUST_MASTER_PORT:-5557}"
+    _LOCUST_OPTS="${_LOCUST_OPTS} --slave --master-host=${LOCUST_MASTER_HOST} --master-port=${LOCUST_MASTER_PORT:-5557}"
 fi
 
-echo "Starting Locust..."
-echo "$ locust ${LOCUST_OPTS}"
+echo "Starting Locust in ${LOCUST_MODE} mode..."
+echo "$ locust ${LOCUST_OPTS} ${_LOCUST_OPTS}"
 
-locust ${LOCUST_OPTS}
+locust ${LOCUST_OPTS} ${_LOCUST_OPTS}

--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -4,8 +4,7 @@
 Running Locust with Docker
 =================================
 
-To keep things simple we provide a single Docker image that can run standalone, as a master, or as a slave. 
-
+To keep things simple we provide a single Docker image that can run standalone, as a master, or as a slave.
 
 Environment Variables
 ---------------------------------------------
@@ -26,11 +25,14 @@ The hostname of the master.
 
 The port used to communicate with the master. Defaults to 5557.
 
+- ``LOCUST_OPTS``
 
-Add your tests
+Additional options to pass to locust. Defaults to ''.
+
+Running your tests
 ---------------------------------------------
 
-The easiest way to get your tests running is to build an image with your test file built in. Once you've 
+The easiest way to get your tests running is to build an image with your test file built in. Once you've
 written your locustfile you can bake it into a Docker image with a simple ``Dockerfile``:
 
 ```
@@ -41,3 +43,17 @@ ADD locustfile.py locustfile.py
 You'll need to push the built image to a Docker repository such as Dockerhub, AWS ECR, or GCR in order for
 distributed infrastructure to be able to pull the image. See your chosen repository's documentation on how
 to authenticate with the repository to pull the image.
+
+For debugging locally you can run a container and pass your locustfile in as a volume:
+
+```
+docker run -p 8089:8089 --volume $PWD/dir/of/locustfile:/mnt/locust -e LOCUSTFILE_PATH=/mnt/locust/locustfile.py -e TARGET_URL=https://abc.com locustio/locust
+```
+
+To run in standalone mode without the web UI, you can use the `LOCUST_OPTS` environment variable to add the required options:
+
+```
+docker run --volume $PWD/dir/of/locustfile:/mnt/locust -e LOCUSTFILE_PATH=/mnt/locust/locustfile.py -e TARGET_URL=https://abc.com -e LOCUST_OPTS="--clients=10 --no-web --run-time=600" locustio/locust
+```
+
+If you are Kubernetes user, you can use the [Helm chart](https://github.com/helm/charts/tree/master/stable/locust) to scale and run locust.


### PR DESCRIPTION
In this PR I am:

- Adding a new env var so users can pass options to `locust` in docker image. This means `standalone` mode with no web is now possible. Great for running as k8s `Job`.
- Updating docker documentation with new `LOCUST_OPTS` env var and a couple extra examples for how to run your tests.

Does it make sense? Is that OK?