### PR TITLE
Allow creating a Locust without specifying an environment 

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,7 +1,7 @@
+from .event import Events
+events = Events()
 from .core import HttpLocust, Locust, TaskSet, TaskSequence, task, seq_task
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .wait_time import between, constant, constant_pacing
-from .event import Events
-events = Events()
 
 __version__ = "0.14.5"

--- a/locust/core.py
+++ b/locust/core.py
@@ -19,6 +19,8 @@ from .exception import (InterruptTaskSet, LocustError, RescheduleTask,
                         RescheduleTaskImmediately, StopLocust, MissingWaitTimeError)
 from .runners import STATE_CLEANUP, LOCUST_STATE_RUNNING, LOCUST_STATE_STOPPING, LOCUST_STATE_WAITING
 from .util import deprecation
+from .env import Environment
+from . import events
 
 
 logger = logging.getLogger(__name__)
@@ -155,9 +157,12 @@ class Locust(object):
         super(Locust, self).__init__()
         # check if deprecated wait API is used
         deprecation.check_for_deprecated_wait_api(self)
-        
-        self.environment = environment
-        
+
+        if environment:
+            self.environment = environment
+        else:
+            self.environment = Environment(events=events)
+
         with self._lock:
             if hasattr(self, "setup") and self._setup_has_run is False:
                 self._set_setup_flag()

--- a/locust/core.py
+++ b/locust/core.py
@@ -153,7 +153,7 @@ class Locust(object):
     _lock = gevent.lock.Semaphore()  # Lock to make sure setup is only run once
     _state = False
     
-    def __init__(self, environment):
+    def __init__(self, environment=None):
         super(Locust, self).__init__()
         # check if deprecated wait API is used
         deprecation.check_for_deprecated_wait_api(self)


### PR DESCRIPTION
Defautling to a basic one, with default options, including events.

if a user wants to spawn a basic Locust instance they should be able to do that without generating an environment with settings

This simplifies usage so that you can do (for example):

    HttpLocust().run()

Instead of the very awkward (and requiring knowledge of the internals of locust):

    from locust import env, events
    HttpLocust(env.Environment(events=events)).run()

I have not updated the test cases (there are a lot of them) that could use this approach, but I can do that later.

Tbh I'm only 90% sure this is a good idea. I'd love your opinions :)