### PR TITLE
Set names of Locust classes to run from web or from master to slaves

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -245,7 +245,7 @@ class LocalLocustRunner(LocustRunner):
             self.log_exception("local", str(exception), formatted_tb)
         events.locust_error += on_locust_error
 
-    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False, class_names=False):
+    def start_hatching(self, locust_count=None, hatch_rate=None, wait=False, class_names=None):
         self.hatching_greenlet = gevent.spawn(lambda: super(LocalLocustRunner, self).start_hatching(locust_count, hatch_rate, wait=wait, class_names=class_names))
         self.greenlet = self.hatching_greenlet
 
@@ -478,7 +478,9 @@ class SlaveLocustRunner(DistributedLocustRunner):
                 #self.num_clients = job["num_clients"]
                 self.host = job["host"]
                 self.options.stop_timeout = job["stop_timeout"]
-                self.hatching_greenlet = gevent.spawn(lambda: self.start_hatching(locust_count=job["num_clients"], hatch_rate=job["hatch_rate"]))
+                self.hatching_greenlet = gevent.spawn(lambda: self.start_hatching(locust_count=job["num_clients"],
+                                                                                  hatch_rate=job["hatch_rate"],
+                                                                                  class_names=job["class_names"]))
             elif msg.type == "stop":
                 self.stop()
                 self.client.send(Message("client_stopped", None, self.client_id))

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -460,8 +460,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
 
     def set_locust_classes(self, class_names):
         """Set the Locust classes to run from the original set"""
-        if class_names:
-            self.locust_classes = [cls for cls in self.orig_locust_classes if cls.__name__ in class_names]
+        self.locust_classes = [cls for cls in self.orig_locust_classes if cls.__name__ in class_names]
 
     def worker(self):
         while True:

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -204,7 +204,14 @@ a:hover {
 .edit button:hover {
     background: #74b99d;
 }
-
+.start select.val {
+    border: none;
+    background: #fff;
+    height: 90px;
+    width: 328px;
+    font-size: 24px;
+    padding-left: 10px;
+}
 
 .stopped .start {
     display: none;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -59,8 +59,11 @@
                 <h2>Start new Locust swarm</h2>
                 <form action="./swarm" method="POST" id="swarm_form">
                     <label for="class_names">Locust classes to run</label>
-                    <input type="text" name="class_names" id="class_names" class="val" autocapitalize="off"
-                           autocorrect="off" value="{{ ",".join(class_names) }}" /><br>
+                    <select name="class_names" id="class_names" class="val" multiple>
+                        {% for n in class_names %}
+                            <option value="{{ n }}">{{ n }}</option>
+                        {% endfor %}
+                    </select>
                     <label for="locust_count">Number of total users to simulate</label>
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -58,6 +58,9 @@
             <div class="padder">
                 <h2>Start new Locust swarm</h2>
                 <form action="./swarm" method="POST" id="swarm_form">
+                    <label for="class_names">Locust classes to run</label>
+                    <input type="text" name="class_names" id="class_names" class="val" autocapitalize="off"
+                           autocorrect="off" value="{{ ",".join(class_names) }}" /><br>
                     <label for="locust_count">Number of users to simulate</label>
                     <input type="text" name="locust_count" id="locust_count" class="val" /><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -419,7 +419,7 @@ class TestMasterRunner(LocustTestCase):
             pass
         
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
-            master = MasterLocustRunner(MyTestLocust, self.options)
+            master = MasterLocustRunner([MyTestLocust], self.options)
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -339,7 +339,7 @@ class TestMasterRunner(LocustTestCase):
             pass
 
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
-            master = MasterLocustRunner(MyTestLocust, self.options)
+            master = MasterLocustRunner([MyTestLocust], self.options)
             master.clients[1] = SlaveNode(1)
             master.clients[2] = SlaveNode(2)
             master.clients[3] = SlaveNode(3)
@@ -382,7 +382,7 @@ class TestMasterRunner(LocustTestCase):
             pass
         
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
-            master = MasterLocustRunner(MyTestLocust, self.options)
+            master = MasterLocustRunner([MyTestLocust], self.options)
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
             
@@ -400,7 +400,7 @@ class TestMasterRunner(LocustTestCase):
             pass
         
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
-            master = MasterLocustRunner(MyTestLocust, self.options)
+            master = MasterLocustRunner([MyTestLocust], self.options)
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
             
@@ -512,6 +512,7 @@ class TestSlaveLocustRunner(LocustTestCase):
                 "num_clients": 1,
                 "host": "",
                 "stop_timeout": 1,
+                "class_names": ["MyTestLocust"]
             }, "dummy_client_id"))
             #print("outbox:", client.outbox)
             # wait for slave to hatch locusts
