### PR TITLE
Fix link formatting for the Helm chart

### DIFF
--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -56,4 +56,4 @@ To run in standalone mode without the web UI, you can use the ``LOCUST_OPTS`` en
     docker run --volume $PWD/dir/of/locustfile:/mnt/locust -e LOCUSTFILE_PATH=/mnt/locust/locustfile.py -e TARGET_URL=https://abc.com -e LOCUST_OPTS="--clients=10 --no-web --run-time=600" locustio/locust
 
 
-If you are Kubernetes user, you can use the [Helm chart](https://github.com/helm/charts/tree/master/stable/locust) to scale and run locust.
+If you are Kubernetes user, you can use the `Helm chart <https://github.com/helm/charts/tree/master/stable/locust>`_ to scale and run locust.


### PR DESCRIPTION
The link was in Markdown, rather than reStructuredText.