### PR TITLE
Add Python 3.8 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 cache: pip
 matrix:
   include:
+    - python: 3.8
+      env: TOXENV=py38
     - python: 3.7
       env: TOXENV=py37
       dist: xenial

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Open source licensed under the MIT license (see _LICENSE_ file for details).
 
 ## Supported Python Versions
 
-Locust is supported on Python 2.7, 3.5, 3.6, 3.7.
+Locust is supported on Python 2.7, 3.5, 3.6, 3.7, 3.8.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ To see available options, run:
 Supported Python Versions
 -------------------------
 
-Locust is supported on Python 2.7, 3.5, 3.6, 3.7.
+Locust is supported on Python 2.7, 3.5, 3.6, 3.7, 3.8.
 
 
 Installing Locust on Windows

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py{27,35,36,37,38}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.