### PR TITLE
Group related command line options together

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,7 @@ Locust class
 ============
 
 .. autoclass:: locust.core.Locust
-    :members: wait_time, tasks, weight, abstract
+    :members: wait_time, tasks, weight, abstract, on_start, on_stop
 
 HttpLocust class
 ================
@@ -20,7 +20,7 @@ TaskSet class
 =============
 
 .. autoclass:: locust.core.TaskSet
-    :members: locust, parent, wait_time, client, tasks, interrupt, schedule_task
+    :members: locust, parent, wait_time, client, tasks, interrupt, schedule_task, on_start, on_stop
 
 task decorator
 ==============
@@ -31,7 +31,7 @@ TaskSequence class
 ==================
 
 .. autoclass:: locust.core.TaskSequence
-    :members: locust, parent, wait_time, client, tasks, interrupt, schedule_task
+    :members: locust, parent, wait_time, client, tasks, interrupt, schedule_task, on_start, on_stop
 
 seq_task decorator
 ==================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ For full details of the Locust changelog, please see https://github.com/locustio
 Breaking changes
 ----------------
 
+* The option for running Locust without the Web UI has been renamed from ``--no-web`` to ``--headless``.
 * Removed ``Locust.setup``, ``Locust.teardown``, ``TaskSet.setup`` and ``TaskSet.teardown`` hooks. If you want to 
   run code at the start or end of a test, you should instead use the :py:attr:`test_start <locust.event.Events.test_start>`
   and :py:attr:`test_stop <locust.event.Events.test_stop>` events:

--- a/docs/retrieving-stats.rst
+++ b/docs/retrieving-stats.rst
@@ -7,11 +7,11 @@ You may wish to consume your Locust results via a CSV file. In this case, there 
 First, when running Locust with the web UI, you can retrieve CSV files under the Download Data tab. 
 
 Secondly, you can run Locust with a flag which will periodically save two CSV files. This is particularly useful
-if you plan on running Locust in an automated way with the ``--no-web`` flag:
+if you plan on running Locust in an automated way with the ``--headless`` flag:
 
 .. code-block:: console
 
-    $ locust -f examples/basic.py --csv=example --no-web -t10m
+    $ locust -f examples/basic.py --csv=example --headless -t10m
 
 The files will be named ``example_response_times.csv`` and ``example_stats.csv`` (when using ``--csv=example``) and mirror Locust's built in stat pages.
 

--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -84,7 +84,7 @@ listen to. Defaults to 5557.
 ``--expect-workers=X``
 ----------------------
 
-Used when starting the master node with ``--no-web``. The master node will then wait until X worker
+Used when starting the master node with ``--headless``. The master node will then wait until X worker
 nodes has connected before the test is started.
 
 

--- a/docs/running-locust-docker.rst
+++ b/docs/running-locust-docker.rst
@@ -56,7 +56,7 @@ To run in standalone mode without the web UI, you can use the ``LOCUST_OPTS`` en
 
 .. code-block:: console
 
-    docker run --volume $PWD/dir/of/locustfile:/mnt/locust -e LOCUSTFILE_PATH=/mnt/locust/locustfile.py -e TARGET_URL=https://abc.com -e LOCUST_OPTS="--clients=10 --no-web --run-time=600" locustio/locust
+    docker run --volume $PWD/dir/of/locustfile:/mnt/locust -e LOCUSTFILE_PATH=/mnt/locust/locustfile.py -e TARGET_URL=https://abc.com -e LOCUST_OPTS="--clients=10 --headless --run-time=600" locustio/locust
 
 
 If you are Kubernetes user, you can use the `Helm chart <https://github.com/helm/charts/tree/master/stable/locust>`_ to scale and run locust.

--- a/docs/running-locust-in-step-load-mode.rst
+++ b/docs/running-locust-in-step-load-mode.rst
@@ -39,7 +39,7 @@ If you want to run Locust in step load mode without the web UI, you can do that 
 
 .. code-block:: console
 
-    $ locust -f --no-web -c 1000 -r 100 --run-time 1h30m --step-load --step-clients 300 --step-time 20m
+    $ locust -f --headless -c 1000 -r 100 --run-time 1h30m --step-load --step-clients 300 --step-time 20m
 
 Locust will swarm the clients by step and shutdown once the time is up.
 

--- a/docs/running-locust-without-web-ui.rst
+++ b/docs/running-locust-without-web-ui.rst
@@ -5,11 +5,11 @@ Running Locust without the web UI
 =================================
 
 You can run locust without the web UI - for example if you want to run it in some automated flow, 
