### PR TITLE
Table layout fix to use available space better

### DIFF
--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -290,6 +290,9 @@ a:hover {
 .status th.numeric {
     text-align: right;
 }
+.status th.nowrap {
+    white-space: nowrap;
+}
 .status tr.dark {
     background:#153126;
 }
@@ -315,10 +318,6 @@ a:hover {
     .status td {
         max-width: 350px;
     }
-}
-
-#stats {
-    table-layout: fixed;
 }
 
 #stats td {

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -104,8 +104,8 @@
                             <tr>
                                 <th class="stats_label" href="#" data-sortkey="method">Type</th>
                                 <th class="stats_label" href="#" data-sortkey="name">Name</th>
-                                <th class="stats_label numeric" href="#" data-sortkey="num_requests" title="Number of successful requests"># Requests</th>
-                                <th class="stats_label numeric" href="#" data-sortkey="num_failures" title="Number of failures"># Fails</th>
+                                <th class="stats_label numeric nowrap" href="#" data-sortkey="num_requests" title="Number of successful requests"># Requests</th>
+                                <th class="stats_label numeric nowrap" href="#" data-sortkey="num_failures" title="Number of failures"># Fails</th>
                                 <th class="stats_label numeric" href="#" data-sortkey="median_response_time" title="Median response time">Median (ms)</th>
                                 <th class="stats_label numeric" href="#" data-sortkey="avg_response_time" title="Average response time">Average (ms)</th>
                                 <th class="stats_label numeric" href="#" data-sortkey="min_response_time" title="Min response time">Min (ms)</th>


### PR DESCRIPTION
This PR removes the `table-layout: fixed` CSS property from the  stats table in the web UI, in order to make better use of the available space.

The `table-layout:fixed` property was added by #962 (which is a PR for #938), so this PR will partly revert those changes. However I'm still able to see the whole table by scrolling the page horizontally after these changes.

**Before:**
![image](https://user-images.githubusercontent.com/54217/67237852-5c9d1100-f44c-11e9-875a-5da8bab0bd16.png)

**After:**
![image](https://user-images.githubusercontent.com/54217/67237971-9d952580-f44c-11e9-9713-52cabf870ff4.png)

