### PR TITLE
Fix and add test for when locusts fail to exit at end of iteration during stop timeout.

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -358,15 +358,14 @@ class TaskSet(object):
         
         while (True):
             try:
-                if self.locust._state == LOCUST_STATE_STOPPING:
-                    raise GreenletExit()
-        
                 if not self._task_queue:
                     self.schedule_task(self.get_next_task())
                 
                 try:
                     self.execute_next_task()
                 except RescheduleTaskImmediately:
+                    if self.locust._state == LOCUST_STATE_STOPPING:
+                        raise GreenletExit()
                     pass
                 except RescheduleTask:
                     self.wait()
@@ -430,6 +429,8 @@ class TaskSet(object):
         return millis / 1000.0
 
     def wait(self):
+        if self.locust._state == LOCUST_STATE_STOPPING:
+            raise GreenletExit()
         self.locust._state = LOCUST_STATE_WAITING
         self._sleep(self.get_wait_secs())
         self.locust._state = LOCUST_STATE_RUNNING

--- a/locust/core.py
+++ b/locust/core.py
@@ -362,6 +362,8 @@ class TaskSet(object):
                     self.schedule_task(self.get_next_task())
                 
                 try:
+                    if self.locust._state == LOCUST_STATE_STOPPING:
+                        raise GreenletExit()
                     self.execute_next_task()
                     if self.locust._state == LOCUST_STATE_STOPPING:
                         raise GreenletExit()

--- a/locust/core.py
+++ b/locust/core.py
@@ -363,6 +363,8 @@ class TaskSet(object):
                 
                 try:
                     self.execute_next_task()
+                    if self.locust._state == LOCUST_STATE_STOPPING:
+                        raise GreenletExit()
                 except RescheduleTaskImmediately:
                     if self.locust._state == LOCUST_STATE_STOPPING:
                         raise GreenletExit()
@@ -429,8 +431,6 @@ class TaskSet(object):
         return millis / 1000.0
 
     def wait(self):
-        if self.locust._state == LOCUST_STATE_STOPPING:
-            raise GreenletExit()
         self.locust._state = LOCUST_STATE_WAITING
         self._sleep(self.get_wait_secs())
         self.locust._state = LOCUST_STATE_RUNNING


### PR DESCRIPTION
I discovered a bug introduced in the last commit on stop-timeout. Adding a test case for it (and once you have seen that it actually fails), I will revert that commit to show that it now works :)