### PR TITLE
Improve logging when locust master port is busy.

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -405,7 +405,7 @@ class MasterRunner(DistributedRunner):
         except RPCError as e:
             if e.args[0] == "Socket bind failure: Address already in use":
                 port_string = master_bind_host + ":" + master_bind_port if master_bind_host != "*" else master_bind_port
-                logger.error(f"The Locust master port ({port_string}) was busy. Close any applications using that port - perhaps an old instance of Locust is still running? ({e.args[0]})")
+                logger.error(f"The Locust master port ({port_string}) was busy. Close any applications using that port - perhaps an old instance of Locust master is still running? ({e.args[0]})")
                 sys.exit(1)
             else:
                 raise


### PR DESCRIPTION
Avoid issues like https://stackoverflow.com/questions/62769727/facing-error-address-already-in-use-while-running-locust

Instead of printing:

```
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: Traceback (most recent call last):
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: File "/home/sonali/.local/bin/locust", line 8, in <module>
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: sys.exit(main())
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,897] sonali-Latitude-3490/ERROR/stderr: File "/home/sonali/.local/lib/python3.6/site-packages/locust/main.py", line 503, in main
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: runners.locust_runner = MasterLocustRunner(locust_classes, options)
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: File "/home/sonali/.local/lib/python3.6/site-packages/locust/runners.py", line 320, in __init__
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: self.server = rpc.Server(self.master_bind_host, self.master_bind_port)
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: File "/home/sonali/.local/lib/python3.6/site-packages/locust/rpc/zmqrpc.py", line 41, in __init__
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: self.socket.bind("tcp://%s:%i" % (host, port))
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: File "zmq/backend/cython/socket.pyx", line 550, in zmq.backend.cython.socket.Socket.bind
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: File "zmq/backend/cython/checkrc.pxd", line 26, in zmq.backend.cython.checkrc._check_rc
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: zmq.error
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: .
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: ZMQError
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: :
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: Address already in use
[2020-07-07 12:26:25,898] sonali-Latitude-3490/ERROR/stderr: 
```

It will print something like:

`[2020-07-07 10:19:28,906] lafp-mac-JG5J.int.svenskaspel.se/ERROR/locust.runners: The Locust master port (5557) was busy. Close any applications using that port - perhaps an old instance of Locust is still running? (Socket bind failure: Address already in use)`