### PR TITLE
Import wait functions from locust instead of locust.wait_time

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -120,8 +120,7 @@ Here is an example:
 
 .. code-block:: python
 
-    from locust import Locust, task
-    from locust.wait_time import constant
+    from locust import Locust, task, constant
 
     class MyLocust(Locust):
         wait_time = constant(1)
@@ -135,8 +134,7 @@ the following example *task2* will have twice the chance of being picked as *tas
 
 .. code-block:: python
     
-    from locust import Locust, task
-    from locust.wait_time import between
+    from locust import Locust, task, between
     
     class MyLocust(Locust):
         wait_time = between(5, 15)

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -3,12 +3,11 @@ from gevent import sleep
 from gevent.pool import Group
 
 from locust.exception import InterruptTaskSet, ResponseError
-from locust.core import HttpLocust, Locust, TaskSet, task
+from locust import HttpLocust, Locust, TaskSet, task, between, constant
 from locust.env import Environment
 from locust.exception import (CatchResponseError, LocustError, RescheduleTask,
                               RescheduleTaskImmediately, StopLocust)
 
-from locust.wait_time import between, constant
 from .testcases import LocustTestCase, WebserverTestCase
 
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -5,7 +5,7 @@ from gevent import sleep
 from gevent.queue import Queue
 
 import mock
-from locust import runners
+from locust import runners, between, constant
 from locust.main import create_environment
 from locust.core import Locust, TaskSet, task
 from locust.env import Environment
@@ -15,7 +15,7 @@ from locust.runners import LocustRunner, LocalLocustRunner, MasterLocustRunner, 
      WorkerLocustRunner, STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_MISSING
 from locust.stats import RequestStats
 from locust.test.testcases import LocustTestCase
-from locust.wait_time import between, constant
+
 
 NETWORK_BROKEN = "network broken"
 

--- a/locust/test/test_sequential_taskset.py
+++ b/locust/test/test_sequential_taskset.py
@@ -1,7 +1,6 @@
-from locust.core import Locust, task
+from locust import Locust, task, constant
 from locust.sequential_taskset import SequentialTaskSet
 from locust.exception import RescheduleTask
-from locust.wait_time import constant
 from .testcases import LocustTestCase
 
 

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -7,14 +7,13 @@ import os
 import gevent
 import mock
 import locust
-from locust.core import HttpLocust, TaskSet, task, Locust
+from locust import HttpLocust, TaskSet, task, Locust, constant
 from locust.env import Environment
 from locust.inspectlocust import get_task_ratio_dict
 from locust.runners import LocalLocustRunner, MasterLocustRunner
 from locust.rpc.protocol import Message
 from locust.stats import CachedResponseTimes, RequestStats, StatsEntry, diff_response_time_dicts, stats_writer
 from locust.test.testcases import LocustTestCase
-from locust.wait_time import constant
 
 from .testcases import WebserverTestCase
 from .test_runners import mocked_options, mocked_rpc

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -1,9 +1,8 @@
 import random
 import time
 
-from locust.core import Locust, TaskSet
+from locust import Locust, TaskSet, between, constant, constant_pacing
 from locust.exception import MissingWaitTimeError
-from locust.wait_time import between, constant, constant_pacing
 
 from .testcases import LocustTestCase
 


### PR DESCRIPTION
In documentation as well as test cases. Relates to #1328