### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -417,7 +417,7 @@ Now RequestStats should be instantiated and holds the global stats, as well as a
 Removed support for avg_wait
 ----------------------------
 
-Previously one could specify avg_wait to :py:class:`TaskSet` and :py:class:`Locust` that Locust would try to strive to. However this can be sufficiently accomplished by using min_wait and max_wait for most use-cases. Therefore we've decided to remove the avg_wait as it's use-case is not clear or just too narrow to be in the Locust core.
+Previously one could specify avg_wait to :py:class:`TaskSet` and :py:class:`Locust` that Locust would try to strive to. However this can be sufficiently accomplished by using min_wait and max_wait for most use-cases. Therefore we've decided to remove the avg_wait as its use-case is not clear or just too narrow to be in the Locust core.
 
 Removed support for ramping
 ----------------------------


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!