### PR TITLE
docs: remove the description of port 5558

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=builder /usr/local/bin/locust /usr/local/bin/locust
 COPY docker_start.sh docker_start.sh
 RUN chmod +x docker_start.sh
 
-EXPOSE 8089 5557 5558
+EXPOSE 8089 5557
 
 USER locust
 CMD ["./docker_start.sh"]

--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -67,9 +67,7 @@ to 127.0.0.1)
 ``--master-port=5557``
 ----------------------
 
-Optionally used together with ``--slave`` to set the port number of the master node (defaults to 5557). 
-Note that locust will use the port specified, as well as the port number +1. So if 5557 is used, locust 
-will use both port 5557 and 5558.
+Optionally used together with ``--slave`` to set the port number of the master node (defaults to 5557).
 
 ``--master-bind-host=X.X.X.X``
 ------------------------------
@@ -81,8 +79,7 @@ will bind to. Defaults to * (all available interfaces).
 ------------------------------
 
 Optionally used together with ``--master``. Determines what network ports that the master node will
-listen to. Defaults to 5557. Note that locust will use the port specified, as well as the port 
-number +1. So if 5557 is used, locust will use both port 5557 and 5558.
+listen to. Defaults to 5557.
 
 ``--expect-slaves=X``
 ---------------------

--- a/locust/main.py
+++ b/locust/main.py
@@ -99,7 +99,7 @@ def parse_options(args=None, default_config_files=['~/.locust.conf','locust.conf
         '--master-port',
         type=int,
         default=5557,
-        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --slave. Defaults to 5557. Note that slaves will also connect to the master node on this port + 1."
+        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --slave. Defaults to 5557."
     )
 
     parser.add_argument(
@@ -112,7 +112,7 @@ def parse_options(args=None, default_config_files=['~/.locust.conf','locust.conf
         '--master-bind-port',
         type=int,
         default=5557,
-        help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557. Note that Locust will also use this port + 1, so by default the master node will bind to 5557 and 5558."
+        help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557."
     )
 
     parser.add_argument(


### PR DESCRIPTION
I remove the description of port 5558.
locust hadn't bind two sockets since from #927