### PR TITLE
Docker: add home directory for locust user to install pip packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install .
 
 FROM python:3.6-alpine
 
-RUN apk --no-cache add zeromq && adduser -h / -s /bin/false -H -D locust
+RUN apk --no-cache add zeromq && adduser -s /bin/false -D locust
 COPY --from=builder /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
 COPY --from=builder /usr/local/bin/locust /usr/local/bin/locust
 COPY docker_start.sh docker_start.sh


### PR DESCRIPTION
If the user doesn't have a home directory then `pip install --user xxx` fails as there's nowhere to write to.

Resolves https://github.com/locustio/locust/issues/1149