### PR TITLE
Gracefully handle exceptions in event listeners

### DIFF
--- a/locust/event.py
+++ b/locust/event.py
@@ -30,7 +30,10 @@ class EventHook(object):
         else:
             handlers = self._handlers
         for handler in handlers:
-            handler(**kwargs)
+            try:
+                handler(**kwargs)
+            except:
+                pass
 
 
 class Events:

--- a/locust/event.py
+++ b/locust/event.py
@@ -1,3 +1,5 @@
+import logging
+
 class EventHook(object):
     """
     Simple event class used to provide hooks for different types of events in Locust.
@@ -32,8 +34,8 @@ class EventHook(object):
         for handler in handlers:
             try:
                 handler(**kwargs)
-            except:
-                pass
+            except Exception as e:
+                logging.error("Uncaught exception in event handler: %s", e)
 
 
 class Events:

--- a/locust/event.py
+++ b/locust/event.py
@@ -1,4 +1,5 @@
 import logging
+from .log import unhandled_greenlet_exception
 
 class EventHook(object):
     """
@@ -36,6 +37,7 @@ class EventHook(object):
                 handler(**kwargs)
             except Exception as e:
                 logging.error("Uncaught exception in event handler: %s", e)
+                unhandled_greenlet_exception = True
 
 
 class Events:


### PR DESCRIPTION
An exception thrown during the handling of an event will stop the execution of other listeners.

Solves #1461