### PR TITLE
Improve how we do logging

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -4,7 +4,25 @@
 Logging
 =======
 
-Locust comes with a basic logging configuration that optionally takes ``--loglevel`` and/or ``--logfile`` to modify the configuration. If you want to control the logging configuration you can supply the ``--skip-log-setup`` flag, which ignores the other parameters.
+Locust uses Python's `built in logging framework <https://docs.python.org/3/library/logging.html>`_ for 
+handling logging.
+
+The default logging configuration that Locust applies, writes log messages directly to stderr. ``--loglevel`` 
+and ``--logfile`` can be used to change the verbosity and/or make the log go to a file instead. 
+
+The default logging configuration installs handlers for the ``root`` logger as well as the ``locust.*`` loggers, 
+so using the root logger in your own test scripts will put the message into the log file if ``--logfile`` is used:
+
+.. code-block:: python
+    
+    import logging
+    logging.info("this log message will go wherever the other locust log messages go")
+
+
+It's also possible to control the whole logging configuration in your own test scripts by using the 
+``--skip-log-setup`` option. You will then have to 
+`configure the logging <https://docs.python.org/3/library/logging.config.html>`_ yourself.
+
 
 Options
 =======
@@ -26,3 +44,18 @@ Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO. The short-han
 
 Path to log file. If not set, log will go to stdout/stderr.
 
+
+Locust loggers
+==============
+
+Here's a table of the loggers used within Locust (for reference when configuring logging settings manually):
+
++------------------------+--------------------------------------------------------------------------------------+
+| Logger name            | Purpose                                                                              |
++------------------------+--------------------------------------------------------------------------------------+
+| locust                 | The locust namespace is used for all loggers such as ``locust.main``,                |
+|                        | ``locust.runners``, etc.                                                             |
++------------------------+--------------------------------------------------------------------------------------+
+| locust.stats_logger    | This logger is used to periodically print the current stats to the console. The      |
+|                        | stats does *not* go into the log file when ``--logfile`` is used by default.         |
++------------------------+--------------------------------------------------------------------------------------+

--- a/locust/inspectlocust.py
+++ b/locust/inspectlocust.py
@@ -1,7 +1,6 @@
 import inspect
 
 from .core import Locust, TaskSet
-from .log import console_logger
 
 
 def print_task_ratio(locusts, total=False, level=0, parent_ratio=1.0):
@@ -12,7 +11,7 @@ def _print_task_ratio(x, level=0):
     for k, v in x.items():
         padding = 2*" "*level
         ratio = v.get('ratio', 1)
-        console_logger.info(" %-10s %-50s" % (padding + "%-6.1f" % (ratio*100), padding + k))
+        print(" %-10s %-50s" % (padding + "%-6.1f" % (ratio*100), padding + k))
         if 'tasks' in v:
             _print_task_ratio(v['tasks'], level + 1)
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -15,7 +15,7 @@ from .argument_parser import parse_locustfile_option, parse_options
 from .core import HttpLocust, Locust
 from .env import Environment
 from .inspectlocust import get_task_ratio_dict, print_task_ratio
-from .log import console_logger, setup_logging
+from .log import setup_logging, greenlet_exception_logger
 from .runners import LocalLocustRunner, MasterLocustRunner, WorkerLocustRunner
 from .stats import (print_error_report, print_percentile_stats, print_stats,
                     stats_printer, stats_writer, write_csv_files)
@@ -120,14 +120,19 @@ def main():
     
     # setup logging
     if not options.skip_log_setup:
-        setup_logging(options.loglevel, options.logfile)
+        if options.loglevel.upper() in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+            setup_logging(options.loglevel, options.logfile)
+        else:
+            sys.stderr.write("Invalid --loglevel. Valid values are: DEBUG/INFO/WARNING/ERROR/CRITICAL\n")
+            sys.exit(1)
 
     logger = logging.getLogger(__name__)
+    greenlet_exception_handler = greenlet_exception_logger(logger)
 
     if options.list_commands:
-        console_logger.info("Available Locusts:")
+        print("Available Locusts:")
         for name in locusts:
-            console_logger.info("    " + name)
+            print("    " + name)
         sys.exit(0)
 
     if not locusts:
@@ -151,11 +156,11 @@ def main():
     environment = create_environment(options, events=locust.events)
     
     if options.show_task_ratio:
-        console_logger.info("\n Task ratio per locust class")
-        console_logger.info( "-" * 80)
+        print("\n Task ratio per locust class")
+        print( "-" * 80)
         print_task_ratio(locust_classes)
