### PR TITLE
Hotfix - CLI Failing on start due to Service Unknown

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -110,7 +110,7 @@ class Environment:
             master_port=master_port,
         )
     
-    def create_web_ui(self, host="", port=8089, auth_credentials=None):
+    def create_web_ui(self, host="*", port=8089, auth_credentials=None):
         """
         Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server
         

--- a/locust/env.py
+++ b/locust/env.py
@@ -110,7 +110,7 @@ class Environment:
             master_port=master_port,
         )
     
-    def create_web_ui(self, host="*", port=8089, auth_credentials=None):
+    def create_web_ui(self, host="", port=8089, auth_credentials=None):
         """
         Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server
         

--- a/locust/main.py
+++ b/locust/main.py
@@ -224,13 +224,12 @@ def main():
         # spawn web greenlet
         logger.info("Starting web monitor at http://%s:%s" % (options.web_host or "*", options.web_port))
         try:
-            web_ui = environment.create_web_ui(auth_credentials=options.web_auth)
+            web_ui = environment.create_web_ui(host=options.web_host, port=options.web_port, auth_credentials=options.web_auth)
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)
         else:
-            main_greenlet = gevent.spawn(web_ui.start, host=options.web_host, port=options.web_port)
-            main_greenlet.link_exception(greenlet_exception_handler)
+            web_ui.greenlet.link_exception(greenlet_exception_handler)
     else:
         web_ui = None
     

--- a/locust/main.py
+++ b/locust/main.py
@@ -229,7 +229,8 @@ def main():
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)
         else:
-            web_ui.greenlet.link_exception(greenlet_exception_handler)
+            main_greenlet = web_ui.greenlet
+            main_greenlet.link_exception(greenlet_exception_handler)
     else:
         web_ui = None
     


### PR DESCRIPTION
It seems that #1327 introduced an issue when starting locust via the cli:
```
(venv) [trouv@ruckus-lite test]$ locust --host https://test.com/ -c 10 -r 10
[2020-04-16 21:08:24,861] ruckus-lite/INFO/locust.main: Starting web monitor at http://*:8089
[2020-04-16 21:08:24,868] ruckus-lite/INFO/locust.main: Starting Locust 1.0.0
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 854, in gevent._greenlet.Greenlet.run
  File "/home/trouv/Projects/locust/repo/locust/web.py", line 273, in start
    self.server.serve_forever()
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/baseserver.py", line 387, in serve_forever
    self.start()
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/baseserver.py", line 325, in start
    self.init_socket()
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/pywsgi.py", line 1482, in init_socket
    StreamServer.init_socket(self)
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/server.py", line 180, in init_socket
    self.socket = self.get_listener(self.address, self.backlog, self.family)
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/server.py", line 192, in get_listener
    return _tcp_listener(address, backlog=backlog, reuse_addr=cls.reuse_addr, family=family)
  File "/home/trouv/Projects/locust/venv/lib/python3.8/site-packages/gevent/server.py", line 288, in _tcp_listener
    sock.bind(address)
socket.gaierror: [Errno -2] Name or service not known: ('*', 8089)
2020-04-17T03:08:24Z <Greenlet at 0x7f45a4db6150: <bound method WebUI.start of <locust.web.WebUI object at 0x7f45a4e18a90>>> failed with gaierror

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 854, in gevent._greenlet.Greenlet.run
TypeError: start() got an unexpected keyword argument 'host'
2020-04-17T03:08:24Z <Greenlet at 0x7f45a4db6260: <bound method WebUI.start of <locust.web.WebUI object at 0x7f45a4e18a90>>(host='', port=8089)> failed with TypeError

[2020-04-16 21:08:24,876] ruckus-lite/CRITICAL/locust.main: Unhandled exception in greenlet: <Greenlet at 0x7f45a4db6260: <bound method WebUI.start of <locust.web.WebUI object at 0x7f45a4e18a90>>(host='', port=8089)>
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 854, in gevent._greenlet.Greenlet.run
TypeError: start() got an unexpected keyword argument 'host'
[2020-04-16 21:08:24,877] ruckus-lite/INFO/locust.main: Shutting down (exit code 0), bye.
```
This branch seems to resolve the issue, or at least part of it. It mostly just seems that this block of code wasn't updated to accommodate the new environment api

However, part of the reason this resolves the issue is that, when you use the cli, web_host defaults to an empty string instead of '*'. It seems that this was how the cli worked in the past as well. Using * breaks things again for me, so I'm concerned about us using * as the default host in env.create_web_ui(). I don't think I know enough about pywsgi to make a good argument here though. What do y'all think?