### PR TITLE
Add User count to CSV history stats

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Breaking changes
       def on_test_start(**kw):
           print("test is stopping")
 * ``TaskSequence`` and ``@seq_task`` has been replaced with :ref:`SequentialTaskSet <sequential-taskset>`.
+* A ``User count`` column has been added to the history stats CSV file, and the column order has been changed 
+  (``Timestamp`` is now the first column).
 
 
 0.14.0

--- a/locust/main.py
+++ b/locust/main.py
@@ -260,7 +260,7 @@ def main():
         stats_printer_greenlet = gevent.spawn(stats_printer(runner.stats))
 
     if options.csvfilebase:
-        gevent.spawn(stats_writer, runner.stats, options.csvfilebase, full_history=options.stats_history_enabled)
+        gevent.spawn(stats_writer, environment, options.csvfilebase, full_history=options.stats_history_enabled)
 
     
     def shutdown(code=0):
@@ -278,7 +278,7 @@ def main():
         print_stats(runner.stats, current=False)
         print_percentile_stats(runner.stats)
         if options.csvfilebase:
-            write_csv_files(runner.stats, options.csvfilebase, options.stats_history_enabled)
+            write_csv_files(environment, options.csvfilebase, full_history=options.stats_history_enabled)
         print_error_report(runner.stats)
         sys.exit(code)
     

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -861,24 +861,19 @@ def stats_history_csv_header():
         '"100%"'
     )) + '\n'
 
-def stats_history_csv(stats, stats_history_enabled=False, csv_for_web_ui=False):
-    """Returns the Aggregated stats entry every interval"""
-    # csv_for_web_ui boolean returns the header along with the stats history row so that
-    # it can be returned as a csv for download on the web ui. Otherwise when run with
-    # the '--headless' option we write the header first and then append the file with stats
-    # entries every interval.
-    if csv_for_web_ui:
-        rows = [stats_history_csv_header()]
-    else:
-        rows = []
-
+def stats_history_csv(stats, all_entries=False):
+    """
+    Return a string of CSV rows with the *current* stats. By default only includes the 
+    Aggregated stats entry, but if all_entries is set to True, a row for each entry will 
+    will be included.
+    """
     timestamp = int(time.time())
-    stats_entries_per_iteration = []
-
-    if stats_history_enabled:
-        stats_entries_per_iteration = sort_stats(stats.entries)
-
-    for s in chain(stats_entries_per_iteration, [stats.total]):
+    stats_entries = []
+    if all_entries:
+        stats_entries = sort_stats(stats.entries)
+    
+    rows = []
+    for s in chain(stats_entries, [stats.total]):
         if s.num_requests:
             percentile_str = ','.join([
                 str(int(s.get_current_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT])

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -169,7 +169,6 @@
                 <div style="display:none;">
                     <div style="margin-top:20px;">
                         <a href="./stats/requests/csv">Download request statistics CSV</a><br>
-                        <a href="./stats/stats_history/csv">Download response time stats history CSV</a><br>
                         <a href="./stats/failures/csv">Download failures CSV</a><br>
                         <a href="./exceptions/csv">Download exceptions CSV</a>
                     </div>

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -331,42 +331,42 @@ class TestWriteStatCSVs(LocustTestCase):
         self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
     
+    @mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2)
     def test_csv_stats_writer(self):
-        with mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2):
-            greenlet = gevent.spawn(stats_writer, self.runner.stats, self.STATS_BASE_NAME)
-            gevent.sleep(0.21)
-            gevent.kill(greenlet)
-            self.assertTrue(os.path.exists(self.STATS_FILENAME))
-            self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
-            self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-            
-            with open(self.STATS_HISTORY_FILENAME) as f:
-                reader = csv.DictReader(f)
-                rows = [r for r in reader]
-            
-            self.assertEqual(2, len(rows))
-            self.assertEqual("Aggregated", rows[0]["Name"])
-            self.assertEqual("Aggregated", rows[1]["Name"])
+        greenlet = gevent.spawn(stats_writer, self.runner.stats, self.STATS_BASE_NAME)
+        gevent.sleep(0.21)
+        gevent.kill(greenlet)
+        self.assertTrue(os.path.exists(self.STATS_FILENAME))
+        self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
+        self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
+        
+        with open(self.STATS_HISTORY_FILENAME) as f:
+            reader = csv.DictReader(f)
+            rows = [r for r in reader]
+        
+        self.assertEqual(2, len(rows))
+        self.assertEqual("Aggregated", rows[0]["Name"])
+        self.assertEqual("Aggregated", rows[1]["Name"])
     