-        console_logger.info("\n Total task ratio")
-        console_logger.info("-" * 80)
+        print("\n Total task ratio")
+        print("-" * 80)
         print_task_ratio(locust_classes, total=True)
         sys.exit(0)
     if options.show_task_ratio_json:
@@ -164,7 +169,7 @@ def main():
             "per_class": get_task_ratio_dict(locust_classes), 
             "total": get_task_ratio_dict(locust_classes, total=True)
         }
-        console_logger.info(dumps(task_data))
+        print(dumps(task_data))
         sys.exit(0)
 
     if options.step_time:
@@ -221,7 +226,7 @@ def main():
             def timelimit_stop():
                 logger.info("Time limit reached. Stopping Locust.")
                 runner.quit()
-            gevent.spawn_later(options.run_time, timelimit_stop)
+            gevent.spawn_later(options.run_time, timelimit_stop).link_exception(greenlet_exception_handler)
     
     # start Web UI
     if not options.headless and not options.worker:
@@ -234,6 +239,7 @@ def main():
             sys.exit(1)
         else:
             main_greenlet = gevent.spawn(web_ui.start, host=options.web_host, port=options.web_port)
+            main_greenlet.link_exception(greenlet_exception_handler)
     else:
         web_ui = None
     
@@ -263,9 +269,10 @@ def main():
     if not options.only_summary and (options.print_stats or (options.headless and not options.worker)):
         # spawn stats printing greenlet
         stats_printer_greenlet = gevent.spawn(stats_printer(runner.stats))
+        stats_printer_greenlet.link_exception(greenlet_exception_handler)
 
     if options.csvfilebase:
-        gevent.spawn(stats_writer, environment, options.csvfilebase, full_history=options.stats_history_enabled)
+        gevent.spawn(stats_writer, environment, options.csvfilebase, full_history=options.stats_history_enabled).link_exception(greenlet_exception_handler)
 
     
     def shutdown(code=0):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -11,6 +11,7 @@ import gevent
 import psutil
 from gevent.pool import Group
 
+from .log import greenlet_exception_logger
 from .rpc import Message, rpc
 from .stats import RequestStats, setup_distributed_stats_event_listeners
 
@@ -27,6 +28,9 @@ HEARTBEAT_LIVENESS = 3
 FALLBACK_INTERVAL = 5
 
 
+greenlet_exception_handler = greenlet_exception_logger(logger)
+
+
 class LocustRunner(object):
     def __init__(self, environment, locust_classes):
         environment.runner = self
@@ -39,7 +43,7 @@ class LocustRunner(object):
         self.stepload_greenlet = None
         self.current_cpu_usage = 0
         self.cpu_warning_emitted = False
-        self.greenlet.spawn(self.monitor_cpu)
+        self.greenlet.spawn(self.monitor_cpu).link_exception(greenlet_exception_handler)
         self.exceptions = {}
         self.stats = RequestStats()
         
@@ -230,6 +234,7 @@ class LocustRunner(object):
         logger.info("Start a new swarming in Step Load mode: total locust count of %d, hatch rate of %d, step locust count of %d, step duration of %d " % (locust_count, hatch_rate, step_locust_count, step_duration))
         self.state = STATE_INIT
         self.stepload_greenlet = self.greenlet.spawn(self.stepload_worker, hatch_rate, step_locust_count, step_duration)
+        self.stepload_greenlet.link_exception(greenlet_exception_handler)
 
     def stepload_worker(self, hatch_rate, step_clients_growth, step_duration):
         current_num_clients = 0
@@ -285,6 +290,7 @@ class LocalLocustRunner(LocustRunner):
             # kill existing hatching_greenlet before we start a new one
             self.hatching_greenlet.kill(block=True)
         self.hatching_greenlet = self.greenlet.spawn(lambda: super(LocalLocustRunner, self).start(locust_count, hatch_rate, wait=wait))
+        self.hatching_greenlet.link_exception(greenlet_exception_handler)
     
     def stop(self):
         if self.state == STATE_STOPPED:
@@ -337,8 +343,8 @@ class MasterLocustRunner(DistributedLocustRunner):
         
         self.clients = WorkerNodesDict()
         self.server = rpc.Server(master_bind_host, master_bind_port)
-        self.greenlet.spawn(self.heartbeat_worker)
-        self.greenlet.spawn(self.client_listener)
+        self.greenlet.spawn(self.heartbeat_worker).link_exception(greenlet_exception_handler)
+        self.greenlet.spawn(self.client_listener).link_exception(greenlet_exception_handler)
 
         # listener that gathers info on how many locust users the worker has spawned
         def on_worker_report(client_id, data):
