### PR TITLE
Bump geventhttpclient and switch back to use its original repo 

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -6,7 +6,6 @@ import signal
 import socket
 import sys
 import time
-import resource 
 
 import gevent
 
@@ -155,6 +154,7 @@ def main():
         user_classes = list(user_classes.values())
     
     try:
+        import resource 
         if resource.getrlimit(resource.RLIMIT_NOFILE)[0] < 10000:
             # Increasing the limit to 10000 within a running process should work on at least MacOS.
             # It does not work on all OS:es, but we should be no worse off for trying.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "requests>=2.9.1", 
         "msgpack>=0.6.2", 
         "pyzmq>=16.0.2", 
-        "geventhttpclient-wheels==1.3.1.dev3",
+        "geventhttpclient>=1.4.0",
         "ConfigArgParse>=1.0",
         "psutil>=5.6.7",
         "Flask-BasicAuth>=0.2.0"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "requests>=2.9.1", 
         "msgpack>=0.6.2", 
         "pyzmq>=16.0.2", 
-        "geventhttpclient>=1.4.0",
+        "geventhttpclient>=1.4.2",
         "ConfigArgParse>=1.0",
         "psutil>=5.6.7",
         "Flask-BasicAuth>=0.2.0"


### PR DESCRIPTION
... instead of its fork, now that there is a new release (I can trigger new releases later on as well). Relates to #1116