### PR TITLE
Decouple Runner and Locust code by introducing Locust.start and Locust.stop methods

### DIFF
--- a/locust/core.py
+++ b/locust/core.py
@@ -274,14 +274,9 @@ class TaskSet(object, metaclass=TaskSetMeta):
                     self.schedule_task(self.get_next_task())
                 
                 try:
-                    if self.locust._state == LOCUST_STATE_STOPPING:
-                        raise StopLocust()
+                    self._check_stop_condition()
                     self.execute_next_task()
-                    if self.locust._state == LOCUST_STATE_STOPPING:
-                        raise StopLocust()
                 except RescheduleTaskImmediately:
-                    if self.locust._state == LOCUST_STATE_STOPPING:
-                        raise StopLocust()
                     pass
                 except RescheduleTask:
                     self.wait()
@@ -363,12 +358,17 @@ class TaskSet(object, metaclass=TaskSetMeta):
             ))
     
     def wait(self):
+        self._check_stop_condition()
         self.locust._state = LOCUST_STATE_WAITING
         self._sleep(self.wait_time())
         self.locust._state = LOCUST_STATE_RUNNING
 
     def _sleep(self, seconds):
         gevent.sleep(seconds)
+    
+    def _check_stop_condition(self):
+        if self.locust._state == LOCUST_STATE_STOPPING:
+            raise StopLocust()
     
     def interrupt(self, reschedule=True):
         """

--- a/locust/core.py
+++ b/locust/core.py
@@ -585,7 +585,7 @@ class Locust(object, metaclass=LocustMeta):
         """
         def run_locust(user):
             """
-            Main function gor Locust user greenlet. It's important that this function takes the locust 
+            Main function for Locust user greenlet. It's important that this function takes the locust 
             instance as argument, since we use greenlet_instance.args[0] to retrieve a reference to the 
             locust instance.
             """

--- a/locust/core.py
+++ b/locust/core.py
@@ -361,6 +361,7 @@ class TaskSet(object, metaclass=TaskSetMeta):
         self._check_stop_condition()
         self.locust._state = LOCUST_STATE_WAITING
         self._sleep(self.wait_time())
+        self._check_stop_condition()
         self.locust._state = LOCUST_STATE_RUNNING
 
     def _sleep(self, seconds):

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -1,3 +1,7 @@
+import gevent
+from gevent import sleep
+from gevent.pool import Group
+
 from locust import InterruptTaskSet, ResponseError
 from locust.core import HttpLocust, Locust, TaskSet, task
 from locust.env import Environment
@@ -393,6 +397,78 @@ class TestLocustClass(LocustTestCase):
         l.run()
         self.assertTrue(l.t1_executed)
         self.assertTrue(l.t2_executed)
+    
+    def test_locust_start(self):
+        class TestUser(Locust):
+            wait_time = constant(0.1)
+            test_state = 0
+            @task
+            def t(self):
+                self.test_state = 1
+                sleep(0.1)
+                raise StopLocust()
+        group = Group()
+        user = TestUser(self.environment)
+        greenlet = user.start(group)
+        sleep(0)
+        self.assertEqual(1, len(group))
+        self.assertIn(greenlet, group)
+        self.assertEqual(1, user.test_state)
+        timeout = gevent.Timeout(1)
+        timeout.start()
+        group.join()
+        timeout.cancel()
+    
+    def test_locust_graceful_stop(self):
+        class TestUser(Locust):
+            wait_time = constant(0)
+            test_state = 0
+            @task
+            def t(self):
+                self.test_state = 1
+                sleep(0.1)
+                self.test_state = 2
+        
+        group = Group()
+        user = TestUser(self.environment)
+        greenlet = user.start(group)
+        sleep(0)
+        self.assertEqual(1, user.test_state)
+        
+        # stop Locust instance gracefully
+        user.stop(group, force=False)
+        sleep(0)
+        # make sure instance is not killed right away
+        self.assertIn(greenlet, group)
+        self.assertEqual(1, user.test_state)
+        sleep(0.2)
+        # check that locust instance has now died and that the task got to finish
+        self.assertEqual(0, len(group))
+        self.assertEqual(2, user.test_state)
+    
+    def test_locust_forced_stop(self):
+        class TestUser(Locust):
+            wait_time = constant(0)
+            test_state = 0
+            @task
+            def t(self):
+                self.test_state = 1
+                sleep(0.1)
+                self.test_state = 2
+    
+        group = Group()
+        user = TestUser(self.environment)
+        greenlet = user.start(group)
+        sleep(0)
+        self.assertIn(greenlet, group)
+        self.assertEqual(1, user.test_state)
+    
+        # stop Locust instance gracefully
+        user.stop(group, force=True)
+        sleep(0)
+        # make sure instance is killed right away, and that the task did NOT get to finish
+        self.assertEqual(0, len(group))
+        self.assertEqual(1, user.test_state)
 
 
 class TestWebLocustClass(WebserverTestCase):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -901,11 +901,12 @@ class TestStopTimeout(LocustTestCase):
         
         class MyTestLocust(Locust):
             tasks = [MyTaskSet]
+            wait_time = constant(0)
 
         environment = create_environment(mocked_options())
         environment.stop_timeout = short_time
         runner = LocalLocustRunner(environment, [MyTestLocust])
-        runner.start(1, 1)
+        runner.start(1, 1, wait=True)
         gevent.sleep(0)
         timeout = gevent.Timeout(short_time)
         timeout.start()

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -918,6 +918,35 @@ class TestStopTimeout(LocustTestCase):
         finally:
             timeout.cancel()
     
+    def test_stop_timeout_with_interrupt_no_reschedule(self):
+        state = [0]
+        class MySubTaskSet(TaskSet):
+            @task
+            def a_task(self):
+                gevent.sleep(0.1)
+                state[0] = 1
+                self.interrupt(reschedule=False)
+        
+        class MyTestLocust(Locust):
+            tasks = [MySubTaskSet]
+            wait_time = constant(3)
+
+        environment = create_environment(mocked_options())
+        environment.stop_timeout = 0.3
+        runner = LocalLocustRunner(environment, [MyTestLocust])
+        runner.start(1, 1, wait=True)
+        gevent.sleep(0)
+        timeout = gevent.Timeout(0.11)
+        timeout.start()
+        try:
+            runner.quit()
+            runner.greenlet.join()
+        except gevent.Timeout:
+            self.fail("Got Timeout exception. Interrupted locusts should exit immediately during stop_timeout.")
+        finally:
+            timeout.cancel()
+        self.assertEqual(1, state[0])
+    
     def test_kill_locusts_with_stop_timeout(self):
         short_time = 0.05
         class MyTaskSet(TaskSet):


### PR DESCRIPTION
Decouples the runner code from the Locust user code by introducing Locust.start and Locust.stop methods.

The start() and stop() methods takes a gevent.pool.Group instance, and is responsible for spawning and killing a greenlet for the locust user. With this change the runner does no longer need to keep track of the state of the individual Locust instances, and the Locust instance does no longer need to be given a reference to the runner.

(This PR is based on the tasks-directly-under-locust-class branch, and shouldn't be merged until that PR is merged).