### PR TITLE
Adding TCP Keep Alive to guarantee master-slave communication after i…

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -7,6 +7,9 @@ class BaseSocket(object):
     def __init__(self, sock_type):
         context = zmq.Context()
         self.socket = context.socket(sock_type)
+
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
     
     @retry()
     def send(self, msg):

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -14,6 +14,12 @@ class ZMQRPC_tests(unittest.TestCase):
         self.server.socket.close()
         self.client.socket.close()
 
+    def test_constructor(self):
+        self.assertEqual(self.server.socket.getsockopt(zmq.TCP_KEEPALIVE), 1)
+        self.assertEqual(self.server.socket.getsockopt(zmq.TCP_KEEPALIVE_IDLE), 30)
+        self.assertEqual(self.client.socket.getsockopt(zmq.TCP_KEEPALIVE), 1)
+        self.assertEqual(self.client.socket.getsockopt(zmq.TCP_KEEPALIVE_IDLE), 30)
+
     def test_client_send(self):
         self.client.send(Message('test', 'message', 'identity'))
         addr, msg = self.server.recv_from_client()


### PR DESCRIPTION
This PR is a copy of https://github.com/locustio/locust/pull/1020 (obsolete due to merge conflict issues)

> For context, the cloud infrastructure my company uses has a firewall that closes idle connections after 5 minutes. For us, that means that if we leave a test running for a while and come back to it, we are unable to control the slaves through the master UI.

> If you look through the comments PR 740, you can see that this is easily fixed by adding keep alive at the ZMQ socket level.

> We thought that PR 927 would make the change redundant but, after testing Locust 0.11.0 (which includes the change) we were able to reproduce the problem again pretty consistently.