### PR TITLE
Escape HTML entities in endpoint names #374

### DIFF
--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -219,7 +219,7 @@
         <![CDATA[
         <tr class="<%=(alternate ? "dark" : "")%> <%=(this.name == "Total" ? "total" : "")%>">
             <td><%= (this.method ? this.method : "") %></td>
-            <td class="name" title="<%= this.name %>"><%= this.name %></td>
+            <td class="name" title="<%= this.name %>"><%= this.safe_name %></td>
             <td class="numeric"><%= this.num_requests %></td>
             <td class="numeric"><%= this.num_failures %></td>
             <td class="numeric"><%= Math.round(this.median_response_time) %></td>

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -43,13 +43,14 @@ class TestWebUI(LocustTestCase):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code)
     
     def test_stats(self):
-        stats.global_stats.log_request("GET", "/test", 120, 5612)
+        stats.global_stats.log_request("GET", "/<html>", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
         
         data = json.loads(response.text)
         self.assertEqual(2, len(data["stats"])) # one entry plus Total
-        self.assertEqual("/test", data["stats"][0]["name"])
+        self.assertEqual("/<html>", data["stats"][0]["name"])
+        self.assertEqual("/&lt;html&gt;", data["stats"][0]["safe_name"])
         self.assertEqual("GET", data["stats"][0]["method"])
         self.assertEqual(120, data["stats"][0]["avg_response_time"])
         

--- a/locust/web.py
+++ b/locust/web.py
@@ -7,7 +7,13 @@ import os.path
 from collections import defaultdict
 from itertools import chain
 from time import time
-import html
+
+try:
+    # >= Py3.2
+    from html import escape
+except ImportError:
+    # < Py3.2
+    from cgi import escape
 
 import six
 from flask import Flask, make_response, jsonify, render_template, request
@@ -105,12 +111,12 @@ def failures_stats_csv():
 @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
 def request_stats():
     stats = []
-    
+
     for s in chain(sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.total]):
         stats.append({
             "method": s.method,
             "name": s.name,
-            "safe_name": html.escape(s.name),
+            "safe_name": escape(s.name, quote=False),
             "num_requests": s.num_requests,
             "num_failures": s.num_failures,
             "avg_response_time": s.avg_response_time,

--- a/locust/web.py
+++ b/locust/web.py
@@ -7,6 +7,7 @@ import os.path
 from collections import defaultdict
 from itertools import chain
 from time import time
+import html
 
 import six
 from flask import Flask, make_response, jsonify, render_template, request
@@ -109,6 +110,7 @@ def request_stats():
         stats.append({
             "method": s.method,
             "name": s.name,
+            "safe_name": html.escape(s.name),
             "num_requests": s.num_requests,
             "num_failures": s.num_failures,
             "avg_response_time": s.avg_response_time,


### PR DESCRIPTION
URL names (for stats) were not HTML-escaped in the dashboard.
This made names with angle brackets disappear. For example:

```
self.client.get(url, name='/some-resource/upload/<uuid>')
```

would show up as `/some-resource/upload/` instead of `/some-resource/upload/<uuid>` which is confusing.

I added new key to /stats/request - "safe_name" - so that escaping
is on the server side and javascript has less logic.