### PR TITLE
Base Locust Docker image on non-alpine python image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ build/
 .coverage
 .tox/
 docs/
+.git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ dist/
 build/
 .coverage
 .tox/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.8
 
-COPY . /src
-WORKDIR /src
-RUN pip install .
-RUN rm -rf /src
+COPY . /build
+RUN cd /build && pip install . && rm -rf /build
 
 EXPOSE 8089 5557
 
 RUN useradd --create-home locust
 USER locust
+WORKDIR /home/locust
 ENTRYPOINT ["locust"]
 
 # turn off python output buffering

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM python:3.8-alpine as builder
+FROM python:3.8 as builder
 
-RUN apk --no-cache add g++ zeromq-dev libffi-dev file make gcc musl-dev
 COPY . /src
 WORKDIR /src
 RUN pip install .
 
-FROM python:3.8-alpine
 
-RUN apk --no-cache add zeromq && adduser -s /bin/false -D locust
+FROM python:3.8
+
 COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 COPY --from=builder /usr/local/bin/locust /usr/local/bin/locust
 
 EXPOSE 8089 5557
 
+RUN useradd --create-home locust
 USER locust
 ENTRYPOINT ["locust"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
-FROM python:3.8 as builder
+FROM python:3.8
 
 COPY . /src
 WORKDIR /src
 RUN pip install .
-
-
-FROM python:3.8
-
-COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
-COPY --from=builder /usr/local/bin/locust /usr/local/bin/locust
+RUN rm -rf /src
 
 EXPOSE 8089 5557
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,12 @@ Changelog Highlights
 
 For full details of the Locust changelog, please see https://github.com/locustio/locust/blob/master/CHANGELOG.md
 
-In development
-==============
+1.1 (In development)
+====================
+
+* The official Docker image is now based on the ``python:3.8`` image instead of ``python:3.8-alpine``. This should 
+  make it easier to install other python packages when extending the locust  docker image.
+
 
 1.0.3
 =====


### PR DESCRIPTION
This PR makes Locust use the `python:3.8` docker image instead of `python:3.8-alpine` as the base image.

The reason for this is that it'll make it possible to `pip install ...` most PyPI packages out of the box, which should be a very common thing to do in project specific docker images. 

It comes with a ~900 MB cost in total image size, though I think the `python:3.8` image should be a very common base image to already have pulled, in which case there will effectively be no higher disk usage, and I think it makes sense to prioritize developer convenience and happiness over disk usage.

This is what the description at the [official docker python repo](https://hub.docker.com/_/python) says about the `python:3.8` image:

> This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.

We could consider maintaining two branches of docker images (`locustio/locust` and `locustio/locust-alpine`), but I don't think it's worth the extra maintenance work.

We would have to bump the Locust version to 1.1 if we release this, since it might break end-users custom docker images (the fixes should be very easy though, and mostly consist of removing a bunch of lines no longer needed from their Dockerfiles).