### PR TITLE
Revert "update build_url function in Locust HttpSession "

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -8,7 +8,7 @@ from requests.auth import HTTPBasicAuth
 from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
                                  RequestException)
 
-from six.moves.urllib.parse import urlparse, urlunparse, urljoin
+from six.moves.urllib.parse import urlparse, urlunparse
 
 from . import events
 from .exception import CatchResponseError, ResponseError
@@ -69,8 +69,8 @@ class HttpSession(requests.Session):
         if absolute_http_url_regexp.match(path):
             return path
         else:
-            return urljoin(self.base_url, path)
-
+            return "%s%s" % (self.base_url, path)
+    
     def request(self, method, url, name=None, catch_response=False, **kwargs):
         """
         Constructs and sends a :py:class:`requests.Request`.

--- a/locust/test/test_client.py
+++ b/locust/test/test_client.py
@@ -23,8 +23,8 @@ class TestHttpSession(WebserverTestCase):
     def test_wrong_url(self):
         for url, exception in (
                 (u"http://\x94", InvalidURL),
-                ("telnet://127.0.0.1", MissingSchema),
-                ("127.0.0.1", MissingSchema),
+                ("telnet://127.0.0.1", InvalidSchema),
+                ("127.0.0.1", MissingSchema), 
             ):
             s = HttpSession(url)
             try:


### PR DESCRIPTION
Reverts locustio/locust#1134
Unfortunately, I've found a big disadvantage of this change:
 `urljoin` from `urllib` has a surprising behavior: it cuts everything in base url after "/", if the second part of url to join starts from "/".
For example, `urljoin("http://mysite.com/api/v0", "/path/to/join")" returns a result:
`http://mysite.com/path/to/join`

It will lead to a lot of issues and errors in all existing locust tests where combined base url is used.
The only option I see is to revert this change. Sorry for inconvenience.