@@ -549,6 +550,7 @@ class TestSlaveLocustRunner(LocustTestCase):
                 "num_clients": 1,
                 "host": "",
                 "stop_timeout": None,
+                "class_names": ["MyTestLocust"]
             }, "dummy_client_id"))
             #print("outbox:", client.outbox)
             # wait for slave to hatch locusts

--- a/locust/web.py
+++ b/locust/web.py
@@ -76,7 +76,7 @@ def index():
 def swarm():
     assert request.method == "POST"
 
-    hatch_names = [n for n in request.form["class_names"].split(",") if n in class_names()]
+    hatch_names = [n.strip() for n in request.form["class_names"].split(",") if n.strip() in class_names()]
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
     if (request.form.get("host")):

--- a/locust/web.py
+++ b/locust/web.py
@@ -81,9 +81,7 @@ def index():
 def swarm():
     assert request.method == "POST"
 
-    hatch_names = [n.strip()
-                   for n in request.form["class_names"].split(",")
-                   if n.strip() in class_names()] if request.form.get("class_names") else []
+    hatch_names = request.form.getlist("class_names")
     is_step_load = runners.locust_runner.step_load
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])

--- a/locust/web.py
+++ b/locust/web.py
@@ -36,6 +36,8 @@ app = Flask(__name__)
 app.debug = True
 app.root_path = os.path.dirname(os.path.abspath(__file__))
 
+def class_names():
+    return [cls.__name__ for cls in runners.locust_runner.locust_classes]
 
 @app.route('/')
 def index():
@@ -67,17 +69,19 @@ def index():
         version=version,
         host=host,
         override_host_warning=override_host_warning,
+        class_names=class_names(),
     )
 
 @app.route('/swarm', methods=["POST"])
 def swarm():
     assert request.method == "POST"
 
+    hatch_names = [n for n in request.form["class_names"].split(",") if n in class_names()]
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
     if (request.form.get("host")):
         runners.locust_runner.host = str(request.form["host"]) 
-    runners.locust_runner.start_hatching(locust_count, hatch_rate)
+    runners.locust_runner.start_hatching(locust_count, hatch_rate, class_names=hatch_names)
     return jsonify({'success': True, 'message': 'Swarming started', 'host': runners.locust_runner.host})
 
 @app.route('/stop')

--- a/locust/web.py
+++ b/locust/web.py
@@ -76,7 +76,9 @@ def index():
 def swarm():
     assert request.method == "POST"
 
-    hatch_names = [n.strip() for n in request.form["class_names"].split(",") if n.strip() in class_names()]
+    hatch_names = [n.strip()
+                   for n in request.form["class_names"].split(",")
+                   if n.strip() in class_names()] if request.form.get("class_names") else []
     locust_count = int(request.form["locust_count"])
     hatch_rate = float(request.form["hatch_rate"])
     if (request.form.get("host")):


### PR DESCRIPTION
# Summary

Set the names of Locust classes to run, either from the web interface or from the master command line.

This change means that slaves can be started without specifying which Locust classes they will run. Instead they are instructed to hatch only certain Locust classes by the master. The list of classes can come from the master command line or from the web interface.

## Web mode

A set of slaves is started with a locustfile that contains a number of Locust classes. The master is started in web mode with the same locustfile. The web form includes a text box with a comma-separated list of available class names.

If a subset of Locust class names is entered in the box, only those classes are run by all the slaves. Unrecognised strings are ignored.

A subset of Locust classes can also be run in local mode.

## Non-web mode

In non-web mode, slaves quit when the master quits. 

But slaves are instructed which Locust classes to run by the master so they can be started with the same command line. For example, a slave can be started with:
```bash
locust --slave --master-host=$MASTER_HOST -f locustfile.py
```
and will run different Locust classes in these two cases:
```bash
locust --master --host=$TARGET_HOST -c 10 -r 1 -t 20m -f locustfile.py Locust1
locust --master --host=$TARGET_HOST -c 10 -r 1 -t 20m -f locustfile.py Locust2
```

This makes it possible to have self-restarting slaves (e.g. in a script loop).