@@ -513,11 +519,11 @@ class WorkerLocustRunner(DistributedLocustRunner):
         self.master_host = master_host
         self.master_port = master_port
         self.client = rpc.Client(master_host, master_port, self.client_id)
-        self.greenlet.spawn(self.heartbeat)
-        self.greenlet.spawn(self.worker)
+        self.greenlet.spawn(self.heartbeat).link_exception(greenlet_exception_handler)
+        self.greenlet.spawn(self.worker).link_exception(greenlet_exception_handler)
         self.client.send(Message("client_ready", None, self.client_id))
         self.worker_state = STATE_INIT
-        self.greenlet.spawn(self.stats_reporter)
+        self.greenlet.spawn(self.stats_reporter).link_exception(greenlet_exception_handler)
         
         # register listener for when all locust users have hatched, and report it to the master node
         def on_hatch_complete(user_count):
@@ -576,6 +582,7 @@ class WorkerLocustRunner(DistributedLocustRunner):
                     # kill existing hatching greenlet before we launch new one
                     self.hatching_greenlet.kill(block=True)
                 self.hatching_greenlet = self.greenlet.spawn(lambda: self.start(locust_count=job["num_clients"], hatch_rate=job["hatch_rate"]))
+                self.hatching_greenlet.link_exception(greenlet_exception_handler)
             elif msg.type == "stop":
                 self.stop()
                 self.client.send(Message("client_stopped", None, self.client_id))

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -7,7 +7,9 @@ from itertools import chain
 import gevent
 
 from .exception import StopLocust
-from .log import console_logger
+
+import logging
+console_logger = logging.getLogger("locust.stats_logger")
 
 STATS_NAME_WIDTH = 60
 STATS_TYPE_WIDTH = 20

--- a/locust/test/mock_logging.py
+++ b/locust/test/mock_logging.py
@@ -6,9 +6,14 @@ class MockedLoggingHandler(logging.Handler):
     warning = []
     info = []
     error = []
+    critical = []
 
     def emit(self, record):
-        getattr(self.__class__, record.levelname.lower()).append(record.getMessage())
+        if record.exc_info:
+            value = {"message":record.getMessage(), "exc_info":record.exc_info}
+        else:
+            value = record.getMessage()
+        getattr(self.__class__, record.levelname.lower()).append(value)
 
     @classmethod
     def reset(cls):

