### PR TITLE
Add toolbox control for for downloading chart as png

### DIFF
--- a/locust/static/chart.js
+++ b/locust/static/chart.js
@@ -76,6 +76,14 @@
                 series: seriesData,
                 grid: {x:60, y:70, x2:40, y2:40},
                 color: colors,
+                toolbox: {
+                    feature: {
+                        saveAsImage: {
+                            name: this.title.replace(/\s+/g, '_').toLowerCase() + '_' + Date.parse(new Date()) / 1000,
+                            title: "Download as PNG"
+                        }
+                    }
+                }
             })
         }
         


### PR DESCRIPTION
I find myself taking screenshots of the charts quite often, this adds a small button in the top right corner of the charts for downloading them as PNG images.

<img width="1440" alt="download-button" src="https://user-images.githubusercontent.com/2919796/69186043-1bb21e00-0b18-11ea-9216-47b88a6e5ee5.png">
