### PR TITLE
Using docker multi-stage for 50% smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
+FROM python:3.6.6-alpine3.8 as builder
+
+RUN apk --no-cache add g++ zeromq-dev
+RUN pip install locustio pyzmq
+
 FROM python:3.6.6-alpine3.8
 
-RUN apk --no-cache add g++ \
-      && apk --no-cache add zeromq-dev \
-      && pip install locustio pyzmq
-
+RUN apk --no-cache add zeromq-dev
+COPY --from=builder /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
+COPY --from=builder /usr/local/bin/locust /usr/local/bin/locust
 COPY docker_start.sh docker_start.sh
 RUN chmod +x docker_start.sh
 


### PR DESCRIPTION
A simple PR to change the Dockerfile to use a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/). This reduces docker image size from 286MB to 127MB.