+    @mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2)
     def test_csv_stats_writer_full_history(self):
         self.runner.stats.log_request("GET", "/", 10, content_length=666)
-        with mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2):
-            greenlet = gevent.spawn(stats_writer, self.runner.stats, self.STATS_BASE_NAME, full_history=True)
-            gevent.sleep(0.21)
-            gevent.kill(greenlet)
-            self.assertTrue(os.path.exists(self.STATS_FILENAME))
-            self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
-            self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-            
-            with open(self.STATS_HISTORY_FILENAME) as f:
-                reader = csv.DictReader(f)
-                rows = [r for r in reader]
-            
-            self.assertEqual(4, len(rows))
-            self.assertEqual("/", rows[0]["Name"])
-            self.assertEqual("Aggregated", rows[1]["Name"])
-            self.assertEqual("/", rows[2]["Name"])
-            self.assertEqual("Aggregated", rows[3]["Name"])
+        greenlet = gevent.spawn(stats_writer, self.runner.stats, self.STATS_BASE_NAME, full_history=True)
+        gevent.sleep(0.21)
+        gevent.kill(greenlet)
+        self.assertTrue(os.path.exists(self.STATS_FILENAME))
+        self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
+        self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
+        
+        with open(self.STATS_HISTORY_FILENAME) as f:
+            reader = csv.DictReader(f)
+            rows = [r for r in reader]
+        
+        self.assertEqual(4, len(rows))
+        self.assertEqual("/", rows[0]["Name"])
+        self.assertEqual("Aggregated", rows[1]["Name"])
+        self.assertEqual("/", rows[2]["Name"])
+        self.assertEqual("Aggregated", rows[3]["Name"])
     
     def test_csv_stats_on_master_from_aggregated_stats(self):
         # Failing test for: https://github.com/locustio/locust/issues/1315

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -108,11 +108,6 @@ class TestWebUI(LocustTestCase):
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
 
-    def test_request_stats_history_csv(self):
-        self.stats.log_request("GET", "/test2", 120, 5612)
-        response = requests.get("http://127.0.0.1:%i/stats/stats_history/csv" % self.web_port)
-        self.assertEqual(200, response.status_code)
-
     def test_failure_stats_csv(self):
         self.stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/failures/csv" % self.web_port)

--- a/locust/web.py
+++ b/locust/web.py
@@ -23,7 +23,7 @@ from io import StringIO
 
 from . import runners
 from .runners import MasterLocustRunner
-from .stats import failures_csv, median_from_dict, requests_csv, sort_stats, stats_history_csv
+from .stats import failures_csv, median_from_dict, requests_csv, sort_stats
 from .util.cache import memoize
 from .util.rounding import proper_round
 from .util.timespan import parse_timespan
@@ -115,15 +115,6 @@ class WebUI:
         def request_stats_csv():
             response = make_response(requests_csv(self.environment.runner.stats))
             file_name = "requests_{0}.csv".format(time())
-            disposition = "attachment;filename={0}".format(file_name)
-            response.headers["Content-type"] = "text/csv"
-            response.headers["Content-disposition"] = disposition
-            return response
-        
-        @app.route("/stats/stats_history/csv")
-        def stats_history_stats_csv():
-            response = make_response(stats_history_csv(self.environment.runner.stats, False, True))
-            file_name = "stats_history_{0}.csv".format(time())
             disposition = "attachment;filename={0}".format(file_name)
             response.headers["Content-type"] = "text/csv"
             response.headers["Content-disposition"] = disposition


### PR DESCRIPTION
This PR does:

* Add a column "User count" to the history CSV stats (should fix #1292)
* Makes the "Timestamp" column in history CSV the first column
* Remove the "Download response time history CSV" from Web UI since it has never worked, and fixing it is non-trivial (since we would either have to always store the whole stats history in memory, or always create a disk file somewhere, and I don't think we want to do either).