### PR TITLE
Fix web options

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -159,7 +159,7 @@ def setup_parser_arguments(parser):
     web_ui_group.add_argument(
         '--web-host',
         default="",
-        help="Host to bind the web interface to. Defaults to '' (all interfaces)"
+        help="Host to bind the web interface to. Defaults to '*' (all interfaces)"
     )
     web_ui_group.add_argument(
         '--web-port', '-P',

--- a/locust/env.py
+++ b/locust/env.py
@@ -114,7 +114,7 @@ class Environment:
         """
         Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server
         
-        :param host: Host/interface that the web server should accept connections to. Defaults to "*"
+        :param host: Host/interface that the web server should accept connections to. Defaults to ""
                      which means all interfaces
         :param port: Port that the web server should listen to
         :param auth_credentials: If provided (in format "username:password") basic auth will be enabled

--- a/locust/main.py
+++ b/locust/main.py
@@ -223,9 +223,14 @@ def main():
     # start Web UI
     if not options.headless and not options.worker:
         # spawn web greenlet
-        logger.info("Starting web monitor at http://%s:%s" % (options.web_host or "*", options.web_port))
+        logger.info("Starting web monitor at http://%s:%s" % (options.web_host, options.web_port))
         try:
-            web_ui = environment.create_web_ui(host=options.web_host, port=options.web_port, auth_credentials=options.web_auth)
+            if options.web_host == "*":
+                # special check for "*" so that we're consistent with --master-bind-host
+                web_host = ''
+            else:
+                web_host = options.web_host
+            web_ui = environment.create_web_ui(host=web_host, port=options.web_port, auth_credentials=options.web_auth)
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)

--- a/locust/main.py
+++ b/locust/main.py
@@ -225,7 +225,7 @@ def main():
         # spawn web greenlet
         logger.info("Starting web monitor at http://%s:%s" % (options.web_host or "*", options.web_port))
         try:
-            web_ui = environment.create_web_ui(web_host=options.web_host, web_port=options.web_port, auth_credentials=options.web_auth)
+            web_ui = environment.create_web_ui(host=options.web_host, port=options.web_port, auth_credentials=options.web_auth)
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)

--- a/locust/main.py
+++ b/locust/main.py
@@ -225,7 +225,7 @@ def main():
         # spawn web greenlet
         logger.info("Starting web monitor at http://%s:%s" % (options.web_host or "*", options.web_port))
         try:
-            web_ui = environment.create_web_ui(auth_credentials=options.web_auth)
+            web_ui = environment.create_web_ui(web_host=options.web_host, web_port=options.web_port, auth_credentials=options.web_auth)
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)

--- a/locust/test/mock_locustfile.py
+++ b/locust/test/mock_locustfile.py
@@ -51,5 +51,7 @@ def mock_locustfile(filename_prefix="mock_locustfile", content=MOCK_LOUCSTFILE_C
     with open(mocked.file_path, 'w') as file:
         file.write(content)
     
-    yield mocked
-    os.remove(mocked.file_path)
+    try:
+        yield mocked
+    finally:
+        os.remove(mocked.file_path)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -114,10 +114,10 @@ class LocustProcessIntegrationTest(TestCase):
             proc = subprocess.Popen(
                     ["locust",
                         "-f", mocked.file_path,
-                        "--web-host", "127.0.0.1",
+                        "--web-host", "127.0.0.2",
                         "--web-port", "8090"],
                     stdout=PIPE, stderr=PIPE
                     )
             gevent.sleep(0.5)
-            self.assertEqual(200, requests.get("http://127.0.0.1:8090/").status_code)
+            self.assertEqual(200, requests.get("http://127.0.0.2:8090/").status_code)
             proc.terminate()

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -136,3 +136,14 @@ class LocustProcessIntegrationTest(TestCase):
             gevent.sleep(0.5)
             self.assertEqual(200, requests.get("http://%s:%i/" % (interface, port), timeout=1).status_code)
             proc.terminate()
+            
+        with mock_locustfile() as mocked:
+            proc = subprocess.Popen([
+                "locust",
+                "-f", mocked.file_path,
+                "--web-host", "*",
+                "--web-port", str(port),
+            ], stdout=PIPE, stderr=PIPE)
+            gevent.sleep(0.5)
+            self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % port, timeout=1).status_code)
+            proc.terminate()

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -78,6 +78,15 @@ class TestLoadLocustfile(LocustTestCase):
 
 
 class LocustProcessIntegrationTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.timeout = gevent.Timeout(10)
+        self.timeout.start()
+    
+    def tearDowwn():
+        self.timeout.cancel()
+        super().tearDown()
+    
     def test_help_arg(self):
         output = subprocess.check_output(
             ["locust", "--help"], 

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -127,13 +127,12 @@ class LocustProcessIntegrationTest(TestCase):
         else:
             interface = "127.0.0.2"
         with mock_locustfile() as mocked:
-            proc = subprocess.Popen(
-                    ["locust",
-                        "-f", mocked.file_path,
-                        "--web-host", interface,
-                        "--web-port", str(port)],
-                    stdout=PIPE, stderr=PIPE
-                    )
+            proc = subprocess.Popen([
+                "locust",
+                "-f", mocked.file_path,
+                "--web-host", interface,
+                "--web-port", str(port)
+            ], stdout=PIPE, stderr=PIPE)
             gevent.sleep(0.5)
             self.assertEqual(200, requests.get("http://%s:%i/" % (interface, port), timeout=1).status_code)
             proc.terminate()

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from subprocess import PIPE
 
 import gevent
+import requests
 
 from locust import main
 from locust.argument_parser import parse_options
@@ -108,3 +109,15 @@ class LocustProcessIntegrationTest(TestCase):
             self.assertIn("Starting Locust", stderr)
             self.assertIn("Shutting down (exit code 0), bye", stderr)
 
+    def test_web_options(self):
+        with mock_locustfile() as mocked:
+            proc = subprocess.Popen(
+                    ["locust",
+                        "-f", mocked.file_path,
+                        "--web-host", "127.0.0.1",
+                        "--web-port", "8090"],
+                    stdout=PIPE, stderr=PIPE
+                    )
+            gevent.sleep(0.5)
+            self.assertEqual(200, requests.get("http://127.0.0.1:8090/").status_code)
+            proc.terminate()

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -83,7 +83,7 @@ class LocustProcessIntegrationTest(TestCase):
         self.timeout = gevent.Timeout(10)
         self.timeout.start()
     
-    def tearDowwn():
+    def tearDown(self):
         self.timeout.cancel()
         super().tearDown()
     

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -9,9 +9,11 @@ def temporary_file(content, suffix="_locustfile.py"):
     f = NamedTemporaryFile(suffix=suffix, delete=False)
     f.write(content.encode("utf-8"))
     f.close()
-    yield f.name
-    if os.path.exists(f.name):
-        os.remove(f.name)
+    try:
+        yield f.name
+    finally:
+        if os.path.exists(f.name):
+            os.remove(f.name)
 
 
 def get_free_tcp_port():

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -1,4 +1,5 @@
 import os
+import socket
 
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
@@ -11,3 +12,14 @@ def temporary_file(content, suffix="_locustfile.py"):
     yield f.name
     if os.path.exists(f.name):
         os.remove(f.name)
+
+
+def get_free_tcp_port():
+    """
+    Find an unused TCP port
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port


### PR DESCRIPTION
As mentioned in #1339, web_host and web_port aren't actually being used. Fixed this and added a test for it.

Still not sure about saying "*" is the default web_host when it no longer is. I changed the docstring for this anyway but idk if "" still means "all interfaces"? 