### PR TITLE
Drop support for pre 3.6 Python versions (give error during installation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
       env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 2.7
-      env: TOXENV=py27
     - stage: Verify Docker image builds
       script: docker build -t locustio/locust .
 addons:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ For full details of the Locust changelog, please see https://github.com/locustio
 In development (master)
 =======================
 
+* Drop Python 2 and Python 3.5 support!
 * Continuously measure CPU usage and emit a warning if we get a five second average above 90%
 * Show CPU usage of slave nodes in the Web UI
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,17 +3,10 @@ Installation
 
 Locust is available on `PyPI <https://pypi.org/project/locustio/>`_ and can be installed with `pip <https://pip.pypa.io/>`_.
 
-for Python 2.7:
 
 .. code-block:: console
 
-    $ pip install locustio
-
-for Python 3:
-
-.. code-block:: console
-
-    $ pip3 install locustio
+    $ pip3 install locust
 
 If you want the bleeding edge version, you can use pip to install directly from our Git repository.  For example, to install the master branch using Python 3:
 
@@ -34,7 +27,7 @@ To see available options, run:
 Supported Python Versions
 -------------------------
 
-Locust is supported on Python 2.7, 3.5, 3.6, 3.7 and 3.8.
+Locust is supported on Python 3.6, 3.7 and 3.8.
 
 
 Installing Locust on Windows

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import HttpLocust, Locust, TaskSet, TaskSequence, task, seq_task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .wait_time import between, constant, constant_pacing
 
-__version__ = "0.13.5"
+__version__ = "0.14.0"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import ast
 import os
 import re
+import sys
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import os
 import re
 
 from setuptools import find_packages, setup
-
+from setuptools.command.develop import develop
+from setuptools.command.install import install
 
 # parse version from locust/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
@@ -12,6 +13,16 @@ _init_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "locust", 
 with open(_init_file, 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
+
+class PostDevelopCommand(develop):
+    def run(self):
+        if sys.version_info[0] < 3 or sys.version_info[1] < 6:
+            sys.exit("Your Python version is no longer supported by Locust. Please upgrade Python to at least 3.6, or use a pinned old locust version (pip/pip3 install locustio==0.13.5)")
+
+class PostInstallCommand(install):
+    def run(self):
+        if sys.version_info[0] < 3 or sys.version_info[1] < 6:
+            sys.exit("Your Python version is no longer supported by Locust. Please upgrade Python to at least 3.6, or use a pinned old locust version (pip/pip3 install locustio==0.13.5)")
 
 setup(
     name='locustio',
@@ -59,5 +70,9 @@ setup(
         'console_scripts': [
             'locust = locust.main:main',
         ]
+    },    
+    cmdclass={
+        'develop': PostDevelopCommand,
+        'install': PostInstallCommand,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,13 @@ class PostDevelopCommand(develop):
     def run(self):
         if sys.version_info[0] < 3 or sys.version_info[1] < 6:
             sys.exit("Your Python version is no longer supported by Locust. Please upgrade Python to at least 3.6, or use a pinned old locust version (pip/pip3 install locustio==0.13.5)")
+        develop.run(self)
 
 class PostInstallCommand(install):
     def run(self):
         if sys.version_info[0] < 3 or sys.version_info[1] < 6:
             sys.exit("Your Python version is no longer supported by Locust. Please upgrade Python to at least 3.6, or use a pinned old locust version (pip/pip3 install locustio==0.13.5)")
+        install.run(self)
 
 setup(
     name='locustio',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}
+envlist = py{36,37,38}
 
 [testenv]
 deps =


### PR DESCRIPTION
Future releases will just not show support for these versions (so they wont be installed by pip), but this way we can show users what to do instead of just giving them an old package.

Solves #1120 