### PR TITLE
ensure the connection between master and slave in heartbeat

### DIFF
--- a/locust/exception.py
+++ b/locust/exception.py
@@ -37,3 +37,10 @@ class RescheduleTaskImmediately(Exception):
     """
     When raised in a Locust task, another locust task will be rescheduled immediately
     """
+
+class RPCError(Exception):
+    """
+    Exception that shows bad or broken network.
+
+    When raised from zmqrpc, RPC should be reestablished.
+    """

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,7 +1,9 @@
 import zmq.green as zmq
-
 from .protocol import Message
 from locust.util.exception_handler import retry
+from locust.exception import RPCError
+import zmq.error as zmqerr
+import msgpack.exceptions as msgerr
 
 class BaseSocket(object):
     def __init__(self, sock_type):
@@ -13,23 +15,37 @@ class BaseSocket(object):
     
     @retry()
     def send(self, msg):
-        self.socket.send(msg.serialize(), zmq.NOBLOCK)
+        try:
+            self.socket.send(msg.serialize(), zmq.NOBLOCK)
+        except zmqerr.ZMQError as e:
+            raise RPCError("ZMQ sent failure: %s" % (e) )
 
     @retry()
     def send_to_client(self, msg):
-        self.socket.send_multipart([msg.node_id.encode(), msg.serialize()])
+        try:
+            self.socket.send_multipart([msg.node_id.encode(), msg.serialize()])
+        except zmqerr.ZMQError as e:
+            raise RPCError("ZMQ sent failure: %s" % (e) )
 
-    @retry()
     def recv(self):
-        data = self.socket.recv()
-        msg = Message.unserialize(data)
+        try:
+            data = self.socket.recv()
+            msg = Message.unserialize(data)
+        except msgerr.ExtraData as e:
+            raise RPCError("Interrupted message: %s" % (e) )
+        except zmqerr.ZMQError as e:
+            raise RPCError("Network broken: %s" % (e) )
         return msg
 
-    @retry()
     def recv_from_client(self):
-        data = self.socket.recv_multipart()
-        addr = data[0].decode()
-        msg = Message.unserialize(data[1])
+        try:
+            data = self.socket.recv_multipart()
+            addr = data[0].decode()
+            msg = Message.unserialize(data[1])
+        except (UnicodeDecodeError, msgerr.ExtraData) as e:
+            raise RPCError("Interrupted message: %s" % (e) )
+        except zmqerr.ZMQError as e:
+            raise RPCError("Network broken: %s" % (e) )
         return addr, msg
 
     def close(self):
@@ -41,12 +57,14 @@ class Server(BaseSocket):
         if port == 0:
             self.port = self.socket.bind_to_random_port("tcp://%s" % host)
         else:
-            self.socket.bind("tcp://%s:%i" % (host, port))
-            self.port = port
+            try:
+                self.socket.bind("tcp://%s:%i" % (host, port))
+                self.port = port
+            except zmqerr.ZMQError as e:
+                raise RPCError("Socket bind failure: %s" % (e) )
 
 class Client(BaseSocket):
     def __init__(self, host, port, identity):
         BaseSocket.__init__(self, zmq.DEALER)
         self.socket.setsockopt(zmq.IDENTITY, identity.encode())
         self.socket.connect("tcp://%s:%i" % (host, port))
-        

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -13,7 +13,7 @@ class BaseSocket(object):
     
     @retry()
     def send(self, msg):
-        self.socket.send(msg.serialize())
+        self.socket.send(msg.serialize(), zmq.NOBLOCK)
 
     @retry()
     def send_to_client(self, msg):
@@ -31,6 +31,9 @@ class BaseSocket(object):
         addr = data[0].decode()
         msg = Message.unserialize(data[1])
         return addr, msg
+
+    def close(self):
+        self.socket.close()
 
 class Server(BaseSocket):
     def __init__(self, host, port):

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -18,23 +18,23 @@ class BaseSocket(object):
         try:
             self.socket.send(msg.serialize(), zmq.NOBLOCK)
         except zmqerr.ZMQError as e:
