### PR TITLE
Fixing syntax error in env.py

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -57,7 +57,7 @@ class Environment:
         step_load=False, 
         stop_timeout=None,
         catch_exceptions=True,
-        parsed_options=None,
+        parsed_options=None
     ):
         if events:
             self.events = events


### PR DESCRIPTION
Fixing invalid syntax - 

  File "/home/azureuser/.local/bin/locust", line 9, in <module>
    load_entry_point('locustio', 'console_scripts', 'locust')()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/azureuser/locust-tests/bin/src/locustio/locust/main.py", line 16, in <module>
    from .env import Environment
  File "/home/azureuser/locust-tests/bin/src/locustio/locust/env.py", line 61
    ):
    ^