### PR TITLE
renamed slave to drone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 **Fixed bugs:**
 
-- autoscaling slaves resets users [\#1143](https://github.com/locustio/locust/issues/1143)
+- autoscaling drones resets users [\#1143](https://github.com/locustio/locust/issues/1143)
 - Repeated secure requests with FastHttpLocust crashes in cookie management [\#1138](https://github.com/locustio/locust/issues/1138)
 - FastHttpLocust gives ssl error with let's encrypt certs [\#1137](https://github.com/locustio/locust/issues/1137)
 - stop\_timeout defined in Locust class takes precedence over --run-time option [\#1117](https://github.com/locustio/locust/issues/1117)
@@ -52,7 +52,7 @@
 - Stop locusts graceful [\#1062](https://github.com/locustio/locust/issues/1062)
 - could we report 99.9% percentile in CSV file? [\#1040](https://github.com/locustio/locust/issues/1040)
 - Provide an official Docker image [\#849](https://github.com/locustio/locust/issues/849)
-- Number of Users Dependent on Number of slaves ?  [\#724](https://github.com/locustio/locust/issues/724)
+- Number of Users Dependent on Number of drones ?  [\#724](https://github.com/locustio/locust/issues/724)
 - Allow a fixed RPS rate [\#646](https://github.com/locustio/locust/issues/646)
 - nitpick: "\# requests" should be "\# successful requests"? [\#145](https://github.com/locustio/locust/issues/145)
 - Display percentiles in the UI instead of just min, max and average [\#140](https://github.com/locustio/locust/issues/140)
@@ -90,7 +90,7 @@
 - Exceptions tab not working for on\_start method [\#269](https://github.com/locustio/locust/issues/269)
 - Percentile response time anomalies at 100% [\#254](https://github.com/locustio/locust/issues/254)
 - log.py's StdErrWrapper swallows fatal stacktraces [\#163](https://github.com/locustio/locust/issues/163)
-- Slave count doesn't get updated in the UI if no more slaves are alive [\#62](https://github.com/locustio/locust/issues/62)
+- Slave count doesn't get updated in the UI if no more drones are alive [\#62](https://github.com/locustio/locust/issues/62)
 
 **Closed issues:**
 
@@ -109,7 +109,7 @@
 - locust's statistic collect N/A records [\#626](https://github.com/locustio/locust/issues/626)
 - how to make all locust users wait after executing on\_start method ? [\#611](https://github.com/locustio/locust/issues/611)
 - EventHook\(\) fired when locust user has stopped [\#604](https://github.com/locustio/locust/issues/604)
-- Is there a way to de-register slave with master on a slave node shutdown? [\#603](https://github.com/locustio/locust/issues/603)
+- Is there a way to de-register drone with master on a  node shutdown? [\#603](https://github.com/locustio/locust/issues/603)
 - Unable to Stop locust from Web interface occasionally [\#602](https://github.com/locustio/locust/issues/602)
 - no-web performance data saved [\#601](https://github.com/locustio/locust/issues/601)
 - Can you add or can I create a Pull Request to accept a command line option that would enable ALL events \(http requests\) to be logged to a file/location? [\#576](https://github.com/locustio/locust/issues/576)

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -10,13 +10,13 @@ _LOCUST_OPTS="-f ${LOCUSTFILE_PATH:-/locustfile.py} -H ${TARGET_URL}"
 
 if [ "${LOCUST_MODE}" = "master" ]; then
     _LOCUST_OPTS="${_LOCUST_OPTS} --master"
-elif [ "${LOCUST_MODE}" = "slave" ]; then
+elif [ "${LOCUST_MODE}" = "drone" ]; then
     if [ -z "${LOCUST_MASTER_HOST}" ]; then
-        echo "ERROR: MASTER_HOST is empty. Slave mode requires a master" >&2
+        echo "ERROR: MASTER_HOST is empty. Drone mode requires a master" >&2
         exit 1
     fi
 
-    _LOCUST_OPTS="${_LOCUST_OPTS} --slave --master-host=${LOCUST_MASTER_HOST} --master-port=${LOCUST_MASTER_PORT:-5557}"
+    _LOCUST_OPTS="${_LOCUST_OPTS} --drone --master-host=${LOCUST_MASTER_HOST} --master-port=${LOCUST_MASTER_PORT:-5557}"
 fi
 
 echo "Starting Locust in ${LOCUST_MODE} mode..."

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,20 +131,20 @@ To run Locust distributed across multiple processes we would start a master proc
     $ locust -f locust_files/my_locust_file.py --master
 
 
-and then we would start an arbitrary number of slave processes:
+and then we would start an arbitrary number of drone processes:
 
 .. code-block:: console
 
-    $ locust -f locust_files/my_locust_file.py --slave
+    $ locust -f locust_files/my_locust_file.py --drone
 
 
 If we want to run Locust distributed on multiple machines we would also have to specify the master host when
-starting the slaves (this is not needed when running Locust distributed on a single machine, since the master
+starting the drones (this is not needed when running Locust distributed on a single machine, since the master
 host defaults to 127.0.0.1):
 
 .. code-block:: console
 
-    $ locust -f locust_files/my_locust_file.py --slave --master-host=192.168.0.100
+    $ locust -f locust_files/my_locust_file.py --drone --master-host=192.168.0.100
 
 
 Parameters can also be set in a `config file <https://github.com/bw2/ConfigArgParse#config-file-syntax>`_ (locust.conf or ~/.locust.conf) or in env vars, prefixed by LOCUST\_

--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -10,24 +10,24 @@ running load tests distributed across multiple machines.
 To do this, you start one instance of Locust in master mode using the ``--master`` flag. This is 
 the instance that will be running Locust's web interface where you start the test and see live 
 statistics. The master node doesn't simulate any users itself. Instead you have to start one or 
-—most likely—multiple slave Locust nodes using the ``--slave`` flag, together with the 
+—most likely—multiple drone Locust nodes using the ``--drone`` flag, together with the
 ``--master-host`` (to specify the IP/hostname of the master node).
 
-A common set up is to run a single master on one machine, and then run one slave instance per 
-processor core, on the slave machines.
+A common set up is to run a single master on one machine, and then run one drone instance per
+processor core, on the drone machines.
 
 .. note::
-    Both the master and each slave machine, must have a copy of the locust test scripts 
+    Both the master and each drone machine, must have a copy of the locust test scripts
     when running Locust distributed. 
 
 .. note::
     It's recommended that you start a number of simulated users that are greater  than 
-    ``number of locust classes * number of slaves`` when running Locust distributed. 
+    ``number of locust classes * number of drones`` when running Locust distributed.
     
     Otherwise - due to the current implementation - 
     you might end up with a distribution of the  Locust classes that doesn't correspond to the 
-    Locust classes' ``weight`` attribute. And if the hatch rate is lower than the number of slave 
-    nodes, the hatching would occur in "bursts" where all slave node would hatch a single user and 
+    Locust classes' ``weight`` attribute. And if the hatch rate is lower than the number of drone
+    nodes, the hatching would occur in "bursts" where all drone node would hatch a single user and
     then sleep for multiple seconds, hatch another user, sleep and repeat.
 
 
@@ -38,9 +38,9 @@ To start locust in master mode::
 
     locust -f my_locustfile.py --master
 
-And then on each slave (replace ``192.168.0.14`` with IP of the master machine)::
+And then on each drone (replace ``192.168.0.14`` with IP of the master machine)::
 
-    locust -f my_locustfile.py --slave --master-host=192.168.0.14
+    locust -f my_locustfile.py --drone --master-host=192.168.0.14
 
 
 Options
@@ -52,22 +52,22 @@ Options
 Sets locust in master mode. The web interface will run on this node.
 
 
-``--slave``
+``--drone``
 -----------
 
-Sets locust in slave mode.
+Sets locust in drone mode.
 
 
 ``--master-host=X.X.X.X``
 -------------------------
 
-Optionally used together with ``--slave`` to set the hostname/IP of the master node (defaults 
+Optionally used together with ``--drone`` to set the hostname/IP of the master node (defaults
 to 127.0.0.1)
 
 ``--master-port=5557``
 ----------------------
 
-Optionally used together with ``--slave`` to set the port number of the master node (defaults to 5557). 
+Optionally used together with ``--drone`` to set the port number of the master node (defaults to 5557).
 Note that locust will use the port specified, as well as the port number +1. So if 5557 is used, locust 
 will use both port 5557 and 5558.
 
@@ -84,10 +84,10 @@ Optionally used together with ``--master``. Determines what network ports that t
 listen to. Defaults to 5557. Note that locust will use the port specified, as well as the port 
 number +1. So if 5557 is used, locust will use both port 5557 and 5558.
 
-``--expect-slaves=X``
+``--expect-drones=X``
 ---------------------
 
-Used when starting the master node with ``--no-web``. The master node will then wait until X slave 
+Used when starting the master node with ``--no-web``. The master node will then wait until X drone
 nodes has connected before the test is started.
 
 

--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -4,14 +4,14 @@
 Running Locust with Docker
 =================================
 
-To keep things simple we provide a single Docker image that can run standalone, as a master, or as a slave.
+To keep things simple we provide a single Docker image that can run standalone, as a master, or as a drone.
 
 Environment Variables
 ---------------------------------------------
 
 - ``LOCUST_MODE``
 
-One of 'standalone', 'master', or 'slave'. Defaults to 'standalone'.
+One of 'standalone', 'master', or 'drone'. Defaults to 'standalone'.
 
 - ``LOCUSTFILE_PATH``
 

--- a/docs/running-locust-without-web-ui.rst
+++ b/docs/running-locust-without-web-ui.rst
@@ -37,7 +37,7 @@ Running Locust distributed without the web UI
 ---------------------------------------------
 
 If you want to :ref:`run Locust distributed <running-locust-distributed>` without the web UI, 
-you should specify the ``--expect-slaves`` option when starting the master node, to specify 
-the number of slave nodes that are expected to connect. It will then wait until that many slave 
+you should specify the ``--expect-drones`` option when starting the master node, to specify
+the number of drone nodes that are expected to connect. It will then wait until that many drone
 nodes have connected before starting the test.
 

--- a/docs/third-party-tools.rst
+++ b/docs/third-party-tools.rst
@@ -5,9 +5,9 @@ Third party tools
 Using other languages
 =====================
 
-A Locust master and a Locust slave communicate by exchanging `msgpack <http://msgpack.org/>`_ messages, which is
+A Locust master and a Locust drone communicate by exchanging `msgpack <http://msgpack.org/>`_ messages, which is
 supported by many languages. So, you can write your Locust tasks in any languages you like. For convenience, some
-libraries do the job as a slave runner. They run your Locust tasks, and report to master regularly.
+libraries do the job as a drone runner. They run your Locust tasks, and report to master regularly.
 
 
 Golang 

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       <<: *common-env
       LOCUST_MODE: master
   
-  locust-slave:
+  locust-drone:
     <<: *common
     environment:
       <<: *common-env
-      LOCUST_MODE: slave
+      LOCUST_MODE: drone
       LOCUST_MASTER_HOST: locust-master

--- a/examples/events.py
+++ b/examples/events.py
@@ -27,7 +27,7 @@ class WebsiteUser(HttpLocust):
 We need somewhere to store the stats.
 
 On the master node stats will contain the aggregated sum of all content-lengths,
-while on the slave nodes this will be the sum of the content-lengths since the 
+while on the drone nodes this will be the sum of the content-lengths since the 
 last stats report was sent to the master
 """
 stats = {"content-length":0}
@@ -40,17 +40,17 @@ def on_request_success(request_type, name, response_time, response_length):
 
 def on_report_to_master(client_id, data):
     """
-    This event is triggered on the slave instances every time a stats report is
+    This event is triggered on the drone instances every time a stats report is
     to be sent to the locust master. It will allow us to add our extra content-length
-    data to the dict that is being sent, and then we clear the local stats in the slave.
+    data to the dict that is being sent, and then we clear the local stats in the drone.
     """
     data["content-length"] = stats["content-length"]
     stats["content-length"] = 0
 
-def on_slave_report(client_id, data):
+def on_drone_report(client_id, data):
     """
     This event is triggered on the master instance when a new stats report arrives
-    from a slave. Here we just add the content-length to the master's aggregated
+    from a drone. Here we just add the content-length to the master's aggregated
     stats dict.
     """
     stats["content-length"] += data["content-length"]
@@ -58,7 +58,7 @@ def on_slave_report(client_id, data):
 # Hook up the event listeners
 events.request_success += on_request_success
 events.report_to_master += on_report_to_master
-events.slave_report += on_slave_report
+events.drone_report += on_drone_report
 
 @web.app.route("/content-length")
 def total_content_length():

--- a/examples/vagrant/supervisord.conf
+++ b/examples/vagrant/supervisord.conf
@@ -26,9 +26,9 @@ autostart=true
 directory=/vagrant
 priority=1
 
-[program:locustslaves]
-command=locust --slave -f examples/basic.py ; TODO host should perhaps be configurable through the web UI
-process_name=slave_%(process_num)s
+[program:locustdrones]
+command=locust --drone -f examples/basic.py ; TODO host should perhaps be configurable through the web UI
+process_name=drone_%(process_num)s
 numprocs=2
 numprocs_start=1
 autostart=true

--- a/locust/events.py
+++ b/locust/events.py
@@ -71,7 +71,7 @@ Event is fired with the following arguments:
 
 report_to_master = EventHook()
 """
-*report_to_master* is used when Locust is running in --slave mode. It can be used to attach
+*report_to_master* is used when Locust is running in --drone mode. It can be used to attach
 data to the dicts that are regularly sent to the master. It's fired regularly when a report
 is to be sent to the master server.
 
@@ -83,17 +83,17 @@ Event is fired with the following arguments:
 * *data*: Data dict that can be modified in order to attach data that should be sent to the master.
 """
 
-slave_report = EventHook()
+drone_report = EventHook()
 """
-*slave_report* is used when Locust is running in --master mode and is fired when the master
-server receives a report from a Locust slave server.
+*drone_report* is used when Locust is running in --master mode and is fired when the master
+server receives a report from a Locust drone server.
 
-This event can be used to aggregate data from the locust slave servers.
+This event can be used to aggregate data from the locust drone servers.
 
 Event is fired with following arguments:
 
-* *client_id*: Client id of the reporting locust slave
-* *data*: Data dict with the data from the slave node
+* *client_id*: Client id of the reporting locust drone
+* *data*: Data dict with the data from the drone node
 """
 
 hatch_complete = EventHook()

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -48,7 +48,7 @@ $("ul.tabs").tabs("div.panes > div").on("onClick", function(event) {
 var stats_tpl = $('#stats-template');
 var errors_tpl = $('#errors-template');
 var exceptions_tpl = $('#exceptions-template');
-var slaves_tpl = $('#slave-template');
+var drones_tpl = $('#drone-template');
 
 function setHostName(hostname) {
     hostname = hostname || "";
@@ -104,7 +104,7 @@ var sortBy = function(field, reverse, primer){
 // Sorting by column
 var alternate = false; //used by jqote2.min.js
 var sortAttribute = "name";
-var slaveSortAttribute = "id";
+var droneSortAttribute = "id";
 var desc = false;
 var report;
 
@@ -147,12 +147,12 @@ function updateStats() {
 
         renderTable(report);
 
-        if (report.slaves) {
-            slaves = (report.slaves).sort(sortBy(slaveSortAttribute, desc));
-            $("#slaves tbody").empty();
+        if (report.drones) {
+            drones = (report.drones).sort(sortBy(droneSortAttribute, desc));
+            $("#drones tbody").empty();
             window.alternate = false;
-            $("#slaves tbody").jqoteapp(slaves_tpl, slaves);
-            $("#slaveCount").html(slaves.length);
+            $("#drones tbody").jqoteapp(drones_tpl, drones);
+            $("#droneCount").html(drones.length);
         }
 
         if (report.state !== "stopped"){

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -80,7 +80,7 @@ a:hover {
     max-width: 165px;
     word-wrap: break-word;
 }
-.boxes .box_rps .value, .boxes .box_slaves .value {
+.boxes .box_rps .value, .boxes .box_drones .value {
     font-size: 32px;
 }
 .boxes .box_fail .value {

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -646,7 +646,7 @@ def on_report_to_master(client_id, data):
     data["errors"] =  global_stats.serialize_errors()
     global_stats.errors = {}
 
-def on_slave_report(client_id, data):
+def on_drone_report(client_id, data):
     for stats_data in data["stats"]:
         entry = StatsEntry.unserialize(stats_data)
         request_key = (entry.name, entry.method)
@@ -667,7 +667,7 @@ def on_slave_report(client_id, data):
     global_stats.total.extend(StatsEntry.unserialize(data["stats_total"]))
     if global_stats.total.last_request_timestamp and global_stats.total.last_request_timestamp > (old_last_request_timestamp or 0):
         # If we've entered a new second, we'll cache the response times. Note that there 
-        # might still be reports from other slave nodes - that contains requests for the same 
+        # might still be reports from other drone nodes - that contains requests for the same
         # time periods - that hasn't been received/accounted for yet. This will cause the cache to 
         # lag behind a second or two, but since StatsEntry.current_response_time_percentile() 
         # (which is what the response times cache is used for) uses an approximation of the 
@@ -678,7 +678,7 @@ def on_slave_report(client_id, data):
 events.request_success += on_request_success
 events.request_failure += on_request_failure
 events.report_to_master += on_report_to_master
-events.slave_report += on_slave_report
+events.drone_report += on_drone_report
 
 
 def print_stats(stats, current=True):

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -28,9 +28,9 @@
                     <a href="#" class="edit_test">Edit</a>
                 </div>
                 {% if is_distributed %}
-                    <div class="top_box box_slaves" id="box_slaves">
-                        <div class="label">SLAVES</div>
-                        <div class="value" id="slaveCount">0</div>
+                    <div class="top_box box_drones" id="box_drones">
+                        <div class="label">DRONES</div>
+                        <div class="value" id="droneCount">0</div>
                     </div>
                 {% endif %}
                 <div class="top_box box_rps box_running" id="box_rps">
@@ -101,7 +101,7 @@
                     <li><a href="#">Exceptions</a></li>
                     <li><a href="#">Download Data</a></li>
                     {% if is_distributed %}
-                    <li><a href="#">Slaves</a></li>
+                    <li><a href="#">Drones</a></li>
                     {% endif %}
                 </ul>
             </nav>
@@ -163,12 +163,12 @@
                     </div>
                 </div>
                 <div style="display:none;">
-                    <table id="slaves">
+                    <table id="drones">
                         <thead>
                             <tr>
-                                <th class="stats_label" href="#" data-sortkey="id">Slave</th>
+                                <th class="stats_label" href="#" data-sortkey="id">Drone</th>
                                 <th class="stats_label" href="#" data-sortkey="state">State</th>
-                                <th class="stats_label numeric" href="#" data-sortkey="user_count" title="Number of users on this slave"># users</th>
+                                <th class="stats_label numeric" href="#" data-sortkey="user_count" title="Number of users on this drone"># users</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -265,7 +265,7 @@
         <% alternate = !alternate; %>
         ]]>
     </script>
-    <script type="text/x-jqote-template" id="slave-template">
+    <script type="text/x-jqote-template" id="drone-template">
         <![CDATA[
         <tr class="<%=(alternate ? "dark" : "")%> <%=(this.name == "Total" ? "total" : "")%>">
             <td><%= this.id %></td>

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -9,8 +9,8 @@ from locust import events
 from locust.core import Locust, TaskSet, task
 from locust.exception import LocustError
 from locust.rpc import Message
-from locust.runners import LocustRunner, LocalLocustRunner, MasterLocustRunner, SlaveNode, \
-     SlaveLocustRunner, STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_MISSING
+from locust.runners import LocustRunner, LocalLocustRunner, MasterLocustRunner, DroneNode, \
+     DroneLocustRunner, STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_MISSING
 from locust.stats import global_stats, RequestStats
 from locust.test.testcases import LocustTestCase
 from locust.wait_time import between, constant
@@ -138,14 +138,14 @@ class TestMasterRunner(LocustTestCase):
     def setUp(self):
         super(TestMasterRunner, self).setUp()
         global_stats.reset_all()
-        self._slave_report_event_handlers = [h for h in events.slave_report._handlers]
+        self._drone_report_event_handlers = [h for h in events.drone_report._handlers]
         self.options = mocked_options()
         
     def tearDown(self):
-        events.slave_report._handlers = self._slave_report_event_handlers
+        events.drone_report._handlers = self._drone_report_event_handlers
         super(TestMasterRunner, self).tearDown()
     
-    def test_slave_connect(self):
+    def test_drone_connect(self):
         class MyTestLocust(Locust):
             pass
         
@@ -162,7 +162,7 @@ class TestMasterRunner(LocustTestCase):
             server.mocked_send(Message("quit", None, "zeh_fake_client3"))
             self.assertEqual(3, len(master.clients))
     
-    def test_slave_stats_report_median(self):
+    def test_drone_stats_report_median(self):
         class MyTestLocust(Locust):
             pass
         
@@ -182,7 +182,7 @@ class TestMasterRunner(LocustTestCase):
             s = master.stats.get("/", "GET")
             self.assertEqual(700, s.median_response_time)
 
-    def test_slave_stats_report_with_none_response_times(self):
+    def test_drone_stats_report_with_none_response_times(self):
         class MyTestLocust(Locust):
             pass
         
@@ -211,7 +211,7 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(0, s2.median_response_time)
             self.assertEqual(0, s2.avg_response_time)
 
-    def test_master_marks_downed_slaves_as_missing(self):
+    def test_master_marks_downed_drones_as_missing(self):
         class MyTestLocust(Locust):
             pass
 
@@ -333,16 +333,16 @@ class TestMasterRunner(LocustTestCase):
                 self.assertEqual(30, master.stats.total.get_current_response_time_percentile(0.5))
                 self.assertEqual(3000, master.stats.total.get_current_response_time_percentile(0.95))
     
-    def test_sends_hatch_data_to_ready_running_hatching_slaves(self):
-        '''Sends hatch job to running, ready, or hatching slaves'''
+    def test_sends_hatch_data_to_ready_running_hatching_drones(self):
+        '''Sends hatch job to running, ready, or hatching drones'''
         class MyTestLocust(Locust):
             pass
 
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = MasterLocustRunner(MyTestLocust, self.options)
-            master.clients[1] = SlaveNode(1)
-            master.clients[2] = SlaveNode(2)
-            master.clients[3] = SlaveNode(3)
+            master.clients[1] = DroneNode(1)
+            master.clients[2] = DroneNode(2)
+            master.clients[3] = DroneNode(3)
             master.clients[1].state = STATE_INIT
             master.clients[2].state = STATE_HATCHING
             master.clients[3].state = STATE_RUNNING
@@ -376,7 +376,7 @@ class TestMasterRunner(LocustTestCase):
     def test_spawn_uneven_locusts(self):
         """
         Tests that we can accurately spawn a certain number of locusts, even if it's not an 
-        even number of the connected slaves
+        even number of the connected drones
         """
         class MyTestLocust(Locust):
             pass
@@ -395,7 +395,7 @@ class TestMasterRunner(LocustTestCase):
             
             self.assertEqual(7, num_clients, "Total number of locusts that would have been spawned is not 7")
     
-    def test_spawn_fewer_locusts_than_slaves(self):
+    def test_spawn_fewer_locusts_than_drones(self):
         class MyTestLocust(Locust):
             pass
         
@@ -481,17 +481,17 @@ class TestMasterRunner(LocustTestCase):
         self.assertEqual(2, exception["count"])
 
 
-class TestSlaveLocustRunner(LocustTestCase):
+class TestDroneLocustRunner(LocustTestCase):
     def setUp(self):
-        super(TestSlaveLocustRunner, self).setUp()
+        super(TestDroneLocustRunner, self).setUp()
         global_stats.reset_all()
         self._report_to_master_event_handlers = [h for h in events.report_to_master._handlers]
         
     def tearDown(self):
         events.report_to_master._handlers = self._report_to_master_event_handlers
-        super(TestSlaveLocustRunner, self).tearDown()
+        super(TestDroneLocustRunner, self).tearDown()
     
-    def test_slave_stop_timeout(self):
+    def test_drone_stop_timeout(self):
         class MyTestLocust(Locust):
             _test_state = 0
             class task_set(TaskSet):
@@ -504,7 +504,7 @@ class TestSlaveLocustRunner(LocustTestCase):
         
         with mock.patch("locust.rpc.rpc.Client", mocked_rpc()) as client:
             options = mocked_options()
-            slave = SlaveLocustRunner([MyTestLocust], options)
+            drone = DroneLocustRunner([MyTestLocust], options)
             self.assertEqual(1, len(client.outbox))
             self.assertEqual("client_ready", client.outbox[0].type)
             client.mocked_send(Message("hatch", {
@@ -514,20 +514,20 @@ class TestSlaveLocustRunner(LocustTestCase):
                 "stop_timeout": 1,
             }, "dummy_client_id"))
             #print("outbox:", client.outbox)
-            # wait for slave to hatch locusts
+            # wait for drone to hatch locusts
             self.assertIn("hatching", [m.type for m in client.outbox])
-            slave.hatching_greenlet.join()
-            self.assertEqual(1, len(slave.locusts))
+            drone.hatching_greenlet.join()
+            self.assertEqual(1, len(drone.locusts))
             # check that locust has started running
             gevent.sleep(0.01)
             self.assertEqual(1, MyTestLocust._test_state)
             # send stop message
             client.mocked_send(Message("stop", None, "dummy_client_id"))
-            slave.locusts.join()
+            drone.locusts.join()
             # check that locust user got to finish
             self.assertEqual(2, MyTestLocust._test_state)
     
-    def test_slave_without_stop_timeout(self):
+    def test_drone_without_stop_timeout(self):
         class MyTestLocust(Locust):
             _test_state = 0
             class task_set(TaskSet):
@@ -541,7 +541,7 @@ class TestSlaveLocustRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.Client", mocked_rpc()) as client:
             options = mocked_options()
             options.stop_timeout = None
-            slave = SlaveLocustRunner([MyTestLocust], options)
+            drone = DroneLocustRunner([MyTestLocust], options)
             self.assertEqual(1, len(client.outbox))
             self.assertEqual("client_ready", client.outbox[0].type)
             client.mocked_send(Message("hatch", {
@@ -551,16 +551,16 @@ class TestSlaveLocustRunner(LocustTestCase):
                 "stop_timeout": None,
             }, "dummy_client_id"))
             #print("outbox:", client.outbox)
-            # wait for slave to hatch locusts
+            # wait for drone to hatch locusts
             self.assertIn("hatching", [m.type for m in client.outbox])
-            slave.hatching_greenlet.join()
-            self.assertEqual(1, len(slave.locusts))
+            drone.hatching_greenlet.join()
+            self.assertEqual(1, len(drone.locusts))
             # check that locust has started running
             gevent.sleep(0.01)
             self.assertEqual(1, MyTestLocust._test_state)
             # send stop message
             client.mocked_send(Message("stop", None, "dummy_client_id"))
-            slave.locusts.join()
+            drone.locusts.join()
             # check that locust user did not get to finish
             self.assertEqual(1, MyTestLocust._test_state)
             

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -241,7 +241,7 @@ class TestRequestStats(unittest.TestCase):
         """
         Serialize a RequestStats instance, then serialize it through a Message, 
         and unserialize the whole thing again. This is done "IRL" when stats are sent 
-        from slaves to master.
+        from drones to master.
         """
         s1 = StatsEntry(self.stats, "test", "GET")
         s1.log(10, 0)

--- a/locust/web.py
+++ b/locust/web.py
@@ -41,9 +41,9 @@ app.root_path = os.path.dirname(os.path.abspath(__file__))
 def index():
     is_distributed = isinstance(runners.locust_runner, MasterLocustRunner)
     if is_distributed:
-        slave_count = runners.locust_runner.slave_count
+        drone_count = runners.locust_runner.drone_count
     else:
-        slave_count = 0
+        drone_count = 0
     
     override_host_warning = False
     if runners.locust_runner.host:
@@ -156,11 +156,11 @@ def request_stats():
     
     is_distributed = isinstance(runners.locust_runner, MasterLocustRunner)
     if is_distributed:
-        slaves = []
-        for slave in runners.locust_runner.clients.values():
-            slaves.append({"id":slave.id, "state":slave.state, "user_count": slave.user_count})
+        drones = []
+        for drone in runners.locust_runner.clients.values():
+            drones.append({"id":drone.id, "state":drone.state, "user_count": drone.user_count})
 
-        report["slaves"] = slaves
+        report["drones"] = drones
     
     report["state"] = runners.locust_runner.state
     report["user_count"] = runners.locust_runner.user_count


### PR DESCRIPTION
# Motivation
Be more inclusive and support better open source practices remove the offensive term 'slave' most often used to reference human rights abuses. See previous examples of similar name changes by other leading open source projects: Python (https://bugs.python.org/issue34605), Drupal (https://www.drupal.org/node/2275877), Django (https://github.com/django/django/pull/2692), Jenkins (https://issues.jenkins-ci.org/browse/JENKINS-29522) et al.

# Proposed Resolution
Rename word 'slave' to 'drone' as seems to match Locust's use case. Industry recommendations for alternate terms: https://www.theserverside.com/opinion/Master-slave-terminology-alternatives-you-can-use-right-now 
