### PR TITLE
Fix empty bytearray(b'') returned when using catch_response=True

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -316,6 +316,8 @@ class ResponseContextManager(FastResponse):
     def __init__(self, response):
         # copy data from response to this object
         self.__dict__ = response.__dict__
+        if isinstance(response, FastResponse):
+            self._cached_content = response._cached_content
     
     def __enter__(self):
         return self

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -317,7 +317,7 @@ class ResponseContextManager(FastResponse):
         # copy data from response to this object
         self.__dict__ = response.__dict__
         if isinstance(response, FastResponse):
-            self._cached_content = response._cached_content
+            self._cached_content = response.content
     
     def __enter__(self):
         return self

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -316,8 +316,7 @@ class ResponseContextManager(FastResponse):
     def __init__(self, response):
         # copy data from response to this object
         self.__dict__ = response.__dict__
-        if isinstance(response, FastResponse):
-            self._cached_content = response.content
+        self._cached_content = response.content
     
     def __enter__(self):
         return self

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -314,6 +314,7 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         with self.locust.client.get("/ultra_fast", catch_response=True) as response: pass
         self.assertEqual(1, self.num_failures)
         self.assertEqual(1, self.num_success)
+        self.assertIn("ultra fast", str(response.content))
         
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             raise ResponseError("Not working")


### PR DESCRIPTION
This is a potential fix for a bug that causes the content to be "dropped" when passing `catch_response=True` in combination with `FastHttpLocust`.

To recreate, run following locust-file with locust v0.12.0:

```python
from locust import TaskSet, task
from locust.contrib.fasthttp import FastHttpLocust


class ExamplePage(TaskSet):
    @task
    def index(self):
        with self.client.get("/", catch_response=True) as r:
            print(r.content)


class AwesomeUser(FastHttpLocust):
    task_set = ExamplePage
    host = "http://example.com"
```

Inside [`ResponseContextManager.__init__`](https://github.com/locustio/locust/blob/master/locust/contrib/fasthttp.py#L318) the responses `__dict__` is copied over, but for some reason the content doesn't tag along...

To be honest, I'm still not entirely sure why it gets dropped, might even be something in `geventhttpclient` but this fixes the issue and seems unobtrusive enough.

Please have a look, if anyone has a better solution, I'm all ears :)