### PR TITLE
Remove 'dist: xenial' from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
     - python: 3.6
       env: TOXENV=py36
     - python: 3.5


### PR DESCRIPTION
'dist: xenial' is now the default.