### PR TITLE
Fix the package name in the sample pip3 command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Locust is available on `PyPI <https://pypi.org/project/locustio/>`_ and can be i
 
 .. code-block:: console
 
-    $ pip3 install locust
+    $ pip3 install locustio
 
 If you want the bleeding edge version, you can use pip to install directly from our Git repository.  For example, to install the master branch using Python 3:
 


### PR DESCRIPTION
The link to `locustio` is correct, but the copy/paste command uses `locust` as the package name.