--- a/locust/test/test_log.py
+++ b/locust/test/test_log.py
@@ -1,0 +1,162 @@
+import mock
+import os
+import socket
+import subprocess
+import textwrap
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from logging import getLogger
+
+import gevent
+
+from locust.log import greenlet_exception_logger
+from .testcases import LocustTestCase
+
+
+@contextmanager
+def temporary_file(content, suffix="_locustfile.py"):
+    f = NamedTemporaryFile(suffix=suffix, delete=False)
+    f.write(content.encode("utf-8"))
+    f.close()
+    yield f.name
+    if os.path.exists(f.name):
+        os.remove(f.name)
+
+
+class TestGreenletExceptionLogger(LocustTestCase):
+    # Gevent outputs all unhandled exceptions to stderr, so we'll suppress that in this test
+    @mock.patch("sys.stderr.write")
+    def test_greenlet_exception_logger(self, mocked_stderr):
+        def thread():
+            raise ValueError("Boom!?")
+        logger = getLogger("greenlet_test_logger")
+        g = gevent.spawn(thread)
+        g.link_exception(greenlet_exception_logger(logger))
+        g.join()
+        self.assertEqual(1, len(self.mocked_log.critical))
+        msg = self.mocked_log.critical[0]
+        self.assertIn("Unhandled exception in greenlet: ", msg["message"])
+        self.assertTrue(isinstance(msg["exc_info"][1], ValueError))
+        self.assertIn("Boom!?", str(msg["exc_info"][1]))
+
+
+class TestLoggingOptions(LocustTestCase):
+    def test_logging_output(self):
+        with temporary_file(textwrap.dedent("""
+            import logging
+            from locust import Locust, task, constant
+            
+            class MyLocust(Locust):
+                wait_time = constant(2)
+                @task
+                def my_task(self):
+                    print("running my_task")
+                    logging.info("custom log message")
+        """)) as file_path:
+            output = subprocess.check_output([
+                "locust", 
+                "-f", file_path, 
+                "-c", "1",
+                "-r", "1",
+                "-t", "1",
+                "--headless",
+            ], stderr=subprocess.STDOUT).decode("utf-8")
+        
+        self.assertIn(
+            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(),
+            output,
+        )
+        self.assertIn(
+            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(),
+            output,
+        )
+        self.assertIn(
+            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
+            output,
+        )
+        self.assertIn(
+            "\nrunning my_task\n",
+            output,
+        )
+        # check that custom message of root logger is also printed
+        self.assertIn(
+            "%s/INFO/root: custom log message" % socket.gethostname(),
+            output,
+        )
+    
+    def test_skip_logging(self):
+        with temporary_file(textwrap.dedent("""
+            from locust import Locust, task, constant
+            
+            class MyLocust(Locust):
+                wait_time = constant(2)
+                @task
+                def my_task(self):
+                    print("running my_task")
+        """)) as file_path:
+            output = subprocess.check_output([
+                "locust", 
+                "-f", file_path, 
+                "-c", "1",
+                "-r", "1",
+                "-t", "1",
+                "--headless",
+                "--skip-log-setup",
+            ], stderr=subprocess.STDOUT).decode("utf-8")
+        self.assertEqual("running my_task", output.strip())
+    
+    def test_log_to_file(self):
+        with temporary_file(textwrap.dedent("""
+            import logging
+            from locust import Locust, task, constant
+            
+            class MyLocust(Locust):
+                wait_time = constant(2)
+                @task
+                def my_task(self):
+                    print("running my_task")
+                    logging.info("custom log message")
+        """)) as file_path:
+            with temporary_file("", suffix=".log") as log_file_path:
+                try:
+                    output = subprocess.check_output([
+                        "locust", 
+                        "-f", file_path, 
+                        "-c", "1",
+                        "-r", "1",
+                        "-t", "1",
+                        "--headless",
+                        "--logfile", log_file_path,
+                    ], stderr=subprocess.STDOUT).decode("utf-8")
+                except Exception as e:
+                    import code
+                    code.interact("Error!", local=locals())
+                
+                with open(log_file_path, encoding="utf-8") as f:
+                    log_content = f.read()
+        
+        # make sure print still appears in output
+        self.assertIn("running my_task", output)
+        
+        # check that log messages don't go into output
+        self.assertNotIn("Starting Locust", output)
+        self.assertNotIn("Run time limit set to 1 seconds", output)
+        
+        # check that log messages goes into file        
+        self.assertIn(
+            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(),
+            log_content,
+        )
+        self.assertIn(
+            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(),
+            log_content,
+        )
+        self.assertIn(
+            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
+            log_content,
+        )
+        # check that message of custom logger also went into log file
+        self.assertIn(
+            "%s/INFO/root: custom log message" % socket.gethostname(),
+            log_content,
+        )

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -15,7 +15,6 @@ from flask import (Flask, Response, make_response, redirect, request,
 import locust
 from locust.event import Events
 from locust.env import Environment
-from locust.log import console_logger
 from locust.runners import LocustRunner
 from locust.test.mock_logging import MockedLoggingHandler
 
@@ -148,11 +147,8 @@ class LocustTestCase(unittest.TestCase):
         # set up mocked logging handler
         self._logger_class = MockedLoggingHandler()
         self._logger_class.setLevel(logging.INFO)
-        console_logger.propagate = True
         self._root_log_handlers = [h for h in logging.root.handlers]
-        self._console_log_handlers = [h for h in console_logger.handlers]
         [logging.root.removeHandler(h) for h in logging.root.handlers]
-        [console_logger.removeHandler(h) for h in console_logger.handlers]
         logging.root.addHandler(self._logger_class)
         logging.root.setLevel(logging.INFO)
         self.mocked_log = MockedLoggingHandler
@@ -161,9 +157,7 @@ class LocustTestCase(unittest.TestCase):
         # restore logging class
         logging.root.removeHandler(self._logger_class)
         [logging.root.addHandler(h) for h in self._root_log_handlers]
-        [console_logger.addHandler(h) for h in self._console_log_handlers]
         self.mocked_log.reset()
-        console_logger.propagate = False
 
 
 class WebserverTestCase(LocustTestCase):


### PR DESCRIPTION
PR for #1285. Does the following:

* We no longer wrap `sys.stdout` and `sys.stderr` (yay!). `print()` statements in locust scripts will no longer automatically go into the log. If someone wants to add entries to the log they can use the root logger instead (`logging.info(…)`), or any custom logger named `"locust.*"`.
* The "console_logger" logger has been removed. For printing stats to the console we now use a logger called `"locust.stats_logger"`. For printing output when using flags such as `--show-task-ratio` or `-l` we now use `print()` statements instead.
* We now set up an exception handler that logs any unhandled exception, for every greenlet we spawn (using Greenlet.link_exception) unless they already have their own exception handler (e.g. Locust User greenlets).
* Only allow valid `--loglevel` values.
* Better tests.