### PR TITLE
Remove task arguments

### DIFF
--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -822,10 +822,7 @@ class TestMasterRunner(LocustTestCase):
         class MyTaskSet(TaskSet):
             def __init__(self, *a, **kw):
                 super(MyTaskSet, self).__init__(*a, **kw)
-                self._task_queue = [
-                    {"callable":self.will_error, "args":[], "kwargs":{}}, 
-                    {"callable":self.will_stop, "args":[], "kwargs":{}},
-                ]
+                self._task_queue = [self.will_error, self.will_stop]
             
             @task(1)
             def will_error(self):


### PR DESCRIPTION
This PR removes `args` and `kwargs` arguments from the internal `TaskSet.schedule_task` and `TaskSet.execute_task` methods.

Passing arguments to tasks was an old legacy feature that was never documented, and never used internally (except in tests). I think removing this feature in the name of KISS makes sense, since the feature aren't used internally, even though the methods are internal.

This will however be a breaking change for people who have looked at the Locust source and chosen to use this feature.