-like a CI server - by using the ``--no-web`` flag together with ``-c`` and ``-r``:
+like a CI server - by using the ``--headless`` flag together with ``-c`` and ``-r``:
 
 .. code-block:: console
 
-    $ locust -f locust_files/my_locust_file.py --no-web -c 1000 -r 100
+    $ locust -f locust_files/my_locust_file.py --headless -c 1000 -r 100
 
 ``-c`` specifies the number of Locust users to spawn, and ``-r`` specifies the hatch rate 
 (number of users to spawn per second).
@@ -22,7 +22,7 @@ If you want to specify the run time for a test, you can do that with ``--run-tim
 
 .. code-block:: console
 
-    $ locust -f --no-web -c 1000 -r 100 --run-time 1h30m
+    $ locust -f --headless -c 1000 -r 100 --run-time 1h30m
 
 Locust will shutdown once the time is up.
 
@@ -33,7 +33,7 @@ By default, locust will stop your tasks immediately. If you want to allow your t
 
 .. code-block:: console
 
-    $ locust -f --no-web -c 1000 -r 100 --run-time 1h30m --stop-timeout 99
+    $ locust -f --headless -c 1000 -r 100 --run-time 1h30m --stop-timeout 99
 
 .. _running-locust-distributed-without-web-ui:
 

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -347,44 +347,40 @@ As you can see, you can compose :py:meth:`@seq_task <locust.core.seq_task>` with
 
 .. _on-start-on-stop:
 
-Setups, Teardowns, on_start, and on_stop
-========================================
 
-Locust optionally supports :py:class:`Locust <locust.core.Locust>` level :py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`,
-:py:class:`TaskSet <locust.core.TaskSet>` level :py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`,
-and :py:class:`TaskSet <locust.core.TaskSet>` :py:meth:`on_start <locust.core.TaskSet.on_start>` and :py:meth:`on_stop <locust.core.TaskSet.on_stop>`
+on_start and on_stop methods
+============================
 
-Setups and Teardowns
---------------------
+Locust and TaskSet classes can declare an :py:meth:`on_start <locust.core.Locust.on_start>` method and/or
+:py:meth:`on_stop <locust.core.TaskSet.on_stop>` method. A Locust user will call it's 
+:py:meth:`on_start <locust.core.Locust.on_start>` method when it starts running, and it's 
+:py:meth:`on_stop <locust.core.Locust.on_stop>` method when it stops running. For a TaskSet, the 
+:py:meth:`on_start <locust.core.TaskSet.on_start>` method is called when a simulated user starts executing 
+that TaskSet, and :py:meth:`on_stop <locust.core.TaskSet.on_stop>` is called when the simulated user stops 
+executing that TaskSet (when :py:meth:`interrupt() <locust.core.TaskSet.interrupt>` is called, or the locust 
+user is killed).
 
-:py:meth:`setup <locust.core.Locust.setup>` and :py:meth:`teardown <locust.core.Locust.teardown>`, whether it's run on :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>`, are methods that are run only once.
-:py:meth:`setup <locust.core.Locust.setup>` is run before tasks start running, while :py:meth:`teardown <locust.core.Locust.teardown>` is run after all tasks have finished and Locust is exiting.
-This enables you to perform some preparation before tasks start running (like creating a database) and to clean up before the Locust quits (like deleting the database).
 
-To use, simply declare a :py:meth:`setup <locust.core.Locust.setup>` and/or :py:meth:`teardown <locust.core.Locust.teardown>` on the :py:class:`Locust <locust.core.Locust>` or :py:class:`TaskSet <locust.core.TaskSet>` class.
-These methods will be run for you.
+test_start and test_stop events
+===============================
 
-The on_start and on_stop methods
-----------------------------------
+If you need to run some code at the start or stop of a load test, you should use the 
+:py:attr:`test_start <locust.event.Events.test_start>` and :py:attr:`test_stop <locust.event.Events.test_stop>` 
+events. You can set up listeners for these events at the module level of your locustfile:
 
-A TaskSet class can declare an :py:meth:`on_start <locust.core.TaskSet.on_start>` method or an :py:meth:`on_stop <locust.core.TaskSet.on_stop>` method.
-The :py:meth:`on_start <locust.core.TaskSet.on_start>` method is called when a simulated user starts executing that TaskSet class,
-while the :py:meth:`on_stop <locust.core.TaskSet.on_stop` method is called when the TaskSet is stopped.
+.. code-block:: python
 
