### PR TITLE
Stats: New argument "--csv-full-history" appends stats entries every interval in a new "_stats_history.csv" File

### DIFF
--- a/docs/retrieving-stats.rst
+++ b/docs/retrieving-stats.rst
@@ -13,7 +13,7 @@ if you plan on running Locust in an automated way with the ``--no-web`` flag:
 
     $ locust -f examples/basic.py --csv=example --no-web -t10m
 
-The files will be named ``example_distribution.csv`` and ``example_requests.csv`` (when using ``--csv=example``) and mirror Locust's built in stat pages.
+The files will be named ``example_response_times.csv`` and ``example_stats.csv`` (when using ``--csv=example``) and mirror Locust's built in stat pages.
 
 You can also customize how frequently this is written if you desire faster (or slower) writing:
 
@@ -22,11 +22,11 @@ You can also customize how frequently this is written if you desire faster (or s
     import locust.stats
     locust.stats.CSV_STATS_INTERVAL_SEC = 5 # default is 2 seconds
 
-This data will write two files with ``_distribution.csv`` and ``_requests.csv`` added to the name you give:
+This data will write two files with ``_response_times.csv`` and ``_stats.csv`` added to the name you give:
 
 .. code-block:: console
 
-    $ cat example_distribution.csv
+    $ cat example_response_times.csv
     "Name","# requests","50%","66%","75%","80%","90%","95%","98%","99%","99.9%","99.99%","100%"
     "GET /",31,4,4,4,4,4,4,4,4,4,4,4
     "/does_not_exist",0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"
@@ -37,8 +37,8 @@ and:
 
 .. code-block:: console
 
-    $ cat example_requests.csv
-    "Method","Name","# requests","# failures","Median response time","Average response time","Min response time","Max response time","Average Content Size","Requests/s"
+    $ cat example_stats.csv
+    "Type","Name","# requests","# failures","Median response time","Average response time","Min response time","Max response time","Average Content Size","Requests/s"
     "GET","/",51,0,4,3,2,6,12274,0.89
     "GET","/does_not_exist",0,56,0,0,0,0,0,0.00
     "GET","/stats/requests",58,0,3,3,2,5,1214,1.01

--- a/locust/main.py
+++ b/locust/main.py
@@ -65,6 +65,15 @@ def parse_options(args=None, default_config_files=['~/.locust.conf','locust.conf
         help="Store current request stats to files in CSV format.",
     )
 
+    # Adds each stats entry at every iteration to the _stats_history.csv file.
+    parser.add_argument(
+        '--csv-full-history',
+        action='store_true',
+        default=False,
+        dest='statshistory',
+        help="Store each stats entry in CSV format to _stats_history.csv file",
+    )
+
     # if locust should be run in distributed mode as master
     parser.add_argument(
         '--master',
@@ -495,7 +504,7 @@ def main():
         stats_printer_greenlet = gevent.spawn(stats_printer)
 
     if options.csvfilebase:
-        gevent.spawn(stats_writer, options.csvfilebase)
+        gevent.spawn(stats_writer, options.csvfilebase, options.statshistory)
 
     
     def shutdown(code=0):
@@ -513,7 +522,7 @@ def main():
         print_stats(runners.locust_runner.stats, current=False)
         print_percentile_stats(runners.locust_runner.stats)
         if options.csvfilebase:
-            write_stat_csvs(options.csvfilebase)
+            write_stat_csvs(options.csvfilebase, options.statshistory)
         print_error_report()
         sys.exit(code)
     

--- a/locust/main.py
+++ b/locust/main.py
@@ -70,7 +70,7 @@ def parse_options(args=None, default_config_files=['~/.locust.conf','locust.conf
         '--csv-full-history',
         action='store_true',
         default=False,
-        dest='statshistory',
+        dest='stats_history_enabled',
         help="Store each stats entry in CSV format to _stats_history.csv file",
     )
 
@@ -504,7 +504,7 @@ def main():
         stats_printer_greenlet = gevent.spawn(stats_printer)
 
     if options.csvfilebase:
-        gevent.spawn(stats_writer, options.csvfilebase, options.statshistory)
+        gevent.spawn(stats_writer, options.csvfilebase, options.stats_history_enabled)
 
     
     def shutdown(code=0):
@@ -522,7 +522,7 @@ def main():
         print_stats(runners.locust_runner.stats, current=False)
         print_percentile_stats(runners.locust_runner.stats)
         if options.csvfilebase:
-            write_stat_csvs(options.csvfilebase, options.statshistory)
+            write_stat_csvs(options.csvfilebase, options.stats_history_enabled)
         print_error_report()
         sys.exit(code)
     

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -862,11 +862,19 @@ def stats_history_csv_header():
         '"100%"'
     )) + '\n'
 
-def stats_history_csv(stats_history_enabled=False):
+def stats_history_csv(stats_history_enabled=False, csv_for_web_ui=False):
     """Returns the Aggregated stats entry every interval"""
     from . import runners
 
-    rows = []
+    # csv_for_web_ui boolean returns the header along with the stats history row so that
+    # it can be returned as a csv for download on the web ui. Otherwise when run with
+    # the '--no-web' option we write the header first and then append the file with stats
+    # entries every interval.
+    if csv_for_web_ui:
+        rows = [stats_history_csv_header()]
+    else:
+        rows = []
+
     timestamp = int(time.time())
     stats_entries_per_iteration = []
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -121,7 +121,7 @@ class RequestStats(object):
         """
         entry = self.entries.get((name, method))
         if not entry:
-            entry = StatsEntry(self, name, method)
+            entry = StatsEntry(self, name, method, True)
             self.entries[(name, method)] = entry
         return entry
     
@@ -887,7 +887,7 @@ def stats_history_csv(stats_history_enabled=False):
     for s in chain(stats_entries_per_iteration, [runners.locust_runner.stats.total]):
         if s.num_requests:
             percentile_str = ','.join([
-                str(int(s.get_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT])
+                str(int(s.get_current_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT])
         else:
             percentile_str = ','.join(['"N/A"'] * len(PERCENTILES_TO_REPORT))
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -880,11 +880,11 @@ def stats_history_csv(stats_history_enabled=False):
         1.0
     ]
 
-    include_stats_entries_per_iteration = []
+    stats_entries_per_iteration = []
     if stats_history_enabled:
-        include_stats_entries_per_iteration = sort_stats(runners.locust_runner.request_stats)
+        stats_entries_per_iteration = sort_stats(runners.locust_runner.request_stats)
 
-    for s in chain(include_stats_entries_per_iteration, [runners.locust_runner.stats.total]):
+    for s in chain(stats_entries_per_iteration, [runners.locust_runner.stats.total]):
         if s.num_requests:
             percentile_str = ','.join([
                 str(int(s.get_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT])

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -157,7 +157,7 @@
                 <div style="display:none;">
                     <div style="margin-top:20px;">
                         <a href="./stats/requests/csv">Download request statistics CSV</a><br>
-                        <a href="./stats/distribution/csv">Download response time distribution CSV</a><br>
+                        <a href="./stats/stats_history/csv">Download response time stats history CSV</a><br>
                         <a href="./stats/failures/csv">Download failures CSV</a><br>
                         <a href="./exceptions/csv">Download exceptions CSV</a>
                     </div>

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -205,14 +205,14 @@ class TestRequestStats(unittest.TestCase):
         s1 = StatsEntry(self.stats, "rounding down!", "GET")
         s1.log(122, 0)    # (rounded 120) min
         actual_percentile = s1.percentile()
-        self.assertEqual(actual_percentile, " GET rounding down!                                                  1    120    120    120    120    120    120    120    120    120    120    120")
+        self.assertEqual(actual_percentile, " GET                  rounding down!                                                      1    120    120    120    120    120    120    120    120    120    120    120")
 
     def test_percentile_rounded_up(self):
         s2 = StatsEntry(self.stats, "rounding up!", "GET")
         s2.log(127, 0)    # (rounded 130) min
         actual_percentile = s2.percentile()
-        self.assertEqual(actual_percentile, " GET rounding up!                                                    1    130    130    130    130    130    130    130    130    130    130    130")
-    
+        self.assertEqual(actual_percentile, " GET                  rounding up!                                                        1    130    130    130    130    130    130    130    130    130    130    130")
+
     def test_error_grouping(self):
         # reset stats
         self.stats = RequestStats()
@@ -259,7 +259,7 @@ class TestStatsPrinting(LocustTestCase):
     def test_print_percentile_stats(self):
         stats = RequestStats()
         for i in range(100):
-            stats.log_request("", "test_entry", i, 2000+i)
+            stats.log_request("GET", "test_entry", i, 2000+i)
         locust.stats.print_percentile_stats(stats)
         info = self.mocked_log.info
         self.assertEqual(7, len(info))

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -96,6 +96,11 @@ class TestWebUI(LocustTestCase):
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
 
+    def test_request_stats_history_csv(self):
+        stats.global_stats.log_request("GET", "/test2", 120, 5612)
+        response = requests.get("http://127.0.0.1:%i/stats/stats_history/csv" % self.web_port)
+        self.assertEqual(200, response.status_code)
+
     def test_failure_stats_csv(self):
         stats.global_stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/failures/csv" % self.web_port)

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -95,7 +95,7 @@ class TestWebUI(LocustTestCase):
         stats.global_stats.log_request("GET", "/test2", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_distribution_stats_csv(self):
         for i in range(19):
             stats.global_stats.log_request("GET", "/test2", 400, 5612)
@@ -105,10 +105,12 @@ class TestWebUI(LocustTestCase):
         rows = response.text.split("\n")
         # check that /test2 is present in stats
         row = rows[len(rows)-2].split(",")
-        self.assertEqual('"GET /test2"', row[0])
+        self.assertEqual('"GET"', row[0])
+        self.assertEqual('"/test2"', row[1])
         # check total row
         total_cols = rows[len(rows)-1].split(",")
-        self.assertEqual('"Aggregated"', total_cols[0])
+        self.assertEqual('"None"', total_cols[0])
+        self.assertEqual('"Aggregated"', total_cols[1])
         # verify that the 95%, 98%, 99% and 100% percentiles are 1200
         for value in total_cols[-4:]:
             self.assertEqual('1200', value)

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -96,25 +96,6 @@ class TestWebUI(LocustTestCase):
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
 
-    def test_distribution_stats_csv(self):
-        for i in range(19):
-            stats.global_stats.log_request("GET", "/test2", 400, 5612)
-        stats.global_stats.log_request("GET", "/test2", 1200, 5612)
-        response = requests.get("http://127.0.0.1:%i/stats/distribution/csv" % self.web_port)
-        self.assertEqual(200, response.status_code)
-        rows = response.text.split("\n")
-        # check that /test2 is present in stats
-        row = rows[len(rows)-2].split(",")
-        self.assertEqual('"GET"', row[0])
-        self.assertEqual('"/test2"', row[1])
-        # check total row
-        total_cols = rows[len(rows)-1].split(",")
-        self.assertEqual('"None"', total_cols[0])
-        self.assertEqual('"Aggregated"', total_cols[1])
-        # verify that the 95%, 98%, 99% and 100% percentiles are 1200
-        for value in total_cols[-4:]:
-            self.assertEqual('1200', value)
-
     def test_failure_stats_csv(self):
         stats.global_stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/failures/csv" % self.web_port)

--- a/locust/web.py
+++ b/locust/web.py
@@ -24,7 +24,7 @@ from six.moves import StringIO, xrange
 
 from . import runners
 from .runners import MasterLocustRunner
-from .stats import failures_csv, median_from_dict, requests_csv, sort_stats
+from .stats import failures_csv, median_from_dict, requests_csv, sort_stats, stats_history_csv
 from .util.cache import memoize
 from .util.rounding import proper_round
 
@@ -95,6 +95,15 @@ def reset_stats():
 def request_stats_csv():
     response = make_response(requests_csv())
     file_name = "requests_{0}.csv".format(time())
+    disposition = "attachment;filename={0}".format(file_name)
+    response.headers["Content-type"] = "text/csv"
+    response.headers["Content-disposition"] = disposition
+    return response
+
+@app.route("/stats/stats_history/csv")
+def stats_history_stats_csv():
+    response = make_response(stats_history_csv(False, True))
+    file_name = "stats_history_{0}.csv".format(time())
     disposition = "attachment;filename={0}".format(file_name)
     response.headers["Content-type"] = "text/csv"
     response.headers["Content-disposition"] = disposition

--- a/locust/web.py
+++ b/locust/web.py
@@ -24,7 +24,7 @@ from six.moves import StringIO, xrange
 
 from . import runners
 from .runners import MasterLocustRunner
-from .stats import distribution_csv, failures_csv, median_from_dict, requests_csv, sort_stats
+from .stats import failures_csv, median_from_dict, requests_csv, sort_stats
 from .util.cache import memoize
 from .util.rounding import proper_round
 
@@ -95,15 +95,6 @@ def reset_stats():
 def request_stats_csv():
     response = make_response(requests_csv())
     file_name = "requests_{0}.csv".format(time())
-    disposition = "attachment;filename={0}".format(file_name)
-    response.headers["Content-type"] = "text/csv"
-    response.headers["Content-disposition"] = disposition
-    return response
-
-@app.route("/stats/distribution/csv")
-def distribution_stats_csv():
-    response = make_response(distribution_csv())
-    file_name = "distribution_{0}.csv".format(time())
     disposition = "attachment;filename={0}".format(file_name)
     response.headers["Content-type"] = "text/csv"
     response.headers["Content-disposition"] = disposition


### PR DESCRIPTION
Adds --csv-append flag to enable appending of the metrics to CSV log file (`locust_stats_distribution`).
It allows for tracking changes in response times over the course of long test runs.