### PR TITLE
Give a more descriptive error when the Locust or TaskSet has no tasks.

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -465,6 +465,8 @@ class TaskSet(object, metaclass=TaskSetMeta):
             self._task_queue.append(task)
     
     def get_next_task(self):
+        if not self.tasks:
+            raise Exception("No tasks defined. use the @task decorator or set the tasks property of the TaskSet")
         return random.choice(self.tasks)
     
     def wait_time(self):

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -36,15 +36,13 @@ class TestTaskSet(LocustTestCase):
             wait_time = constant(0)
             tasks = None
             _catch_exceptions = False
-
-        l = MyTasks(User(self.environment))
-
-        self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
-
+        
         class MyTasks(TaskSet):
             tasks = None
 
-        User.tasks = [MyTasks]
+        l = MyTasks(User(self.environment))
+        self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
+        l.tasks = None
         self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
 
     def test_task_decorator_ratio(self):

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -31,6 +31,22 @@ class TestTaskSet(LocustTestCase):
         self.assertEqual(t1_count, 5)
         self.assertEqual(t2_count, 2)
     
+    def test_tasks_missing_gives_user_friendly_exception(self):
+        class User(Locust):
+            wait_time = constant(0)
+            tasks = None
+            _catch_exceptions = False
+
+        l = MyTasks(User(self.environment))
+
+        self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
+
+        class MyTasks(TaskSet):
+            tasks = None
+
+        User.tasks = [MyTasks]
+        self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
+
     def test_task_decorator_ratio(self):
         t1 = lambda l: None
         t2 = lambda l: None
@@ -177,6 +193,7 @@ class TestTaskSet(LocustTestCase):
                 pass
         taskset = MyTaskSet3(self.locust)
         self.assertEqual(len(taskset.tasks), 3)
+    
     
     def test_wait_function(self):
         class MyTaskSet(TaskSet):


### PR DESCRIPTION
Give the user gets a better exception than `IndexError: Cannot choose from an empty sequence`

Should help with user problems like this one for instance https://stackoverflow.com/questions/60629518/error-while-executing-basic-code-in-locust