-Order of events
----------------
+    from locust import events
+    
+    @events.test_start.add_listener
+    def on_test_start(**kwargs):
+        print("A new test is starting")
+    
+    @events.test_stop.add_listener
+    def on_test_stop(**kwargs):
+        print("A new test is ending")
 
-Since many setup and cleanup operations are dependent on each other, here is the order which they are run:
-
-1. Locust setup (once)
-2. TaskSet setup (once)
-3. TaskSet on_start (every time a user starts executing a new TaskSet)
-4. TaskSet tasks...
-5. TaskSet on_stop (every time a user stops executing a TaskSet, either to run a different one or at shutdown)
-6. TaskSet teardown (once)
-7. Locust teardown (once)
-
-In general, the setup and teardown methods should be complementary.
+When running Locust distributed the ``on_start`` and ``on_stop`` events will only be fired in the master node.
 
 
 Making HTTP requests

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -230,7 +230,7 @@ def setup_parser_arguments(parser):
         help=configargparse.SUPPRESS
     )
     
-    stats_group = parser.add_argument_group("Request statistics")
+    stats_group = parser.add_argument_group("Request statistics options")
     # A file that contains the current request stats.
     stats_group.add_argument(
         '--csv', '--csv-base-name',
@@ -263,7 +263,7 @@ def setup_parser_arguments(parser):
         help="Reset statistics once hatching has been completed. Should be set on both master and workers when running in distributed mode",
     )
     
-    log_group = parser.add_argument_group("Logging options", "Options related to logging")
+    log_group = parser.add_argument_group("Logging options")
     # skip logging setup
     log_group.add_argument(
         '--skip-log-setup',

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -310,19 +310,20 @@ def setup_parser_arguments(parser):
     other_group.add_argument(
         '--show-task-ratio',
         action='store_true',
-        help="print table of the locust classes' task execution ratio"
+        help="Print table of the locust classes' task execution ratio"
     )
     # Display ratio table of all tasks in JSON format
     other_group.add_argument(
         '--show-task-ratio-json',
         action='store_true',
-        help="print json data of the locust classes' task execution ratio"
+        help="Print json data of the locust classes' task execution ratio"
     )
     # Version number (optparse gives you --version but we have to do it
     # ourselves to get -V too. sigh)
     other_group.add_argument(
         '--version', '-V',
         action='version',
+        help="Show program's version number and exit",
         version='%(prog)s {}'.format(version),
     )
     # set the exit code to post on errors
@@ -330,7 +331,7 @@ def setup_parser_arguments(parser):
         '--exit-code-on-error',
         type=int,
         default=1,
-        help="sets the exit code to post on error"
+        help="Sets the process exit code to use when a test result contain any failure or error"
     )
     other_group.add_argument(
         '-s', '--stop-timeout',

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -174,60 +174,68 @@ def setup_parser_arguments(parser):
         help="Disable the web interface, and instead start the load test immediately. Requires -c and -t to be specified."
     )
     