-            raise RPCError("ZMQ sent failure: %s" % (e) )
+            raise RPCError("ZMQ sent failure") from e
 
     @retry()
     def send_to_client(self, msg):
         try:
             self.socket.send_multipart([msg.node_id.encode(), msg.serialize()])
         except zmqerr.ZMQError as e:
-            raise RPCError("ZMQ sent failure: %s" % (e) )
+            raise RPCError("ZMQ sent failure") from e
 
     def recv(self):
         try:
             data = self.socket.recv()
             msg = Message.unserialize(data)
         except msgerr.ExtraData as e:
-            raise RPCError("Interrupted message: %s" % (e) )
+            raise RPCError("ZMQ interrupted message") from e
         except zmqerr.ZMQError as e:
-            raise RPCError("Network broken: %s" % (e) )
+            raise RPCError("ZMQ network broken") from e
         return msg
 
     def recv_from_client(self):
@@ -43,9 +43,9 @@ class BaseSocket(object):
             addr = data[0].decode()
             msg = Message.unserialize(data[1])
         except (UnicodeDecodeError, msgerr.ExtraData) as e:
-            raise RPCError("Interrupted message: %s" % (e) )
+            raise RPCError("ZMQ interrupted message") from e
         except zmqerr.ZMQError as e:
-            raise RPCError("Network broken: %s" % (e) )
+            raise RPCError("ZMQ network broken") from e
         return addr, msg
 
     def close(self):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -495,7 +495,8 @@ class WorkerLocustRunner(DistributedLocustRunner):
     def __init__(self, *args, master_host, master_port, **kwargs):
         super().__init__(*args, **kwargs)
         self.client_id = socket.gethostname() + "_" + uuid4().hex
-        
+        self.master_host = master_host
+        self.master_port = master_port
         self.client = rpc.Client(master_host, master_port, self.client_id)
         self.greenlet.spawn(self.heartbeat).link_exception(callback=self.noop)
         self.greenlet.spawn(self.worker).link_exception(callback=self.noop)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -307,6 +307,8 @@ class MasterLocustRunner(DistributedLocustRunner):
         super().__init__(*args, **kwargs)
         self.worker_cpu_warning_emitted = False
         self.target_user_count = None
+        self.master_bind_host = master_bind_host
+        self.master_bind_port = master_bind_port
 
         class WorkerNodesDict(dict):
             def get_by_state(self, state):

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -3,7 +3,7 @@ from time import sleep
 import zmq
 from locust.rpc import zmqrpc, Message
 from locust.test.testcases import LocustTestCase
-
+from locust.exception import RPCError
 
 class ZMQRPC_tests(LocustTestCase):
     def setUp(self):
@@ -12,8 +12,8 @@ class ZMQRPC_tests(LocustTestCase):
         self.client = zmqrpc.Client('localhost', self.server.port, 'identity')
 
     def tearDown(self):
-        self.server.socket.close()
-        self.client.socket.close()
+        self.server.close()
+        self.client.close()
         super(ZMQRPC_tests, self).tearDown()
 
     def test_constructor(self):
@@ -42,5 +42,15 @@ class ZMQRPC_tests(LocustTestCase):
     def test_client_retry(self):
         server = zmqrpc.Server('127.0.0.1', 0)
         server.socket.close()
-        with self.assertRaises(zmq.error.ZMQError):
+        with self.assertRaises(RPCError):
             server.recv_from_client()
+
+    def test_rpc_error(self):
+        server = zmqrpc.Server('127.0.0.1', 5557)
+        with self.assertRaises(RPCError):
+            server = zmqrpc.Server('127.0.0.1', 5557)
+        server.close()
+        with self.assertRaises(RPCError):
+            server.send_to_client(Message('test', 'message', 'identity'))
+        
+    


### PR DESCRIPTION
With heartbeating enabled, I still noticed network issues (packet drop, invalid byte stream) in long-term running on k8s cluster (overlay network). 

And a straightforward fix is to reestablish the connection when any network issue is detected.

I've applied this fix in my locust tests for one week's running, and it works as expected.
