### PR TITLE
Add an option to allow tasks to finish running their iteration before exiting

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -292,6 +292,15 @@ def parse_options():
         help="sets the exit code to post on error"
     )
 
+    parser.add_option(
+        '--task-finish-wait-time',
+        action='store',
+        type="int",
+        dest='task_finish_wait_time',
+        default=None,
+        help="number of seconds to wait for a taskset to complete an iteration before exiting. default is to terminate immediately."
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -183,7 +183,7 @@ class LocustRunner(object):
                     raise GreenletExit()
                 l.args[0].task_set.wait_function = exit_greenlet
             if not self.locusts.join(timeout=self.options.task_finish_wait_time):
-                logger.info(f"Not all locusts finished their tasks & terminated in {self.options.task_finish_wait_time} seconds. Killing them...")
+                logger.info("Not all locusts finished their tasks & terminated in %s seconds. Killing them..." % self.options.task_finish_wait_time)
         self.locusts.kill(block=True)
         self.state = STATE_STOPPED
         events.locust_stop_hatching.fire()


### PR DESCRIPTION
I ran into a case where I wanted to guarantee that task are allowed to finish (to finish things like logout, return of test data etc). I think this would be useful to other people as well. 

Adding the option also has the nice benefit of making it more clear that the default behaviour is that tasks can exit (almost) at any point.