### PR TITLE
Add "Running Locust with Docker" to the TOC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Running your Locust tests
     :maxdepth: 1
 
     running-locust-distributed
+    running-locust-docker
     running-locust-without-web-ui
     increase-performance
 


### PR DESCRIPTION
Without this, the only way to find the page is by either search, or happening on the link at the bottom of "Running Locust distributed".

Luckily, Google had indexed the page despite not being in the TOC, or I'd have never seen it.