### PR TITLE
Add response_length to request_failure event

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -143,6 +143,7 @@ class HttpSession(requests.Session):
                     request_type=request_meta["method"], 
                     name=request_meta["name"], 
                     response_time=request_meta["response_time"], 
+                    response_length=request_meta["content_size"],
                     exception=e, 
                 )
             else:
@@ -251,6 +252,7 @@ class ResponseContextManager(LocustResponse):
             request_type=self.locust_request_meta["method"],
             name=self.locust_request_meta["name"],
             response_time=self.locust_request_meta["response_time"],
+            response_length=self.locust_request_meta["content_size"],
             exception=exc,
         )
         self._is_reported = True

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -193,6 +193,7 @@ class FastHttpSession(object):
                     request_type=request_meta["method"], 
                     name=request_meta["name"], 
                     response_time=request_meta["response_time"], 
+                    response_length=request_meta["content_size"],
                     exception=e, 
                 )
             else:
@@ -387,6 +388,7 @@ class ResponseContextManager(FastResponse):
             request_type=self.locust_request_meta["method"],
             name=self.locust_request_meta["name"],
             response_time=self.locust_request_meta["response_time"],
+            response_length=self.locust_request_meta["content_size"],
             exception=exc,
         )
         self._is_reported = True

--- a/locust/events.py
+++ b/locust/events.py
@@ -54,6 +54,7 @@ Event is fired with the following arguments:
 * *request_type*: Request type method used
 * *name*: Path to the URL that was called (or override name if it was used in the call to the client)
 * *response_time*: Time in milliseconds until exception was thrown
+* *response_length*: Content-length of the response
 * *exception*: Exception instance that was thrown
 """
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -610,8 +610,8 @@ A global instance for holding the statistics. Should be removed eventually.
 def on_request_success(request_type, name, response_time, response_length, **kwargs):
     global_stats.log_request(request_type, name, response_time, response_length)
 
-def on_request_failure(request_type, name, response_time, exception, **kwargs):
-    global_stats.log_request(request_type, name, response_time, 0)
+def on_request_failure(request_type, name, response_time, response_length, exception, **kwargs):
+    global_stats.log_request(request_type, name, response_time, response_length)
     global_stats.log_error(request_type, name, exception)
 
 def on_report_to_master(client_id, data):

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -301,7 +301,7 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         
         self.num_failures = 0
         self.num_success = 0
-        def on_failure(request_type, name, response_time, exception):
+        def on_failure(request_type, name, response_time, response_length, exception):
             self.num_failures += 1
             self.last_failure_exception = exception
         def on_success(**kwargs):

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -469,7 +469,7 @@ class TestCatchResponse(WebserverTestCase):
         
         self.num_failures = 0
         self.num_success = 0
-        def on_failure(request_type, name, response_time, exception):
+        def on_failure(request_type, name, response_time, response_length, exception):
             self.num_failures += 1
             self.last_failure_exception = exception
         def on_success(**kwargs):

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -19,17 +19,17 @@ class TestRequestStats(unittest.TestCase):
             self.stats.log_request("GET", "test_entry", response_time, size)
         def log_error(exc):
             self.stats.log_error("GET", "test_entry", exc)
-        log(45, 0)
-        log(135, 0)
-        log(44, 0)
-        log(None, 0)        
+        log(45, 1)
+        log(135, 1)
+        log(44, 1)
+        log(None, 1)        
         log_error(Exception("dummy fail"))
         log_error(Exception("dummy fail"))
-        log(375, 0)
-        log(601, 0)
-        log(35, 0)
-        log(79, 0)
-        log(None, 0)        
+        log(375, 1)
+        log(601, 1)
+        log(35, 1)
+        log(79, 1)
+        log(None, 1)        
         log_error(Exception("dummy fail"))
         self.s = self.stats.get("test_entry",  "GET")
 
@@ -79,6 +79,9 @@ class TestRequestStats(unittest.TestCase):
 
     def test_avg(self):
         self.assertEqual(self.s.avg_response_time, 187.71428571428572)
+
+    def test_total_content_length(self):
+        self.assertEqual(self.s.total_content_length, 9)
 
     def test_reset(self):
         self.s.reset()


### PR DESCRIPTION
Like with request_success... This breaks compatibility with existing tests that use event handlers with positional arguments. Maybe it is worth a bumped minor version, to indicate that to users.