### PR TITLE
Replace time.time() with time.monotonic()

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -109,12 +109,12 @@ class HttpSession(requests.Session):
         
         # set up pre_request hook for attaching meta data to the request object
         request_meta["method"] = method
-        request_meta["start_time"] = time.time()
+        request_meta["start_time"] = time.monotonic()
         
         response = self._send_request_safe_mode(method, url, **kwargs)
         
         # record the consumed time
-        request_meta["response_time"] = (time.time() - request_meta["start_time"]) * 1000
+        request_meta["response_time"] = (time.monotonic() - request_meta["start_time"]) * 1000
         
     
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -47,9 +47,9 @@ class TestWaitTime(LocustTestCase):
         self.assertEqual(0, MyUser(self.environment).wait_time())
         self.assertEqual(0, TaskSet1(MyUser(self.environment)).wait_time())
         taskset = TaskSet1(MyUser(self.environment))
-        start_time = time.time()
+        start_time = time.monotonic()
         taskset.wait()
-        self.assertLess(time.time() - start_time, 0.002)
+        self.assertLess(time.monotonic() - start_time, 0.002)
     
     def test_constant_pacing(self):
         class MyUser(User):
@@ -60,12 +60,12 @@ class TestWaitTime(LocustTestCase):
         
         ts2 = TS(MyUser(self.environment))
         
-        previous_time = time.time()
+        previous_time = time.monotonic()
         for i in range(7):
             ts.wait()
-            since_last_run = time.time() - previous_time
+            since_last_run = time.monotonic() - previous_time
             self.assertLess(abs(0.1 - since_last_run), 0.02)
-            previous_time = time.time()
+            previous_time = time.monotonic()
             time.sleep(random.random() * 0.1)
             _ = ts2.wait_time()
             _ = ts2.wait_time()


### PR DESCRIPTION
Resolves https://github.com/locustio/locust/issues/1487

I didn't replace it in parts related to stats as I'm not sure of the effect there. So I've replaced in these 3 parts where time is measured by subtracting a previous time from `time.time()`.

`FastHttpUser` is not affected by this problem in my testing. It uses a timer from the `timeit` package.