-    master_worker_group = parser.add_argument_group(
-        "Master/Worker options", 
-        "Options for running Locust distributed",
+    master_group = parser.add_argument_group(
+        "Master options", 
+        "Options for running a Locust Master node when running Locust distributed. A Master node need Worker nodes that connect to it before it can run load tests.",
     )
     # if locust should be run in distributed mode as master
-    master_worker_group.add_argument(
+    master_group.add_argument(
         '--master',
         action='store_true',
         help="Set locust to run in distributed mode with this process as master"
     )
-    # if locust should be run in distributed mode as worker
-    master_worker_group.add_argument(
-        '--worker',
-        action='store_true',
-        help="Set locust to run in distributed mode with this process as worker"
-    )
-    master_worker_group.add_argument(
-        '--slave',
-        action='store_true',
-        help=configargparse.SUPPRESS
-    )
-    # master host options
-    master_worker_group.add_argument(
-        '--master-host',
-        default="127.0.0.1",
-        help="Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1."
-    )
-    master_worker_group.add_argument(
-        '--master-port',
-        type=int,
-        default=5557,
-        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557."
-    )
-    master_worker_group.add_argument(
+    master_group.add_argument(
         '--master-bind-host',
         default="*",
         help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces)."
     )
-    master_worker_group.add_argument(
+    master_group.add_argument(
         '--master-bind-port',
         type=int,
         default=5557,
         help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557."
     )
-    master_worker_group.add_argument(
+    master_group.add_argument(
         '--expect-workers',
         type=int,
         default=1,
         help="How many workers master should expect to connect before starting the test (only when --headless used)."
     )
-    master_worker_group.add_argument(
+    master_group.add_argument(
         '--expect-slaves',
         action='store_true',
         help=configargparse.SUPPRESS
+    )
+    
+    worker_group = parser.add_argument_group(
+        "Worker options", 
+        textwrap.dedent("""
+            Options for running a Locust Worker node when running Locust distributed. 
+            Only the LOCUSTFILE (-f option) need to be specified when starting a Worker, since other options such as -c, -r, -t are specified on the Master node.
+        """),
+    )
+    # if locust should be run in distributed mode as worker
+    worker_group.add_argument(
+        '--worker',
+        action='store_true',
+        help="Set locust to run in distributed mode with this process as worker"
+    )
+    worker_group.add_argument(
+        '--slave',
+        action='store_true',
+        help=configargparse.SUPPRESS
+    )
+    # master host options
+    worker_group.add_argument(
+        '--master-host',
+        default="127.0.0.1",
+        help="Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1."
+    )
+    worker_group.add_argument(
+        '--master-port',
+        type=int,
+        default=5557,
+        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557."
     )
     
     stats_group = parser.add_argument_group("Request statistics options")

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -133,19 +133,19 @@ def setup_parser_arguments(parser):
         type=int,
         dest='num_clients',
         default=1,
-        help="Number of concurrent Locust users. Only used together with --no-web"
+        help="Number of concurrent Locust users. Only used together with --headless"
     )
     # User hatch rate
     parser.add_argument(
         '-r', '--hatch-rate',
         type=float,
         default=1,
-        help="The rate per second in which clients are spawned. Only used together with --no-web"
+        help="The rate per second in which clients are spawned. Only used together with --headless"
     )
     # Time limit of the test run
     parser.add_argument(
         '-t', '--run-time',
-        help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --no-web"
+        help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --headless"
     )
     # List locust commands found in loaded locust files/source files
     parser.add_argument(
@@ -169,9 +169,9 @@ def setup_parser_arguments(parser):
     )
     # if we should print stats in the console
     web_ui_group.add_argument(
-        '--no-web',
+        '--headless',
         action='store_true',
-        help="Disable the web interface, and instead start running the test immediately. Requires -c and -t to be specified."
+        help="Disable the web interface, and instead start the load test immediately. Requires -c and -t to be specified."
     )
     
     master_worker_group = parser.add_argument_group(
@@ -222,7 +222,7 @@ def setup_parser_arguments(parser):
         '--expect-workers',
         type=int,
         default=1,
-        help="How many workers master should expect to connect before starting the test (only when --no-web used)."
+        help="How many workers master should expect to connect before starting the test (only when --headless used)."
     )
     master_worker_group.add_argument(
         '--expect-slaves',

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -1,5 +1,7 @@
+import argparse
 import os
 import sys
+import textwrap
 
 import configargparse
 
@@ -59,7 +61,15 @@ def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG
         default_config_files=default_config_files, 
         auto_env_var_prefix="LOCUST_", 
         add_env_var_help=False,
+        add_config_file_help=False,
         add_help=add_help,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description=textwrap.dedent("""
+            Usage: locust [OPTIONS] [LocustClass ...]
+            
+        """),
+        #epilog="",
     )
     parser.add_argument(
         '-f', '--locustfile',
@@ -82,7 +92,7 @@ def parse_locustfile_option(args=None):
         default=False,
     )
     parser.add_argument(
-        '-V', '--version',
+        '--version', '-V',
         action='store_true',
         default=False,
     )
@@ -112,93 +122,12 @@ def setup_parser_arguments(parser):
     Takes a configargparse.ArgumentParser as argument and calls it's add_argument 
     for each of the supported arguments
     """
+    parser._optionals.title = "Common options"
     parser.add_argument(
         '-H', '--host',
         help="Host to load test in the following format: http://10.21.32.33"
     )
-    parser.add_argument(
-        '--web-host',
-        default="",
-        help="Host to bind the web interface to. Defaults to '' (all interfaces)"
-    )
-    parser.add_argument(
-        '-P', '--web-port',
-        type=int,
-        default=8089,
-        help="Port on which to run web host"
-    )
-    # A file that contains the current request stats.
-    parser.add_argument(
-        '--csv', '--csv-base-name',
-        dest='csvfilebase',
-        help="Store current request stats to files in CSV format.",
-    )
-    # Adds each stats entry at every iteration to the _stats_history.csv file.
-    parser.add_argument(
-        '--csv-full-history',
-        action='store_true',
-        default=False,
-        dest='stats_history_enabled',
-        help="Store each stats entry in CSV format to _stats_history.csv file",
-    )
-    # if locust should be run in distributed mode as master
-    parser.add_argument(
-        '--master',
-        action='store_true',
-        help="Set locust to run in distributed mode with this process as master"
-    )
-    # if locust should be run in distributed mode as worker
-    parser.add_argument(
-        '--worker',
-        action='store_true',
-        help="Set locust to run in distributed mode with this process as worker"
-    )
-    parser.add_argument(
-        '--slave',
-        action='store_true',
-        help=configargparse.SUPPRESS
-    )
-    # master host options
-    parser.add_argument(
-        '--master-host',
-        default="127.0.0.1",
-        help="Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1."
-    )
-    parser.add_argument(
-        '--master-port',
-        type=int,
-        default=5557,
-        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557."
-    )
-    parser.add_argument(
-        '--master-bind-host',
-        default="*",
-        help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces)."
-    )
-    parser.add_argument(
-        '--master-bind-port',
-        type=int,
-        default=5557,
-        help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557."
-    )
-    parser.add_argument(
-        '--expect-workers',
-        type=int,
-        default=1,
-        help="How many workers master should expect to connect before starting the test (only when --no-web used)."
-    )
-    parser.add_argument(
-        '--expect-slaves',
-        action='store_true',
-        help=configargparse.SUPPRESS
-    )
-    # if we should print stats in the console
-    parser.add_argument(
-        '--no-web',
-        action='store_true',
-        help="Disable the web interface, and instead start running the test immediately. Requires -c and -t to be specified."
-    )
-    # Number of clients
+    # Number of Locust users
     parser.add_argument(
         '-c', '--clients',
         type=int,
@@ -206,7 +135,7 @@ def setup_parser_arguments(parser):
         default=1,
         help="Number of concurrent Locust users. Only used together with --no-web"
     )
-    # Client hatch rate
+    # User hatch rate
     parser.add_argument(
         '-r', '--hatch-rate',
         type=float,
@@ -218,65 +147,6 @@ def setup_parser_arguments(parser):
         '-t', '--run-time',
         help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --no-web"
     )
-    # skip logging setup
-    parser.add_argument(
-        '--skip-log-setup',
-        action='store_true',
-        dest='skip_log_setup',
-        default=False,
-        help="Disable Locust's logging setup. Instead, the configuration is provided by the Locust test or Python defaults."
-    )
-    # Enable Step Load mode
-    parser.add_argument(
-        '--step-load',
-        action='store_true',
-        help="Enable Step Load mode to monitor how performance metrics varies when user load increases. Requires --step-clients and --step-time to be specified."
-    )
-    # Number of clients to incease by Step
-    parser.add_argument(
-        '--step-clients',
-        type=int,
-        default=1,
-        help="Client count to increase by step in Step Load mode. Only used together with --step-load"
-    )
-    # Time limit of each step
-    parser.add_argument(
-        '--step-time',
-        help="Step duration in Step Load mode, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --step-load"
-    )
-    # log level
-    parser.add_argument(
-        '--loglevel', '-L',
-        default='INFO',
-        help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
-    )
-    # log file
-    parser.add_argument(
-        '--logfile',
-        help="Path to log file. If not set, log will go to stdout/stderr",
-    )
-    # if we should print stats in the console
-    parser.add_argument(
-        '--print-stats',
-        action='store_true',
-        help="Print stats in the console"
-    )
-    # only print summary stats
-    parser.add_argument(
-       '--only-summary',
-       action='store_true',
-       help='Only print the summary stats'
-    )
-    parser.add_argument(
-        '--no-reset-stats',
-        action='store_true',
-        help="[DEPRECATED] Do not reset statistics once hatching has been completed. This is now the default behavior. See --reset-stats to disable",
-    )
-    parser.add_argument(
-        '--reset-stats',
-        action='store_true',
-        help="Reset statistics once hatching has been completed. Should be set on both master and workers when running in distributed mode",
-    )
     # List locust commands found in loaded locust files/source files
     parser.add_argument(
         '-l', '--list',
@@ -284,33 +154,185 @@ def setup_parser_arguments(parser):
         dest='list_commands',
         help="Show list of possible locust classes and exit"
     )
+    
+    web_ui_group = parser.add_argument_group("Web UI options")
+    web_ui_group.add_argument(
+        '--web-host',
+        default="",
+        help="Host to bind the web interface to. Defaults to '' (all interfaces)"
+    )
+    web_ui_group.add_argument(
+        '--web-port', '-P',
+        type=int,
+        default=8089,
+        help="Port on which to run web host"
+    )
+    # if we should print stats in the console
+    web_ui_group.add_argument(
+        '--no-web',
+        action='store_true',
+        help="Disable the web interface, and instead start running the test immediately. Requires -c and -t to be specified."
+    )
+    
+    master_worker_group = parser.add_argument_group(
+        "Master/Worker options", 
+        "Options for running Locust distributed",
+    )
+    # if locust should be run in distributed mode as master
+    master_worker_group.add_argument(
+        '--master',
+        action='store_true',
+        help="Set locust to run in distributed mode with this process as master"
+    )
+    # if locust should be run in distributed mode as worker
+    master_worker_group.add_argument(
+        '--worker',
+        action='store_true',
+        help="Set locust to run in distributed mode with this process as worker"
+    )
+    master_worker_group.add_argument(
+        '--slave',
+        action='store_true',
+        help=configargparse.SUPPRESS
+    )
+    # master host options
+    master_worker_group.add_argument(
+        '--master-host',
+        default="127.0.0.1",
+        help="Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1."
+    )
+    master_worker_group.add_argument(
+        '--master-port',
+        type=int,
+        default=5557,
+        help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557."
+    )
+    master_worker_group.add_argument(
+        '--master-bind-host',
+        default="*",
+        help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces)."
+    )
+    master_worker_group.add_argument(
+        '--master-bind-port',
+        type=int,
+        default=5557,
+        help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557."
+    )
+    master_worker_group.add_argument(
+        '--expect-workers',
+        type=int,
+        default=1,
+        help="How many workers master should expect to connect before starting the test (only when --no-web used)."
+    )
+    master_worker_group.add_argument(
+        '--expect-slaves',
+        action='store_true',
+        help=configargparse.SUPPRESS
+    )
+    
+    stats_group = parser.add_argument_group("Request statistics")
+    # A file that contains the current request stats.
+    stats_group.add_argument(
+        '--csv', '--csv-base-name',
+        dest='csvfilebase',
+        help="Store current request stats to files in CSV format.",
+    )
+    # Adds each stats entry at every iteration to the _stats_history.csv file.
+    stats_group.add_argument(
+        '--csv-full-history',
+        action='store_true',
+        default=False,
+        dest='stats_history_enabled',
+        help="Store each stats entry in CSV format to _stats_history.csv file",
+    )    
+    # if we should print stats in the console
+    stats_group.add_argument(
+        '--print-stats',
+        action='store_true',
+        help="Print stats in the console"
+    )
+    # only print summary stats
+    stats_group.add_argument(
+       '--only-summary',
+       action='store_true',
+       help='Only print the summary stats'
+    )
+    stats_group.add_argument(
+        '--reset-stats',
+        action='store_true',
+        help="Reset statistics once hatching has been completed. Should be set on both master and workers when running in distributed mode",
+    )
+    
+    log_group = parser.add_argument_group("Logging options", "Options related to logging")
+    # skip logging setup
+    log_group.add_argument(
+        '--skip-log-setup',
+        action='store_true',
+        dest='skip_log_setup',
+        default=False,
+        help="Disable Locust's logging setup. Instead, the configuration is provided by the Locust test or Python defaults."
+    )
+    # log level
+    log_group.add_argument(
+        '--loglevel', '-L',
+        default='INFO',
+        help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
+    )
+    # log file
+    log_group.add_argument(
+        '--logfile',
+        help="Path to log file. If not set, log will go to stdout/stderr",
+    )
+    
+    step_load_group = parser.add_argument_group("Step load options")
+    # Enable Step Load mode
+    step_load_group.add_argument(
+        '--step-load',
+        action='store_true',
+        help="Enable Step Load mode to monitor how performance metrics varies when user load increases. Requires --step-clients and --step-time to be specified."
+    )
+    # Number of clients to incease by Step
+    step_load_group.add_argument(
+        '--step-clients',
+        type=int,
+        default=1,
+        help="Client count to increase by step in Step Load mode. Only used together with --step-load"
+    )
+    # Time limit of each step
+    step_load_group.add_argument(
+        '--step-time',
+        help="Step duration in Step Load mode, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --step-load"
+    )
+    
+    
+    other_group = parser.add_argument_group("Other options", "Various other options")
     # Display ratio table of all tasks
-    parser.add_argument(
+    other_group.add_argument(
         '--show-task-ratio',
         action='store_true',
         help="print table of the locust classes' task execution ratio"
     )
     # Display ratio table of all tasks in JSON format
-    parser.add_argument(
+    other_group.add_argument(
         '--show-task-ratio-json',
         action='store_true',
         help="print json data of the locust classes' task execution ratio"
     )
     # Version number (optparse gives you --version but we have to do it
     # ourselves to get -V too. sigh)
-    parser.add_argument(
-        '-V', '--version',
+    other_group.add_argument(
+        '--version', '-V',
         action='version',
         version='%(prog)s {}'.format(version),
     )
     # set the exit code to post on errors
-    parser.add_argument(
+    other_group.add_argument(
         '--exit-code-on-error',
         type=int,
         default=1,
         help="sets the exit code to post on error"
     )
-    parser.add_argument(
+    other_group.add_argument(
         '-s', '--stop-timeout',
         action='store',
         type=int,
@@ -318,10 +340,13 @@ def setup_parser_arguments(parser):
         default=None,
         help="Number of seconds to wait for a simulated user to complete any executing task before exiting. Default is to terminate immediately. This parameter only needs to be specified for the master process when running Locust distributed."
     )
-    parser.add_argument(
+    
+    locust_classes_group = parser.add_argument_group("Locust user classes")
+    locust_classes_group.add_argument(
         'locust_classes',
         nargs='*',
         metavar='LocustClass',
+        help="Optionally specify which Locust classes that should be used (available Locust classes can be listed with -l or --list)",
     )
 
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -305,7 +305,7 @@ def setup_parser_arguments(parser):
     )
     
     
-    other_group = parser.add_argument_group("Other options", "Various other options")
+    other_group = parser.add_argument_group("Other options")
     # Display ratio table of all tasks
     other_group.add_argument(
         '--show-task-ratio',

--- a/locust/core.py
+++ b/locust/core.py
@@ -231,13 +231,14 @@ class TaskSet(object, metaclass=TaskSetMeta):
 
     def on_start(self):
         """
-        Hook for end-user scripts for running code when a Locust user starts running
+        Called when a Locust user starts executing (enters) this TaskSet
         """
         pass
     
     def on_stop(self):
         """
-        Hook for end-user scripts for running code when a Locust user stops running
+        Called when a Locust user stops executing this TaskSet. E.g. when Taskset.interrupt() is called 
+        or when the user is killed
         """
         pass
 
@@ -523,13 +524,13 @@ class Locust(object, metaclass=LocustMeta):
     
     def on_start(self):
         """
-        Hook for end-user scripts for running code when a Locust user starts running
+        Called when a Locust user starts running. 
         """
         pass
     
     def on_stop(self):
         """
-        Hook for end-user scripts for running code when a Locust user stops running
+        Called when a Locust user stops running (is killed)
         """
         pass
     

--- a/locust/main.py
+++ b/locust/main.py
@@ -206,8 +206,8 @@ def main():
     main_greenlet = runner.greenlet
     
     if options.run_time:
-        if not options.no_web:
-            logger.error("The --run-time argument can only be used together with --no-web")
+        if not options.headless:
+            logger.error("The --run-time argument can only be used together with --headless")
             sys.exit(1)
         if options.worker:
             logger.error("--run-time should be specified on the master node, and not on worker nodes")
@@ -225,7 +225,7 @@ def main():
             gevent.spawn_later(options.run_time, timelimit_stop)
     
     # start Web UI
-    if not options.no_web and not options.worker:
+    if not options.headless and not options.worker:
         # spawn web greenlet
         logger.info("Starting web monitor at http://%s:%s" % (options.web_host or "*", options.web_port))
         web_ui = WebUI(environment=environment)
@@ -237,7 +237,7 @@ def main():
     # need access to the Environment, Runner or WebUI
     environment.events.init.fire(environment=environment, runner=runner, web_ui=web_ui)    
     
-    if options.no_web:
+    if options.headless:
         # headless mode
         if options.master:
             # what for worker nodes to connect
@@ -256,7 +256,7 @@ def main():
         spawn_run_time_limit_greenlet()
 
     stats_printer_greenlet = None
-    if not options.only_summary and (options.print_stats or (options.no_web and not options.worker)):
+    if not options.only_summary and (options.print_stats or (options.headless and not options.worker)):
         # spawn stats printing greenlet
         stats_printer_greenlet = gevent.spawn(stats_printer(runner.stats))
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -853,7 +853,7 @@ def stats_history_csv(stats, stats_history_enabled=False, csv_for_web_ui=False):
     """Returns the Aggregated stats entry every interval"""
     # csv_for_web_ui boolean returns the header along with the stats history row so that
     # it can be returned as a csv for download on the web ui. Otherwise when run with
-    # the '--no-web' option we write the header first and then append the file with stats
+    # the '--headless' option we write the header first and then append the file with stats
     # entries every interval.
     if csv_for_web_ui:
         rows = [stats_history_csv_header()]

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -26,13 +26,6 @@ class TestParser(unittest.TestCase):
         opts = self.parser.parse_args(args)
         self.assertEqual(opts.reset_stats, True)
 
-    def test_should_accept_legacy_no_reset_stats(self):
-        args = [
-            "--no-reset-stats"
-        ]
-        opts = self.parser.parse_args(args)
-        self.assertEqual(opts.reset_stats, False)
-
     def test_skip_log_setup(self):
         args = [
             "--skip-log-setup"


### PR DESCRIPTION
This PR (for #1282) does the following

* Group related command line options together using Argument Groups from argparse, resulting in a much better `--help` message
* Removes deprecated `--no-reset-stats` options.

This PR is work in progress. Here's the current help output:

```
Usage: locust [OPTIONS] [LocustClass ...]

Common options:
  -h, --help            show this help message and exit
  -f LOCUSTFILE, --locustfile LOCUSTFILE
                        Python module file to import, e.g. '../other.py'. Default: locustfile
  -H HOST, --host HOST  Host to load test in the following format: http://10.21.32.33
  -c NUM_CLIENTS, --clients NUM_CLIENTS
                        Number of concurrent Locust users. Only used together with --headless
  -r HATCH_RATE, --hatch-rate HATCH_RATE
                        The rate per second in which clients are spawned. Only used together with --headless
  -t RUN_TIME, --run-time RUN_TIME
                        Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --headless
  -l, --list            Show list of possible locust classes and exit

Web UI options:
  --web-host WEB_HOST   Host to bind the web interface to. Defaults to '' (all interfaces)
  --web-port WEB_PORT, -P WEB_PORT
                        Port on which to run web host
  --headless            Disable the web interface, and instead start the load test immediately. Requires -c and -t to be specified.

Master options:
  Options for running a Locust Master node when running Locust distributed. A Master node need Worker nodes that connect to it before it can run load tests.

  --master              Set locust to run in distributed mode with this process as master
  --master-bind-host MASTER_BIND_HOST
                        Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces).
  --master-bind-port MASTER_BIND_PORT
                        Port that locust master should bind to. Only used when running with --master. Defaults to 5557.
  --expect-workers EXPECT_WORKERS
                        How many workers master should expect to connect before starting the test (only when --headless used).

Worker options:

  Options for running a Locust Worker node when running Locust distributed.
  Only the LOCUSTFILE (-f option) need to be specified when starting a Worker, since other options such as -c, -r, -t are specified on the Master node.

  --worker              Set locust to run in distributed mode with this process as worker
  --master-host MASTER_HOST
                        Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1.
  --master-port MASTER_PORT
                        The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557.

Request statistics options:
  --csv CSVFILEBASE, --csv-base-name CSVFILEBASE
                        Store current request stats to files in CSV format.
  --csv-full-history    Store each stats entry in CSV format to _stats_history.csv file
  --print-stats         Print stats in the console
  --only-summary        Only print the summary stats
  --reset-stats         Reset statistics once hatching has been completed. Should be set on both master and workers when running in distributed mode

Logging options:
  --skip-log-setup      Disable Locust's logging setup. Instead, the configuration is provided by the Locust test or Python defaults.
  --loglevel LOGLEVEL, -L LOGLEVEL
                        Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.
  --logfile LOGFILE     Path to log file. If not set, log will go to stdout/stderr

Step load options:
  --step-load           Enable Step Load mode to monitor how performance metrics varies when user load increases. Requires --step-clients and --step-time to be specified.
  --step-clients STEP_CLIENTS
                        Client count to increase by step in Step Load mode. Only used together with --step-load
  --step-time STEP_TIME
                        Step duration in Step Load mode, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --step-load

Other options:
  --show-task-ratio     Print table of the locust classes' task execution ratio
  --show-task-ratio-json
                        Print json data of the locust classes' task execution ratio
  --version, -V         Show program's version number and exit
  --exit-code-on-error EXIT_CODE_ON_ERROR
                        Sets the process exit code to use when a test result contain any failure or error
  -s STOP_TIMEOUT, --stop-timeout STOP_TIMEOUT
                        Number of seconds to wait for a simulated user to complete any executing task before exiting. Default is to terminate immediately. This parameter only needs to be specified for
                        the master process when running Locust distributed.

Locust user classes:
  LocustClass           Optionally specify which Locust classes that should be used (available Locust classes can be listed with -l or --list)
```