### PR TITLE
Autoformat using Black. Also fix a few style complaints (trailing whitespaces)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,12 @@ def save_locust_help_output():
     with open(cli_help_output_file, "w") as f:
         f.write(help_output)
 
+
 save_locust_help_output()
 
 # Generate RST table with help/descriptions for all available environment variables
+
+
 def save_locust_env_variables():
     env_options_output_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config-options.rst")
     print("Generating RST table for Locust environment variables and storing in %s" % env_options_output_file)
@@ -33,27 +36,26 @@ def save_locust_env_variables():
     table_data = []
     for action in parser._actions:
         if action.env_var:
-            table_data.append((
-                ", ".join(["``%s``" % c for c in action.option_strings]), 
-                "``%s``" % action.env_var, 
-                ", ".join(["``%s``" % c for c in parser.get_possible_config_keys(action) if not c.startswith("--")]),
-                action.help,
-            ))
+            table_data.append(
+                (
+                    ", ".join(["``%s``" % c for c in action.option_strings]),
+                    "``%s``" % action.env_var,
+                    ", ".join(
+                        ["``%s``" % c for c in parser.get_possible_config_keys(action) if not c.startswith("--")]
+                    ),
+                    action.help,
+                )
+            )
     colsizes = [max(len(r[i]) for r in table_data) for i in range(len(table_data[0]))]
-    formatter = ' '.join('{:<%d}' % c for c in colsizes)
+    formatter = " ".join("{:<%d}" % c for c in colsizes)
     rows = [formatter.format(*row) for row in table_data]
-    edge = formatter.format(*['=' * c for c in colsizes])
-    divider = formatter.format(*['-' * c for c in colsizes])
+    edge = formatter.format(*["=" * c for c in colsizes])
+    divider = formatter.format(*["-" * c for c in colsizes])
     headline = formatter.format(*["Command line", "Environment", "Config file", "Description"])
-    output = "\n".join([
-        edge,
-        headline,
-        divider,
-        "\n".join(rows),
-        edge,
-    ])
+    output = "\n".join([edge, headline, divider, "\n".join(rows), edge])
     with open(env_options_output_file, "w") as f:
         f.write(output)
+
 
 save_locust_env_variables()
 
@@ -69,29 +71,29 @@ from locust import __version__
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", 'sphinx_search.extension']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx_search.extension"]
 
 # autoclass options
-#autoclass_content = "both"
+# autoclass_content = "both"
 
-autodoc_typehints = 'none' # I would have liked to use 'description' but unfortunately it too is very verbose
+autodoc_typehints = "none"  # I would have liked to use 'description' but unfortunately it too is very verbose
 
 # Add any paths that contain templates here, relative to this directory.
-#templates_path = ["_templates"]
+# templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General substitutions.
-project = 'Locust'
-#copyright = ''
+project = "Locust"
+# copyright = ''
 
 # Intersphinx config
 intersphinx_mapping = {
-    'requests': ('https://requests.readthedocs.io/en/latest/', None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
 }
 
 
@@ -100,12 +102,12 @@ release = __version__
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-today_fmt = '%B %d, %Y'
+today_fmt = "%B %d, %Y"
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+# unused_docs = []
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True
@@ -118,9 +120,9 @@ add_module_names = False
 # output. They are ignored by default.
 show_authors = False
 
-# Sphinx will recurse into subversion configuration folders and try to read  
-# any document file within. These should be ignored. 
-# Note: exclude_dirnames is new in Sphinx 0.5 
+# Sphinx will recurse into subversion configuration folders and try to read
+# any document file within. These should be ignored.
+# Note: exclude_dirnames is new in Sphinx 0.5
 exclude_dirnames = []
 
 # Options for HTML output
@@ -131,11 +133,12 @@ html_file_suffix = ".html"
 
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
@@ -147,14 +150,14 @@ html_context = {
 
 
 # HTML theme
-#html_theme = "haiku"
+# html_theme = "haiku"
 
-#html_theme = "default"
-#html_theme_options = {
+# html_theme = "default"
+# html_theme_options = {
 #    "rightsidebar": "true",
 #    "codebgcolor": "#fafcfa",
 #    "bodyfont": "Arial",
-#}
+# }
 
 # The name of the Pygments (syntax highlighting) style to use.
-#pygments_style = 'trac'
+# pygments_style = 'trac'

--- a/examples/add_command_line_argument.py
+++ b/examples/add_command_line_argument.py
@@ -4,10 +4,8 @@ from locust import events
 
 @events.init_command_line_parser.add_listener
 def _(parser):
-    parser.add_argument(
-        '--custom-argument',
-        help="It's working"
-    )
+    parser.add_argument("--custom-argument", help="It's working")
+
 
 @events.init.add_listener
 def _(environment, **kw):
@@ -18,8 +16,10 @@ class WebsiteUser(HttpUser):
     """
     User class that does requests to the locust web server running on localhost
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
+
     @task
     def my_task(self):
         pass

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -4,22 +4,26 @@ from locust import HttpUser, TaskSet, task, between
 def index(l):
     l.client.get("/")
 
+
 def stats(l):
     l.client.get("/stats/requests")
+
 
 class UserTasks(TaskSet):
     # one can specify tasks like this
     tasks = [index, stats]
-    
+
     # but it might be convenient to use the @task decorator
     @task
     def page404(self):
         self.client.get("/does_not_exist")
-    
+
+
 class WebsiteUser(HttpUser):
     """
     User class that does requests to the locust web server running on localhost
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
     tasks = [UserTasks]

--- a/examples/browse_docs_sequence_test.py
+++ b/examples/browse_docs_sequence_test.py
@@ -16,9 +16,7 @@ class BrowseDocumentationSequence(SequentialTaskSet):
         r = self.client.get("/")
         pq = PyQuery(r.content)
         link_elements = pq(".toctree-wrapper a.internal")
-        self.toc_urls = [
-            l.attrib["href"] for l in link_elements
-        ]
+        self.toc_urls = [l.attrib["href"] for l in link_elements]
 
     @task
     def load_page(self, url=None):
@@ -26,9 +24,7 @@ class BrowseDocumentationSequence(SequentialTaskSet):
         r = self.client.get(url)
         pq = PyQuery(r.content)
         link_elements = pq("a.internal")
-        self.urls_on_current_page = [
-            l.attrib["href"] for l in link_elements
-        ]
+        self.urls_on_current_page = [l.attrib["href"] for l in link_elements]
 
     @task
     def load_sub_page(self):

--- a/examples/browse_docs_test.py
+++ b/examples/browse_docs_test.py
@@ -1,4 +1,4 @@
-# This locust test script example will simulate a user 
+# This locust test script example will simulate a user
 # browsing the Locust documentation on https://docs.locust.io/
 
 import random
@@ -11,26 +11,22 @@ class BrowseDocumentation(TaskSet):
         # assume all users arrive at the index page
         self.index_page()
         self.urls_on_current_page = self.toc_urls
-    
+
     @task(10)
     def index_page(self):
         r = self.client.get("/")
         pq = PyQuery(r.content)
         link_elements = pq(".toctree-wrapper a.internal")
-        self.toc_urls = [
-            l.attrib["href"] for l in link_elements
-        ]
-    
+        self.toc_urls = [l.attrib["href"] for l in link_elements]
+
     @task(50)
     def load_page(self, url=None):
         url = random.choice(self.toc_urls)
         r = self.client.get(url)
         pq = PyQuery(r.content)
         link_elements = pq("a.internal")
-        self.urls_on_current_page = [
-            l.attrib["href"] for l in link_elements
-        ]
-    
+        self.urls_on_current_page = [l.attrib["href"] for l in link_elements]
+
     @task(30)
     def load_sub_page(self):
         url = random.choice(self.urls_on_current_page)
@@ -40,9 +36,7 @@ class BrowseDocumentation(TaskSet):
 class AwesomeUser(HttpUser):
     tasks = [BrowseDocumentation]
     host = "https://docs.locust.io/en/latest/"
-    
-    # we assume someone who is browsing the Locust docs, 
-    # generally has a quite long waiting time (between 
-    # 20 and 600 seconds), since there's a bunch of text 
-    # on each page
+
+    # we assume someone who is browsing the Locust docs, generally has a quite long waiting time (between
+    # 20 and 600 seconds), since there's a bunch of text on each page
     wait_time = between(20, 600)

--- a/examples/custom_wait_function.py
+++ b/examples/custom_wait_function.py
@@ -1,51 +1,55 @@
 from locust import HttpUser, TaskSet, task
 import random
 
+
 def index(l):
     l.client.get("/")
+
 
 def stats(l):
     l.client.get("/stats/requests")
 
+
 class UserTasks(TaskSet):
     # one can specify tasks like this
     tasks = [index, stats]
-    
+
     # but it might be convenient to use the @task decorator
     @task
     def page404(self):
         self.client.get("/does_not_exist")
-    
+
+
 class WebsiteUser(HttpUser):
     """
     User class that does requests to the locust web server running on localhost
     """
+
     host = "http://127.0.0.1:8089"
     # Most task inter-arrival times approximate to exponential distributions
     # We will model this wait time as exponentially distributed with a mean of 1 second
     wait_time = lambda self: random.expovariate(1)
     tasks = [UserTasks]
 
-def strictExp(min_wait,max_wait,mu=1):
+
+def strictExp(min_wait, max_wait, mu=1):
     """
     Returns an exponentially distributed time strictly between two bounds.
     """
     while True:
         x = random.expovariate(mu)
-        increment = (max_wait-min_wait)/(mu*6.0)
-        result = min_wait + (x*increment)
-        if result<max_wait:
+        increment = (max_wait - min_wait) / (mu * 6.0)
+        result = min_wait + (x * increment)
+        if result < max_wait:
             break
     return result
+
 
 class StrictWebsiteUser(HttpUser):
     """
     User class that makes exponential requests but strictly between two bounds.
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = lambda self: strictExp(3, 7)
     tasks = [UserTasks]
-
-
-
-

--- a/examples/custom_xmlrpc_client/server.py
+++ b/examples/custom_xmlrpc_client/server.py
@@ -7,9 +7,11 @@ def get_time():
     time.sleep(random.random())
     return time.time()
 
+
 def get_random_number(low, high):
     time.sleep(random.random())
     return random.randint(low, high)
+
 
 server = SimpleXMLRPCServer(("localhost", 8877))
 print("Listening on port 8877...")

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -6,28 +6,33 @@ from locust import User, task, between
 
 class XmlRpcClient(ServerProxy):
     """
-    Simple, sample XML RPC client implementation that wraps xmlrpclib.ServerProxy and 
-    fires locust events on request_success and request_failure, so that all requests 
+    Simple, sample XML RPC client implementation that wraps xmlrpclib.ServerProxy and
+    fires locust events on request_success and request_failure, so that all requests
     gets tracked in locust's statistics.
     """
-    
+
     _locust_environment = None
-    
+
     def __getattr__(self, name):
         func = ServerProxy.__getattr__(self, name)
+
         def wrapper(*args, **kwargs):
             start_time = time.time()
             try:
                 result = func(*args, **kwargs)
             except Fault as e:
                 total_time = int((time.time() - start_time) * 1000)
-                self._locust_environment.events.request_failure.fire(request_type="xmlrpc", name=name, response_time=total_time, exception=e)
+                self._locust_environment.events.request_failure.fire(
+                    request_type="xmlrpc", name=name, response_time=total_time, exception=e
+                )
             else:
                 total_time = int((time.time() - start_time) * 1000)
-                self._locust_environment.events.request_success.fire(request_type="xmlrpc", name=name, response_time=total_time, response_length=0)
-                # In this example, I've hardcoded response_length=0. If we would want the response length to be 
+                self._locust_environment.events.request_success.fire(
+                    request_type="xmlrpc", name=name, response_time=total_time, response_length=0
+                )
+                # In this example, I've hardcoded response_length=0. If we would want the response length to be
                 # reported correctly in the statistics, we would probably need to hook in at a lower level
-        
+
         return wrapper
 
 
@@ -36,7 +41,9 @@ class XmlRpcUser(User):
     This is the abstract User class which should be subclassed. It provides an XML-RPC client
     that can be used to make XML-RPC requests that will be tracked in Locust's statistics.
     """
+
     abstract = True
+
     def __init__(self, *args, **kwargs):
         super(XmlRpcUser, self).__init__(*args, **kwargs)
         self.client = XmlRpcClient(self.host)
@@ -46,11 +53,11 @@ class XmlRpcUser(User):
 class ApiUser(XmlRpcUser):
     host = "http://127.0.0.1:8877/"
     wait_time = between(0.1, 1)
-    
+
     @task(10)
     def get_time(self):
         self.client.get_time()
-    
+
     @task(5)
     def get_random_number(self):
         self.client.get_random_number(0, 100)

--- a/examples/dynamice_user_credentials.py
+++ b/examples/dynamice_user_credentials.py
@@ -8,16 +8,18 @@ USER_CREDENTIALS = [
     ("user3", "password"),
 ]
 
+
 class UserBehaviour(TaskSet):
     def on_start(self):
         if len(USER_CREDENTIALS) > 0:
             user, passw = USER_CREDENTIALS.pop()
-            self.client.post("/login", {"username":user, "password":passw})
-    
+            self.client.post("/login", {"username": user, "password": passw})
+
     @task
     def some_task(self):
         # user should be logged in here (unless the USER_CREDENTIALS ran out)
         self.client.get("/protected/resource")
+
 
 class User(HttpUser):
     tasks = [UserBehaviour]

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This is an example of a locustfile that uses Locust's built in event hooks to 
+This is an example of a locustfile that uses Locust's built in event hooks to
 track the sum of the content-length header in all successful HTTP responses
 """
 
@@ -13,24 +13,26 @@ class MyTaskSet(TaskSet):
     @task(2)
     def index(l):
         l.client.get("/")
-    
+
     @task(1)
     def stats(l):
         l.client.get("/stats/requests")
+
 
 class WebsiteUser(HttpUser):
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
     tasks = [MyTaskSet]
-    
 
-stats = {"content-length":0}
+
+stats = {"content-length": 0}
+
 
 @events.init.add_listener
 def locust_init(environment, **kwargs):
     """
     We need somewhere to store the stats.
-    
+
     On the master node stats will contain the aggregated sum of all content-lengths,
     while on the worker nodes this will be the sum of the content-lengths since the
     last stats report was sent to the master
@@ -43,13 +45,15 @@ def locust_init(environment, **kwargs):
             Add a route to the Locust web app, where we can see the total content-length
             """
             return "Total content-length recieved: %i" % stats["content-length"]
-    
+
+
 @events.request_success.add_listener
 def on_request_success(request_type, name, response_time, response_length):
     """
     Event handler that get triggered on every successful request
     """
     stats["content-length"] += response_length
+
 
 @events.report_to_master.add_listener
 def on_report_to_master(client_id, data):
@@ -60,6 +64,7 @@ def on_report_to_master(client_id, data):
     """
     data["content-length"] = stats["content-length"]
     stats["content-length"] = 0
+
 
 @events.worker_report.add_listener
 def on_worker_report(client_id, data):

--- a/examples/fast_http_locust.py
+++ b/examples/fast_http_locust.py
@@ -1,12 +1,13 @@
 from locust import HttpUser, TaskSet, task, between
 from locust.contrib.fasthttp import FastHttpUser
 
-    
+
 class WebsiteUser(FastHttpUser):
     """
     User class that does requests to the locust web server running on localhost,
     using the fast HTTP client
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
     # some things you can configure on FastHttpUser
@@ -19,8 +20,7 @@ class WebsiteUser(FastHttpUser):
     @task
     def index(self):
         self.client.get("/")
-    
+
     @task
     def stats(self):
         self.client.get("/stats/requests")
-

--- a/examples/locustfile.py
+++ b/examples/locustfile.py
@@ -1,18 +1,19 @@
 import random
 from locust import HttpUser, task, between
 
+
 class MyUser(HttpUser):
     @task
     def index(self):
         self.client.get("/hello")
         self.client.get("/world")
-    
+
     @task(3)
     def view_item(self):
         item_id = random.randint(1, 10000)
         self.client.get(f"/item?id={item_id}", name="/item")
-    
+
     def on_start(self):
-        self.client.post("/login", {"username":"foo", "password":"bar"})
+        self.client.post("/login", {"username": "foo", "password": "bar"})
 
     wait_time = between(5, 9)

--- a/examples/multiple_hosts.py
+++ b/examples/multiple_hosts.py
@@ -3,28 +3,31 @@ import os
 from locust import HttpUser, TaskSet, task, between
 from locust.clients import HttpSession
 
+
 class MultipleHostsUser(HttpUser):
     abstract = True
-    
+
     def __init__(self, *args, **kwargs):
         super(MultipleHostsUser, self).__init__(*args, **kwargs)
         self.api_client = HttpSession(base_url=os.environ["API_HOST"])
-    
+
 
 class UserTasks(TaskSet):
     # but it might be convenient to use the @task decorator
     @task
     def index(self):
         self.user.client.get("/")
-    
+
     @task
     def index_other_host(self):
         self.user.api_client.get("/stats/requests")
-    
+
+
 class WebsiteUser(MultipleHostsUser):
     """
     User class that does requests to the locust web server running on localhost
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
     tasks = [UserTasks]

--- a/examples/nested_inline_tasksets.py
+++ b/examples/nested_inline_tasksets.py
@@ -5,6 +5,7 @@ class WebsiteUser(HttpUser):
     """
     Example of the ability of inline nested TaskSet classes
     """
+
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
 
@@ -15,11 +16,11 @@ class WebsiteUser(HttpUser):
             @task(10)
             def index(self):
                 self.client.get("/")
-            
+
             @task(1)
             def stop(self):
                 self.interrupt()
-        
+
         @task
         def stats(self):
             self.client.get("/stats/requests")

--- a/examples/semaphore_wait.py
+++ b/examples/semaphore_wait.py
@@ -5,21 +5,24 @@ from gevent.lock import Semaphore
 all_users_spawned = Semaphore()
 all_users_spawned.acquire()
 
+
 @events.init.add_listener
 def _(environment, **kw):
     @environment.events.hatch_complete.add_listener
     def on_hatch_complete(**kw):
         all_users_spawned.release()
 
+
 class UserTasks(TaskSet):
     def on_start(self):
         all_users_spawned.wait()
         self.wait()
-    
+
     @task
     def index(self):
         self.client.get("/")
-    
+
+
 class WebsiteUser(HttpUser):
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)

--- a/examples/stop_on_threshold.py
+++ b/examples/stop_on_threshold.py
@@ -4,8 +4,10 @@ from locust.runners import STATE_STOPPING, STATE_STOPPED, STATE_CLEANUP, WorkerR
 import time
 import gevent
 
+
 class MyUser(HttpUser):
     host = "http://www.google.com"
+
     @task
     def my_task(self):
         for _ in range(10):
@@ -17,7 +19,7 @@ class MyUser(HttpUser):
 
 
 def checker(environment):
-    while not environment.runner.state in [STATE_STOPPING, STATE_STOPPED, STATE_CLEANUP]:
+    while environment.runner.state not in [STATE_STOPPING, STATE_STOPPED, STATE_CLEANUP]:
         time.sleep(1)
         if environment.runner.stats.total.fail_ratio > 0.2:
             print(f"fail ratio was {environment.runner.stats.total.fail_ratio}, quitting")

--- a/examples/use_as_lib.py
+++ b/examples/use_as_lib.py
@@ -19,6 +19,7 @@ class User(HttpUser):
     def task_404(self):
         self.client.get("/non-existing-path")
 
+
 # setup Environment and Runner
 env = Environment(user_classes=[User])
 env.create_local_runner()

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,15 +1,23 @@
 import subprocess
 import os
 
-github_api_token = os.getenv("CHANGELOG_GITHUB_TOKEN") if os.getenv("CHANGELOG_GITHUB_TOKEN") else input("Enter Github API token: ")
+github_api_token = (
+    os.getenv("CHANGELOG_GITHUB_TOKEN") if os.getenv("CHANGELOG_GITHUB_TOKEN") else input("Enter Github API token: ")
+)
 version = input("Enter Locust version number (--future-release argument): ")
 
 cmd = [
     "github_changelog_generator",
-    "-t", github_api_token,
-    "-u", "locustio", "-p", "locust",
-    "--exclude-labels", "duplicate,question,invalid,wontfix,cantfix",
-    "--future-release", version,
+    "-t",
+    github_api_token,
+    "-u",
+    "locustio",
+    "-p",
+    "locust",
+    "--exclude-labels",
+    "duplicate,question,invalid,wontfix,cantfix",
+    "--future-release",
+    version,
 ]
 
 print("Running command: %s\n" % " ".join(cmd))

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,8 +1,6 @@
-# Apply Gevent monkey patching of stdlib
 from gevent import monkey as _monkey
+
 _monkey.patch_all()
-
-
 from .user.sequential_taskset import SequentialTaskSet
 from .user import wait_time
 from .user.task import task, tag, TaskSet
@@ -10,15 +8,21 @@ from .user.users import HttpUser, User
 from .user.wait_time import between, constant, constant_pacing
 
 from .event import Events
+
 events = Events()
 
 __version__ = "1.1.1"
 __all__ = (
     "SequentialTaskSet",
     "wait_time",
-    "task", "tag", "TaskSet",
-    "HttpUser", "User",
-    "between", "constant", "constant_pacing",
+    "task",
+    "tag",
+    "TaskSet",
+    "HttpUser",
+    "User",
+    "between",
+    "constant",
+    "constant_pacing",
     "events",
 )
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -10,17 +10,15 @@ import locust
 version = locust.__version__
 
 
-DEFAULT_CONFIG_FILES = ['~/.locust.conf','locust.conf']
+DEFAULT_CONFIG_FILES = ["~/.locust.conf", "locust.conf"]
 
 
 def _is_package(path):
     """
     Is the given path a Python package?
     """
-    return (
-        os.path.isdir(path)
-        and os.path.exists(os.path.join(path, '__init__.py'))
-    )
+    return os.path.isdir(path) and os.path.exists(os.path.join(path, "__init__.py"))
+
 
 def find_locustfile(locustfile):
     """
@@ -29,24 +27,24 @@ def find_locustfile(locustfile):
     # Obtain env value
     names = [locustfile]
     # Create .py version if necessary
-    if not names[0].endswith('.py'):
-        names.append(names[0] + '.py')
+    if not names[0].endswith(".py"):
+        names.append(names[0] + ".py")
     # Does the name contain path elements?
     if os.path.dirname(names[0]):
         # If so, expand home-directory markers and test for existence
         for name in names:
             expanded = os.path.expanduser(name)
             if os.path.exists(expanded):
-                if name.endswith('.py') or _is_package(expanded):
+                if name.endswith(".py") or _is_package(expanded):
                     return os.path.abspath(expanded)
     else:
         # Otherwise, start in cwd and work downwards towards filesystem root
-        path = os.path.abspath('.')
+        path = os.path.abspath(".")
         while True:
             for name in names:
                 joined = os.path.join(path, name)
                 if os.path.exists(joined):
-                    if name.endswith('.py') or _is_package(joined):
+                    if name.endswith(".py") or _is_package(joined):
                         return os.path.abspath(joined)
             parent_path = os.path.dirname(path)
             if parent_path == path:
@@ -58,355 +56,340 @@ def find_locustfile(locustfile):
 
 def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG_FILES):
     parser = configargparse.ArgumentParser(
-        default_config_files=default_config_files, 
+        default_config_files=default_config_files,
         add_env_var_help=False,
         add_config_file_help=False,
         add_help=add_help,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage=argparse.SUPPRESS,
-        description=textwrap.dedent("""
+        description=textwrap.dedent(
+            """
             Usage: locust [OPTIONS] [UserClass ...]
-            
-        """),
-        #epilog="",
+
+        """
+        ),
+        # epilog="",
     )
     parser.add_argument(
-        '-f', '--locustfile',
-        default='locustfile',
+        "-f",
+        "--locustfile",
+        default="locustfile",
         help="Python module file to import, e.g. '../other.py'. Default: locustfile",
         env_var="LOCUST_LOCUSTFILE",
     )
-    parser.add_argument('--config', is_config_file_arg=True, help='Config file path')
+    parser.add_argument("--config", is_config_file_arg=True, help="Config file path")
 
     return parser
 
 
 def parse_locustfile_option(args=None):
     """
-    Construct a command line parser that is only used to parse the -f argument so that we can 
-    import the test scripts in case any of them adds additional command line arguments to the 
+    Construct a command line parser that is only used to parse the -f argument so that we can
+    import the test scripts in case any of them adds additional command line arguments to the
     parser
-    """    
+    """
     parser = get_empty_argument_parser(add_help=False)
     parser.add_argument(
-        '-h', '--help',
-        action='store_true',
-        default=False,
+        "-h", "--help", action="store_true", default=False,
     )
     parser.add_argument(
-        '--version', '-V',
-        action='store_true',
-        default=False,
+        "--version", "-V", action="store_true", default=False,
     )
-    
+
     options, _ = parser.parse_known_args(args=args)
-    
+
     locustfile = find_locustfile(options.locustfile)
-    
+
     if not locustfile:
         if options.help or options.version:
             # if --help or --version is specified we'll call parse_options which will print the help/version message
             parse_options(args=args)
-        sys.stderr.write("Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.\n")
+        sys.stderr.write(
+            "Could not find any locustfile! Ensure file ends in '.py' and see --help for available options.\n"
+        )
         sys.exit(1)
-    
+
     if locustfile == "locust.py":
         sys.stderr.write("The locustfile must not be named `locust.py`. Please rename the file and try again.\n")
         sys.exit(1)
-        
+
     return locustfile
 
 
 def setup_parser_arguments(parser):
     """
     Setup command-line options
-    
-    Takes a configargparse.ArgumentParser as argument and calls it's add_argument 
+
+    Takes a configargparse.ArgumentParser as argument and calls it's add_argument
     for each of the supported arguments
     """
     parser._optionals.title = "Common options"
     parser.add_argument(
-        '-H', '--host',
-        help="Host to load test in the following format: http://10.21.32.33",
-        env_var="LOCUST_HOST",
+        "-H", "--host", help="Host to load test in the following format: http://10.21.32.33", env_var="LOCUST_HOST",
     )
     parser.add_argument(
-        '-u', '--users',
+        "-u",
+        "--users",
         type=int,
-        dest='num_users',
+        dest="num_users",
         help="Number of concurrent Locust users. Only used together with --headless",
         env_var="LOCUST_USERS",
     )
     parser.add_argument(
-        '-r', '--hatch-rate',
+        "-r",
+        "--hatch-rate",
         type=float,
         help="The rate per second in which users are spawned. Only used together with --headless",
         env_var="LOCUST_HATCH_RATE",
     )
     parser.add_argument(
-        '-t', '--run-time',
+        "-t",
+        "--run-time",
         help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --headless",
         env_var="LOCUST_RUN_TIME",
     )
     parser.add_argument(
-        '-l', '--list',
-        action='store_true',
-        dest='list_commands',
-        help="Show list of possible User classes and exit",
+        "-l", "--list", action="store_true", dest="list_commands", help="Show list of possible User classes and exit",
     )
-    
+
     web_ui_group = parser.add_argument_group("Web UI options")
     web_ui_group.add_argument(
-        '--web-host',
+        "--web-host",
         default="",
         help="Host to bind the web interface to. Defaults to '*' (all interfaces)",
         env_var="LOCUST_WEB_HOST",
     )
     web_ui_group.add_argument(
-        '--web-port', '-P',
-        type=int,
-        default=8089,
-        help="Port on which to run web host",
-        env_var="LOCUST_WEB_PORT",
+        "--web-port", "-P", type=int, default=8089, help="Port on which to run web host", env_var="LOCUST_WEB_PORT",
     )
     web_ui_group.add_argument(
-        '--headless',
-        action='store_true',
+        "--headless",
+        action="store_true",
         help="Disable the web interface, and instead start the load test immediately. Requires -u and -t to be specified.",
         env_var="LOCUST_HEADLESS",
     )
     web_ui_group.add_argument(
-        '--web-auth',
+        "--web-auth",
         type=str,
-        dest='web_auth',
+        dest="web_auth",
         default=None,
-        help='Turn on Basic Auth for the web interface. Should be supplied in the following format: username:password',
+        help="Turn on Basic Auth for the web interface. Should be supplied in the following format: username:password",
         env_var="LOCUST_WEB_AUTH",
     )
     web_ui_group.add_argument(
-        '--tls-cert',
+        "--tls-cert",
         default="",
         help="Optional path to TLS certificate to use to serve over HTTPS",
         env_var="LOCUST_TLS_CERT",
     )
     web_ui_group.add_argument(
-        '--tls-key',
+        "--tls-key",
         default="",
         help="Optional path to TLS private key to use to serve over HTTPS",
         env_var="LOCUST_TLS_KEY",
     )
-    
+
     master_group = parser.add_argument_group(
-        "Master options", 
+        "Master options",
         "Options for running a Locust Master node when running Locust distributed. A Master node need Worker nodes that connect to it before it can run load tests.",
     )
     # if locust should be run in distributed mode as master
     master_group.add_argument(
-        '--master',
-        action='store_true',
+        "--master",
+        action="store_true",
         help="Set locust to run in distributed mode with this process as master",
-        env_var='LOCUST_MODE_MASTER',
+        env_var="LOCUST_MODE_MASTER",
     )
     master_group.add_argument(
-        '--master-bind-host',
+        "--master-bind-host",
         default="*",
         help="Interfaces (hostname, ip) that locust master should bind to. Only used when running with --master. Defaults to * (all available interfaces).",
         env_var="LOCUST_MASTER_BIND_HOST",
     )
     master_group.add_argument(
-        '--master-bind-port',
+        "--master-bind-port",
         type=int,
         default=5557,
         help="Port that locust master should bind to. Only used when running with --master. Defaults to 5557.",
         env_var="LOCUST_MASTER_BIND_PORT",
     )
     master_group.add_argument(
-        '--expect-workers',
+        "--expect-workers",
         type=int,
         default=1,
         help="How many workers master should expect to connect before starting the test (only when --headless used).",
         env_var="LOCUST_EXPECT_WORKERS",
     )
     master_group.add_argument(
-        '--expect-slaves',
-        action='store_true',
-        help=configargparse.SUPPRESS,
+        "--expect-slaves", action="store_true", help=configargparse.SUPPRESS,
     )
-    
+
     worker_group = parser.add_argument_group(
-        "Worker options", 
-        textwrap.dedent("""
-            Options for running a Locust Worker node when running Locust distributed. 
+        "Worker options",
+        textwrap.dedent(
+            """
+            Options for running a Locust Worker node when running Locust distributed.
             Only the LOCUSTFILE (-f option) need to be specified when starting a Worker, since other options such as -u, -r, -t are specified on the Master node.
-        """),
+        """
+        ),
     )
     # if locust should be run in distributed mode as worker
     worker_group.add_argument(
-        '--worker',
-        action='store_true',
+        "--worker",
+        action="store_true",
         help="Set locust to run in distributed mode with this process as worker",
         env_var="LOCUST_MODE_WORKER",
     )
     worker_group.add_argument(
-        '--slave',
-        action='store_true',
-        help=configargparse.SUPPRESS,
+        "--slave", action="store_true", help=configargparse.SUPPRESS,
     )
     # master host options
     worker_group.add_argument(
-        '--master-host',
+        "--master-host",
         default="127.0.0.1",
         help="Host or IP address of locust master for distributed load testing. Only used when running with --worker. Defaults to 127.0.0.1.",
         env_var="LOCUST_MASTER_NODE_HOST",
         metavar="MASTER_NODE_HOST",
     )
     worker_group.add_argument(
-        '--master-port',
+        "--master-port",
         type=int,
         default=5557,
         help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557.",
         env_var="LOCUST_MASTER_NODE_PORT",
         metavar="MASTER_NODE_PORT",
     )
-    
-    tag_group = parser.add_argument_group("Tag options", "Locust tasks can be tagged using the @tag decorator. These options let specify which tasks to include or exclude during a test.")
+
+    tag_group = parser.add_argument_group(
+        "Tag options",
+        "Locust tasks can be tagged using the @tag decorator. These options let specify which tasks to include or exclude during a test.",
+    )
     tag_group.add_argument(
-        '-T', '--tags',
-        nargs='*',
-        metavar='TAG',
+        "-T",
+        "--tags",
+        nargs="*",
+        metavar="TAG",
         env_var="LOCUST_TAGS",
-        help="List of tags to include in the test, so only tasks with any matching tags will be executed"
+        help="List of tags to include in the test, so only tasks with any matching tags will be executed",
     )
     tag_group.add_argument(
-        '-E', '--exclude-tags',
-        nargs='*',
-        metavar='TAG',
+        "-E",
+        "--exclude-tags",
+        nargs="*",
+        metavar="TAG",
         env_var="LOCUST_EXCLUDE_TAGS",
-        help="List of tags to exclude from the test, so only tasks with no matching tags will be executed"
+        help="List of tags to exclude from the test, so only tasks with no matching tags will be executed",
     )
-    
+
     stats_group = parser.add_argument_group("Request statistics options")
     stats_group.add_argument(
-        '--csv',
+        "--csv",
         dest="csv_prefix",
         help="Store current request stats to files in CSV format. Setting this option will generate three files: [CSV_PREFIX]_stats.csv, [CSV_PREFIX]_stats_history.csv and [CSV_PREFIX]_failures.csv",
         env_var="LOCUST_CSV",
     )
     stats_group.add_argument(
-        '--csv-full-history',
-        action='store_true',
+        "--csv-full-history",
+        action="store_true",
         default=False,
-        dest='stats_history_enabled',
+        dest="stats_history_enabled",
         help="Store each stats entry in CSV format to _stats_history.csv file",
         env_var="LOCUST_CSV_FULL_HISTORY",
-    )    
-    stats_group.add_argument(
-        '--print-stats',
-        action='store_true',
-        help="Print stats in the console",
-        env_var="LOCUST_PRINT_STATS",
     )
     stats_group.add_argument(
-       '--only-summary',
-       action='store_true',
-       help='Only print the summary stats',
-       env_var="LOCUST_ONLY_SUMMARY",
+        "--print-stats", action="store_true", help="Print stats in the console", env_var="LOCUST_PRINT_STATS",
     )
     stats_group.add_argument(
-        '--reset-stats',
-        action='store_true',
+        "--only-summary", action="store_true", help="Only print the summary stats", env_var="LOCUST_ONLY_SUMMARY",
+    )
+    stats_group.add_argument(
+        "--reset-stats",
+        action="store_true",
         help="Reset statistics once hatching has been completed. Should be set on both master and workers when running in distributed mode",
         env_var="LOCUST_RESET_STATS",
     )
-    
+
     log_group = parser.add_argument_group("Logging options")
     log_group.add_argument(
-        '--skip-log-setup',
-        action='store_true',
-        dest='skip_log_setup',
+        "--skip-log-setup",
+        action="store_true",
+        dest="skip_log_setup",
         default=False,
         help="Disable Locust's logging setup. Instead, the configuration is provided by the Locust test or Python defaults.",
         env_var="LOCUST_SKIP_LOG_SETUP",
     )
     log_group.add_argument(
-        '--loglevel', '-L',
-        default='INFO',
+        "--loglevel",
+        "-L",
+        default="INFO",
         help="Choose between DEBUG/INFO/WARNING/ERROR/CRITICAL. Default is INFO.",
         env_var="LOCUST_LOGLEVEL",
     )
     log_group.add_argument(
-        '--logfile',
-        help="Path to log file. If not set, log will go to stdout/stderr",
-        env_var="LOCUST_LOGFILE",
+        "--logfile", help="Path to log file. If not set, log will go to stdout/stderr", env_var="LOCUST_LOGFILE",
     )
-    
+
     step_load_group = parser.add_argument_group("Step load options")
     step_load_group.add_argument(
-        '--step-load',
-        action='store_true',
+        "--step-load",
+        action="store_true",
         help="Enable Step Load mode to monitor how performance metrics varies when user load increases. Requires --step-users and --step-time to be specified.",
         env_var="LOCUST_STEP_LOAD",
     )
     step_load_group.add_argument(
-        '--step-users',
+        "--step-users",
         type=int,
         help="User count to increase by step in Step Load mode. Only used together with --step-load",
         env_var="LOCUST_STEP_USERS",
     )
+    step_load_group.add_argument("--step-clients", action="store_true", help=configargparse.SUPPRESS)
     step_load_group.add_argument(
-        '--step-clients',
-        action='store_true',
-        help=configargparse.SUPPRESS
-    )
-    step_load_group.add_argument(
-        '--step-time',
+        "--step-time",
         help="Step duration in Step Load mode, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --step-load",
         env_var="LOCUST_STEP_TIME",
     )
-    
-    
+
     other_group = parser.add_argument_group("Other options")
     other_group.add_argument(
-        '--show-task-ratio',
-        action='store_true',
-        help="Print table of the User classes' task execution ratio"
+        "--show-task-ratio", action="store_true", help="Print table of the User classes' task execution ratio"
     )
     other_group.add_argument(
-        '--show-task-ratio-json',
-        action='store_true',
-        help="Print json data of the User classes' task execution ratio"
+        "--show-task-ratio-json", action="store_true", help="Print json data of the User classes' task execution ratio"
     )
     # optparse gives you --version but we have to do it ourselves to get -V too
     other_group.add_argument(
-        '--version', '-V',
-        action='version',
+        "--version",
+        "-V",
+        action="version",
         help="Show program's version number and exit",
-        version='%(prog)s {}'.format(version),
+        version="%(prog)s {}".format(version),
     )
     other_group.add_argument(
-        '--exit-code-on-error',
+        "--exit-code-on-error",
         type=int,
         default=1,
         help="Sets the process exit code to use when a test result contain any failure or error",
         env_var="LOCUST_EXIT_CODE_ON_ERROR",
     )
     other_group.add_argument(
-        '-s', '--stop-timeout',
-        action='store',
+        "-s",
+        "--stop-timeout",
+        action="store",
         type=int,
-        dest='stop_timeout',
+        dest="stop_timeout",
         default=None,
         help="Number of seconds to wait for a simulated user to complete any executing task before exiting. Default is to terminate immediately. This parameter only needs to be specified for the master process when running Locust distributed.",
         env_var="LOCUST_STOP_TIMEOUT",
     )
-    
+
     user_classes_group = parser.add_argument_group("User classes")
     user_classes_group.add_argument(
-        'user_classes',
-        nargs='*',
-        metavar='UserClass',
+        "user_classes",
+        nargs="*",
+        metavar="UserClass",
         help="Optionally specify which User classes that should be used (available User classes can be listed with -l or --list)",
     )
+
 
 def get_parser(default_config_files=DEFAULT_CONFIG_FILES):
     # get a parser that is only able to parse the -f argument

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -4,8 +4,7 @@ import time
 import requests
 from requests import Request, Response
 from requests.auth import HTTPBasicAuth
-from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
-                                 RequestException)
+from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema, RequestException
 
 from urllib.parse import urlparse, urlunparse
 
@@ -15,9 +14,8 @@ absolute_http_url_regexp = re.compile(r"^https?://", re.I)
 
 
 class LocustResponse(Response):
-
     def raise_for_status(self):
-        if hasattr(self, 'error') and self.error:
+        if hasattr(self, "error") and self.error:
             raise self.error
         Response.raise_for_status(self)
 
@@ -25,52 +23,55 @@ class LocustResponse(Response):
 class HttpSession(requests.Session):
     """
     Class for performing web requests and holding (session-) cookies between requests (in order
-    to be able to log in and out of websites). Each request is logged so that locust can display 
+    to be able to log in and out of websites). Each request is logged so that locust can display
     statistics.
-    
+
     This is a slightly extended version of `python-request <http://python-requests.org>`_'s
-    :py:class:`requests.Session` class and mostly this class works exactly the same. However 
-    the methods for making requests (get, post, delete, put, head, options, patch, request) 
-    can now take a *url* argument that's only the path part of the URL, in which case the host 
+    :py:class:`requests.Session` class and mostly this class works exactly the same. However
+    the methods for making requests (get, post, delete, put, head, options, patch, request)
+    can now take a *url* argument that's only the path part of the URL, in which case the host
     part of the URL will be prepended with the HttpSession.base_url which is normally inherited
     from a User class' host property.
-    
-    Each of the methods for making requests also takes two additional optional arguments which 
+
+    Each of the methods for making requests also takes two additional optional arguments which
     are Locust specific and doesn't exist in python-requests. These are:
-    
-    :param name: (optional) An argument that can be specified to use as label in Locust's statistics instead of the URL path. 
+
+    :param name: (optional) An argument that can be specified to use as label in Locust's statistics instead of the URL path.
                  This can be used to group different URL's that are requested into a single entry in Locust's statistics.
-    :param catch_response: (optional) Boolean argument that, if set, can be used to make a request return a context manager 
-                           to work as argument to a with statement. This will allow the request to be marked as a fail based on the content of the 
+    :param catch_response: (optional) Boolean argument that, if set, can be used to make a request return a context manager
+                           to work as argument to a with statement. This will allow the request to be marked as a fail based on the content of the
                            response, even if the response code is ok (2xx). The opposite also works, one can use catch_response to catch a request
                            and then mark it as successful even if the response code was not (i.e 500 or 404).
     """
+
     def __init__(self, base_url, request_success, request_failure, *args, **kwargs):
         super(HttpSession, self).__init__(*args, **kwargs)
-        
+
         self.base_url = base_url
         self.request_success = request_success
         self.request_failure = request_failure
-        
+
         # Check for basic authentication
         parsed_url = urlparse(self.base_url)
         if parsed_url.username and parsed_url.password:
             netloc = parsed_url.hostname
             if parsed_url.port:
                 netloc += ":%d" % parsed_url.port
-            
+
             # remove username and password from the base_url
-            self.base_url = urlunparse((parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment))
+            self.base_url = urlunparse(
+                (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
+            )
             # configure requests to use basic auth
             self.auth = HTTPBasicAuth(parsed_url.username, parsed_url.password)
-    
+
     def _build_url(self, path):
         """ prepend url with hostname unless it's already an absolute URL """
         if absolute_http_url_regexp.match(path):
             return path
         else:
             return "%s%s" % (self.base_url, path)
-    
+
     def request(self, method, url, name=None, catch_response=False, **kwargs):
         """
         Constructs and sends a :py:class:`requests.Request`.
@@ -78,10 +79,10 @@ class HttpSession(requests.Session):
 
         :param method: method for the new :class:`Request` object.
         :param url: URL for the new :class:`Request` object.
-        :param name: (optional) An argument that can be specified to use as label in Locust's statistics instead of the URL path. 
+        :param name: (optional) An argument that can be specified to use as label in Locust's statistics instead of the URL path.
           This can be used to group different URL's that are requested into a single entry in Locust's statistics.
-        :param catch_response: (optional) Boolean argument that, if set, can be used to make a request return a context manager 
-          to work as argument to a with statement. This will allow the request to be marked as a fail based on the content of the 
+        :param catch_response: (optional) Boolean argument that, if set, can be used to make a request return a context manager
+          to work as argument to a with statement. This will allow the request to be marked as a fail based on the content of the
           response, even if the response code is ok (2xx). The opposite also works, one can use catch_response to catch a request
           and then mark it as successful even if the response code was not (i.e 500 or 404).
         :param params: (optional) Dictionary or bytes to be sent in the query string for the :class:`Request`.
@@ -90,7 +91,7 @@ class HttpSession(requests.Session):
         :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
         :param files: (optional) Dictionary of ``'filename': file-like-objects`` for multipart encoding upload.
         :param auth: (optional) Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth.
-        :param timeout: (optional) How long in seconds to wait for the server to send data before giving up, as a float, 
+        :param timeout: (optional) How long in seconds to wait for the server to send data before giving up, as a float,
             or a (`connect timeout, read timeout <user/advanced.html#timeouts>`_) tuple.
         :type timeout: float or tuple
         :param allow_redirects: (optional) Set to True by default.
@@ -100,39 +101,40 @@ class HttpSession(requests.Session):
         :param verify: (optional) if ``True``, the SSL cert will be verified. A CA_BUNDLE path can also be provided.
         :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
         """
-        
+
         # prepend url with hostname unless it's already an absolute URL
         url = self._build_url(url)
-        
+
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {}
-        
+
         # set up pre_request hook for attaching meta data to the request object
         request_meta["method"] = method
         request_meta["start_time"] = time.monotonic()
-        
+
         response = self._send_request_safe_mode(method, url, **kwargs)
-        
+
         # record the consumed time
         request_meta["response_time"] = (time.monotonic() - request_meta["start_time"]) * 1000
-        
-    
+
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url
-        
+
         # get the length of the content, but if the argument stream is set to True, we take
         # the size from the content-length header, in order to not trigger fetching of the body
         if kwargs.get("stream", False):
             request_meta["content_size"] = int(response.headers.get("content-length") or 0)
         else:
             request_meta["content_size"] = len(response.content or b"")
-        
+
         if catch_response:
             response.locust_request_meta = request_meta
-            return ResponseContextManager(response, request_success=self.request_success, request_failure=self.request_failure)
+            return ResponseContextManager(
+                response, request_success=self.request_success, request_failure=self.request_failure
+            )
         else:
             if name:
-                # Since we use the Exception message when grouping failures, in order to not get 
-                # multiple failure entries for different URLs for the same name argument, we need 
+                # Since we use the Exception message when grouping failures, in order to not get
+                # multiple failure entries for different URLs for the same name argument, we need
                 # to temporarily override the reponse.url attribute
                 orig_url = response.url
                 response.url = name
@@ -140,11 +142,11 @@ class HttpSession(requests.Session):
                 response.raise_for_status()
             except RequestException as e:
                 self.request_failure.fire(
-                    request_type=request_meta["method"], 
-                    name=request_meta["name"], 
-                    response_time=request_meta["response_time"], 
+                    request_type=request_meta["method"],
+                    name=request_meta["name"],
+                    response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
-                    exception=e, 
+                    exception=e,
                 )
             else:
                 self.request_success.fire(
@@ -156,11 +158,11 @@ class HttpSession(requests.Session):
             if name:
                 response.url = orig_url
             return response
-    
+
     def _send_request_safe_mode(self, method, url, **kwargs):
         """
         Send an HTTP request, and catch any exception that might occur due to connection problems.
-        
+
         Safe mode has been removed from requests 1.x.
         """
         try:
@@ -171,42 +173,42 @@ class HttpSession(requests.Session):
             r = LocustResponse()
             r.error = e
             r.status_code = 0  # with this status_code, content returns None
-            r.request = Request(method, url).prepare() 
+            r.request = Request(method, url).prepare()
             return r
 
 
 class ResponseContextManager(LocustResponse):
     """
-    A Response class that also acts as a context manager that provides the ability to manually 
+    A Response class that also acts as a context manager that provides the ability to manually
     control if an HTTP request should be marked as successful or a failure in Locust's statistics
-    
-    This class is a subclass of :py:class:`Response <requests.Response>` with two additional 
-    methods: :py:meth:`success <locust.clients.ResponseContextManager.success>` and 
+
+    This class is a subclass of :py:class:`Response <requests.Response>` with two additional
+    methods: :py:meth:`success <locust.clients.ResponseContextManager.success>` and
     :py:meth:`failure <locust.clients.ResponseContextManager.failure>`.
     """
-    
+
     _manual_result = None
-    
+
     def __init__(self, response, request_success, request_failure):
         # copy data from response to this object
         self.__dict__ = response.__dict__
         self._request_success = request_success
         self._request_failure = request_failure
-    
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc, value, traceback):
         if self._manual_result is not None:
             if self._manual_result == True:
                 self._report_success()
             elif isinstance(self._manual_result, Exception):
                 self._report_failure(self._manual_result)
-            
+
             # if the user has already manually marked this response as failure or success
             # we can ignore the default haviour of letting the response code determine the outcome
             return exc is None
-        
+
         if exc:
             if isinstance(value, ResponseError):
                 self._report_failure(value)
@@ -220,9 +222,9 @@ class ResponseContextManager(LocustResponse):
                 self._report_failure(e)
             else:
                 self._report_success()
-        
+
         return True
-    
+
     def _report_success(self):
         self._request_success.fire(
             request_type=self.locust_request_meta["method"],
@@ -230,7 +232,7 @@ class ResponseContextManager(LocustResponse):
             response_time=self.locust_request_meta["response_time"],
             response_length=self.locust_request_meta["content_size"],
         )
-    
+
     def _report_failure(self, exc):
         self._request_failure.fire(
             request_type=self.locust_request_meta["method"],
@@ -239,28 +241,28 @@ class ResponseContextManager(LocustResponse):
             response_length=self.locust_request_meta["content_size"],
             exception=exc,
         )
-    
+
     def success(self):
         """
         Report the response as successful
-        
+
         Example::
-        
+
             with self.client.get("/does/not/exist", catch_response=True) as response:
                 if response.status_code == 404:
                     response.success()
         """
         self._manual_result = True
-    
+
     def failure(self, exc):
         """
         Report the response as a failure.
-        
+
         exc can be either a python exception, or a string in which case it will
-        be wrapped inside a CatchResponseError. 
-        
+        be wrapped inside a CatchResponseError.
+
         Example::
-        
+
             with self.client.get("/", catch_response=True) as response:
                 if response.content == b"":
                     response.failure("No data")

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import re
 import socket
 import json
-import json as unshadowed_json # some methods take a named parameter called json
+import json as unshadowed_json  # some methods take a named parameter called json
 from base64 import b64encode
 from urllib.parse import urlparse, urlunparse
 from ssl import SSLError
@@ -34,75 +34,84 @@ CompatRequest.type = "https"
 # Regexp for checking if an absolute URL was specified
 absolute_http_url_regexp = re.compile(r"^https?://", re.I)
 
-# List of exceptions that can be raised by geventhttpclient when sending an HTTP request, 
+# List of exceptions that can be raised by geventhttpclient when sending an HTTP request,
 # and that should result in a Locust failure
-FAILURE_EXCEPTIONS = (ConnectionError, ConnectionRefusedError, ConnectionResetError, socket.error, \
-                      SSLError, Timeout, HTTPConnectionClosed)
+FAILURE_EXCEPTIONS = (
+    ConnectionError,
+    ConnectionRefusedError,
+    ConnectionResetError,
+    socket.error,
+    SSLError,
+    Timeout,
+    HTTPConnectionClosed,
+)
 
 
 def _construct_basic_auth_str(username, password):
     """Construct Authorization header value to be used in HTTP Basic Auth"""
     if isinstance(username, str):
-        username = username.encode('latin1')
+        username = username.encode("latin1")
     if isinstance(password, str):
-        password = password.encode('latin1')
-    return 'Basic ' + b64encode(b':'.join((username, password))).strip().decode("ascii")
+        password = password.encode("latin1")
+    return "Basic " + b64encode(b":".join((username, password))).strip().decode("ascii")
 
 
 class FastHttpUser(User):
     """
     FastHttpUser uses a different HTTP client (geventhttpclient) compared to HttpUser (python-requests).
     It's significantly faster, but not as capable.
-    
-    The behaviour of this user is defined by it's tasks. Tasks can be declared either directly on the 
-    class by using the :py:func:`@task decorator <locust.task>` on the methods, or by setting 
+
+    The behaviour of this user is defined by it's tasks. Tasks can be declared either directly on the
+    class by using the :py:func:`@task decorator <locust.task>` on the methods, or by setting
     the :py:attr:`tasks attribute <locust.User.tasks>`.
-    
-    This class creates a *client* attribute on instantiation which is an HTTP client with support 
+
+    This class creates a *client* attribute on instantiation which is an HTTP client with support
     for keeping a user session between requests.
     """
-    
+
     client = None
     """
-    Instance of HttpSession that is created upon instantiation of User. 
+    Instance of HttpSession that is created upon instantiation of User.
     The client support cookies, and therefore keeps the session between HTTP requests.
     """
-    
+
     # Below are various UserAgent settings. Change these in your subclass to alter FastHttpUser's behaviour.
     # It needs to be done before FastHttpUser is instantiated, changing them later will have no effect
-    
+
     network_timeout: float = 60.0
     """Parameter passed to FastHttpSession"""
-    
+
     connection_timeout: float = 60.0
     """Parameter passed to FastHttpSession"""
-    
+
     max_redirects: int = 5
     """Parameter passed to FastHttpSession. Default 5, meaning 4 redirects."""
-    
+
     max_retries: int = 1
     """Parameter passed to FastHttpSession. Default 1, meaning zero retries."""
-    
+
     insecure: bool = True
     """Parameter passed to FastHttpSession. Default True, meaning no SSL verification."""
 
-    abstract = True 
+    abstract = True
     """Dont register this as a User class that can be run by itself"""
 
     def __init__(self, environment):
         super().__init__(environment)
         if self.host is None:
-            raise LocustError("You must specify the base host. Either in the host attribute in the User class, or on the command line using the --host option.")
+            raise LocustError(
+                "You must specify the base host. Either in the host attribute in the User class, or on the command line using the --host option."
+            )
         if not re.match(r"^https?://[^/]+", self.host, re.I):
             raise LocustError("Invalid host (`%s`), must be a valid base URL. E.g. http://example.com" % self.host)
-        
+
         self.client = FastHttpSession(
-            self.environment, 
-            base_url=self.host, 
-            network_timeout=self.network_timeout, 
-            connection_timeout=self.connection_timeout, 
-            max_redirects=self.max_redirects, 
-            max_retries=self.max_retries, 
+            self.environment,
+            base_url=self.host,
+            network_timeout=self.network_timeout,
+            connection_timeout=self.connection_timeout,
+            max_redirects=self.max_redirects,
+            max_retries=self.max_retries,
             insecure=self.insecure,
         )
 
@@ -116,7 +125,7 @@ def insecure_ssl_context_factory():
 
 class FastHttpSession(object):
     auth_header = None
-    
+
     def __init__(self, environment: Environment, base_url: str, insecure=True, **kwargs):
         self.environment = environment
         self.base_url = base_url
@@ -126,34 +135,33 @@ class FastHttpSession(object):
         else:
             ssl_context_factory = gevent.ssl.create_default_context
         self.client = LocustUserAgent(
-            cookiejar=self.cookiejar,
-            ssl_context_factory=ssl_context_factory,
-            insecure=insecure,
-            **kwargs,
+            cookiejar=self.cookiejar, ssl_context_factory=ssl_context_factory, insecure=insecure, **kwargs,
         )
-        
+
         # Check for basic authentication
         parsed_url = urlparse(self.base_url)
         if parsed_url.username and parsed_url.password:
             netloc = parsed_url.hostname
             if parsed_url.port:
                 netloc += ":%d" % parsed_url.port
-            
+
             # remove username and password from the base_url
-            self.base_url = urlunparse((parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment))
+            self.base_url = urlunparse(
+                (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
+            )
             # store authentication header (we construct this by using _basic_auth_str() function from requests.auth)
             self.auth_header = _construct_basic_auth_str(parsed_url.username, parsed_url.password)
-    
+
     def _build_url(self, path):
         """ prepend url with hostname unless it's already an absolute URL """
         if absolute_http_url_regexp.match(path):
             return path
         else:
             return "%s%s" % (self.base_url, path)
-    
+
     def _send_request_safe_mode(self, method, url, **kwargs):
         """
-        Send an HTTP request, and catch any exception that might occur due to either 
+        Send an HTTP request, and catch any exception that might occur due to either
         connection problems, or invalid HTTP status codes
         """
         try:
@@ -165,65 +173,77 @@ class FastHttpSession(object):
                 r = ErrorResponse()
             r.error = e
             return r
-    
-    def request(self, method: str, path: str, name: str=None, data: str=None, catch_response: bool=False, stream: bool=False,
-                headers: dict=None, auth=None, json: dict=None, allow_redirects=True, **kwargs):
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        name: str = None,
+        data: str = None,
+        catch_response: bool = False,
+        stream: bool = False,
+        headers: dict = None,
+        auth=None,
+        json: dict = None,
+        allow_redirects=True,
+        **kwargs,
+    ):
         """
         Send and HTTP request
         Returns :py:class:`locust.contrib.fasthttp.FastResponse` object.
 
         :param method: method for the new :class:`Request` object.
         :param path: Path that will be concatenated with the base host URL that has been specified.
-            Can also be a full URL, in which case the full URL will be requested, and the base host 
+            Can also be a full URL, in which case the full URL will be requested, and the base host
             is ignored.
-        :param name: (optional) An argument that can be specified to use as label in Locust's 
-            statistics instead of the URL path. This can be used to group different URL's 
+        :param name: (optional) An argument that can be specified to use as label in Locust's
+            statistics instead of the URL path. This can be used to group different URL's
             that are requested into a single entry in Locust's statistics.
-        :param catch_response: (optional) Boolean argument that, if set, can be used to make a request 
-            return a context manager to work as argument to a with statement. This will allow the 
-            request to be marked as a fail based on the content of the response, even if the response 
-            code is ok (2xx). The opposite also works, one can use catch_response to catch a request 
+        :param catch_response: (optional) Boolean argument that, if set, can be used to make a request
+            return a context manager to work as argument to a with statement. This will allow the
+            request to be marked as a fail based on the content of the response, even if the response
+            code is ok (2xx). The opposite also works, one can use catch_response to catch a request
             and then mark it as successful even if the response code was not (i.e 500 or 404).
         :param data: (optional) String/bytes to send in the body of the request.
-        :param json: (optional) Dictionary to send in the body of the request. 
+        :param json: (optional) Dictionary to send in the body of the request.
             Automatically sets Content-Type and Accept headers to "application/json".
             Only used if data is not set.
         :param headers: (optional) Dictionary of HTTP Headers to send with the request.
         :param auth: (optional) Auth (username, password) tuple to enable Basic HTTP Auth.
-        :param stream: (optional) If set to true the response body will not be consumed immediately 
+        :param stream: (optional) If set to true the response body will not be consumed immediately
             and can instead be consumed by accessing the stream attribute on the Response object.
-            Another side effect of setting stream to True is that the time for downloading the response 
+            Another side effect of setting stream to True is that the time for downloading the response
             content will not be accounted for in the request time that is reported by Locust.
         """
         # prepend url with hostname unless it's already an absolute URL
         url = self._build_url(path)
-        
+
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {}
         # set up pre_request hook for attaching meta data to the request object
         request_meta["method"] = method
         request_meta["start_time"] = default_timer()
         request_meta["name"] = name or path
-        
+
         headers = headers or {}
         if auth:
-            headers['Authorization'] = _construct_basic_auth_str(auth[0], auth[1])
+            headers["Authorization"] = _construct_basic_auth_str(auth[0], auth[1])
         elif self.auth_header:
-            headers['Authorization'] = self.auth_header
+            headers["Authorization"] = self.auth_header
         if "Accept-Encoding" not in headers and "accept-encoding" not in headers:
-            headers['Accept-Encoding'] = "gzip, deflate"
+            headers["Accept-Encoding"] = "gzip, deflate"
 
         if not data and json is not None:
             data = unshadowed_json.dumps(json)
             if "Content-Type" not in headers and "content-type" not in headers:
-                headers['Content-Type'] = "application/json"
+                headers["Content-Type"] = "application/json"
             if "Accept" not in headers and "accept" not in headers:
-                headers['Accept'] = "application/json"
+                headers["Accept"] = "application/json"
 
         if not allow_redirects:
             old_redirect_response_codes = self.client.redirect_resonse_codes
             self.client.redirect_resonse_codes = []
-        
+
         # send request, and catch any exceptions
         response = self._send_request_safe_mode(method, url, payload=data, headers=headers, **kwargs)
 
@@ -247,12 +267,12 @@ class FastHttpSession(object):
                     exception=e,
                 )
                 return response
-        
+
         # Record the consumed time
-        # Note: This is intentionally placed after we record the content_size above, since 
+        # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
         request_meta["response_time"] = int((default_timer() - request_meta["start_time"]) * 1000)
-        
+
         if catch_response:
             response.locust_request_meta = request_meta
             return ResponseContextManager(response, environment=self.environment)
@@ -261,11 +281,11 @@ class FastHttpSession(object):
                 response.raise_for_status()
             except FAILURE_EXCEPTIONS as e:
                 self.environment.events.request_failure.fire(
-                    request_type=request_meta["method"], 
-                    name=request_meta["name"], 
-                    response_time=request_meta["response_time"], 
+                    request_type=request_meta["method"],
+                    name=request_meta["name"],
+                    response_time=request_meta["response_time"],
                     response_length=request_meta["content_size"],
-                    exception=e, 
+                    exception=e,
                 )
             else:
                 self.environment.events.request_success.fire(
@@ -275,30 +295,30 @@ class FastHttpSession(object):
                     response_length=request_meta["content_size"],
                 )
             return response
-    
+
     def delete(self, path, **kwargs):
         return self.request("DELETE", path, **kwargs)
-    
+
     def get(self, path, **kwargs):
         """Sends a GET request"""
         return self.request("GET", path, **kwargs)
-    
+
     def head(self, path, **kwargs):
         """Sends a HEAD request"""
         return self.request("HEAD", path, **kwargs)
-    
+
     def options(self, path, **kwargs):
         """Sends a OPTIONS request"""
         return self.request("OPTIONS", path, **kwargs)
-    
+
     def patch(self, path, data=None, **kwargs):
         """Sends a POST request"""
         return self.request("PATCH", path, data=data, **kwargs)
-    
+
     def post(self, path, data=None, **kwargs):
         """Sends a POST request"""
         return self.request("POST", path, data=data, **kwargs)
-    
+
     def put(self, path, data=None, **kwargs):
         """Sends a PUT request"""
         return self.request("PUT", path, data=data, **kwargs)
@@ -307,9 +327,9 @@ class FastHttpSession(object):
 class FastResponse(CompatResponse):
     headers = None
     """Dict like object containing the response headers"""
-    
+
     _response = None
-    
+
     encoding: str = None
     """In some cases setting the encoding explicitly is needed. If so, do it before calling .text"""
 
@@ -322,10 +342,10 @@ class FastResponse(CompatResponse):
             return None
         if self.encoding is None:
             if self.headers is None:
-                self.encoding = 'utf-8'
+                self.encoding = "utf-8"
             else:
-                self.encoding = self.headers.get('content-type', '').partition("charset=")[2] or 'utf-8'
-        return str(self.content, self.encoding, errors='replace')
+                self.encoding = self.headers.get("content-type", "").partition("charset=")[2] or "utf-8"
+        return str(self.content, self.encoding, errors="replace")
 
     def json(self) -> dict:
         """
@@ -335,17 +355,17 @@ class FastResponse(CompatResponse):
 
     def raise_for_status(self):
         """Raise any connection errors that occured during the request"""
-        if hasattr(self, 'error') and self.error:
+        if hasattr(self, "error") and self.error:
             raise self.error
-    
+
     @property
     def status_code(self) -> int:
         """
-        We override status_code in order to return None if no valid response was 
+        We override status_code in order to return None if no valid response was
         returned. E.g. in the case of connection errors
         """
         return self._response is not None and self._response.get_code() or 0
-    
+
     def _content(self):
         if self.headers is None:
             return None
@@ -354,14 +374,16 @@ class FastResponse(CompatResponse):
 
 class ErrorResponse(object):
     """
-    This is used as a dummy response object when geventhttpclient raises an error 
+    This is used as a dummy response object when geventhttpclient raises an error
     that doesn't have a real Response object attached. E.g. a socket error or similar
     """
+
     headers = None
     content = None
     status_code = 0
     error = None
     text = None
+
     def raise_for_status(self):
         raise self.error
 
@@ -369,51 +391,52 @@ class ErrorResponse(object):
 class LocustUserAgent(UserAgent):
     response_type = FastResponse
     valid_response_codes = frozenset([200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 301, 302, 303, 307])
-    
+
     def __init__(self, **kwargs):
         super(LocustUserAgent, self).__init__(**kwargs)
 
     def _urlopen(self, request):
         """Override _urlopen() in order to make it use the response_type attribute"""
         client = self.clientpool.get_client(request.url_split)
-        resp = client.request(request.method, request.url_split.request_uri,
-                              body=request.payload, headers=request.headers)
+        resp = client.request(
+            request.method, request.url_split.request_uri, body=request.payload, headers=request.headers
+        )
         return self.response_type(resp, request=request, sent_request=resp._sent_request)
 
 
 class ResponseContextManager(FastResponse):
     """
-    A Response class that also acts as a context manager that provides the ability to manually 
+    A Response class that also acts as a context manager that provides the ability to manually
     control if an HTTP request should be marked as successful or a failure in Locust's statistics
-    
-    This class is a subclass of :py:class:`FastResponse <locust.contrib.fasthttp.FastResponse>` 
+
+    This class is a subclass of :py:class:`FastResponse <locust.contrib.fasthttp.FastResponse>`
     with two additional methods: :py:meth:`success <locust.contrib.fasthttp.ResponseContextManager.success>`
     and :py:meth:`failure <locust.contrib.fasthttp.ResponseContextManager.failure>`.
     """
-    
+
     _manual_result = None
-    
+
     def __init__(self, response, environment):
         # copy data from response to this object
         self.__dict__ = response.__dict__
         self._cached_content = response.content
         # store reference to locust Environment
         self.environment = environment
-    
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc, value, traceback):
         if self._manual_result is not None:
             if self._manual_result == True:
                 self._report_success()
             elif isinstance(self._manual_result, Exception):
                 self._report_failure(self._manual_result)
-            
+
             # if the user has already manually marked this response as failure or success
             # we can ignore the default haviour of letting the response code determine the outcome
-            return exc is None        
-        
+            return exc is None
+
         if exc:
             if isinstance(value, ResponseError):
                 self._report_failure(value)
@@ -427,7 +450,7 @@ class ResponseContextManager(FastResponse):
             else:
                 self._report_success()
         return True
-    
+
     def _report_success(self):
         self.environment.events.request_success.fire(
             request_type=self.locust_request_meta["method"],
@@ -435,7 +458,7 @@ class ResponseContextManager(FastResponse):
             response_time=self.locust_request_meta["response_time"],
             response_length=self.locust_request_meta["content_size"],
         )
-    
+
     def _report_failure(self, exc):
         self.environment.events.request_failure.fire(
             request_type=self.locust_request_meta["method"],
@@ -444,28 +467,28 @@ class ResponseContextManager(FastResponse):
             response_length=self.locust_request_meta["content_size"],
             exception=exc,
         )
-    
+
     def success(self):
         """
         Report the response as successful
-        
+
         Example::
-        
+
             with self.client.get("/does/not/exist", catch_response=True) as response:
                 if response.status_code == 404:
                     response.success()
         """
         self._manual_result = True
-    
+
     def failure(self, exc):
         """
         Report the response as a failure.
-        
+
         exc can be either a python exception, or a string in which case it will
-        be wrapped inside a CatchResponseError. 
-        
+        be wrapped inside a CatchResponseError.
+
         Example::
-        
+
             with self.client.get("/", catch_response=True) as response:
                 if response.content == "":
                     response.failure("No data")

--- a/locust/env.py
+++ b/locust/env.py
@@ -12,10 +12,10 @@ class Environment:
     Event hooks used by Locust internally, as well as to extend Locust's functionality
     See :ref:`events` for available events.
     """
-    
+
     user_classes = []
     """User classes that the runner will run"""
-    
+
     tags = None
     """If set, only tasks that are tagged by tags in this list will be executed"""
 
@@ -24,34 +24,34 @@ class Environment:
 
     stats = None
     """Reference to RequestStats instance"""
-    
+
     runner = None
     """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
-    
+
     web_ui = None
     """Reference to the WebUI instance"""
-    
+
     host = None
     """Base URL of the target system"""
-    
+
     reset_stats = False
     """Determines if stats should be reset once all simulated users have been spawned"""
-    
+
     step_load = False
     """Determines if we're running in step load mode"""
-    
+
     stop_timeout = None
     """
-    If set, the runner will try to stop the runnning users gracefully and wait this many seconds 
+    If set, the runner will try to stop the runnning users gracefully and wait this many seconds
     before killing them hard.
     """
-    
+
     catch_exceptions = True
     """
     If True exceptions that happen within running users will be catched (and reported in UI/console).
     If False, exeptions will be raised.
     """
-    
+
     process_exit_code: int = None
     """
     If set it'll be the exit code of the Locust process
@@ -59,16 +59,17 @@ class Environment:
 
     parsed_options = None
     """Optional reference to the parsed command line options (used to pre-populate fields in Web UI)"""
-    
-    def  __init__(
-        self, *,
+
+    def __init__(
+        self,
+        *,
         user_classes=[],
         tags=None,
         exclude_tags=None,
-        events=None, 
-        host=None, 
-        reset_stats=False, 
-        step_load=False, 
+        events=None,
+        host=None,
+        reset_stats=False,
+        step_load=False,
         stop_timeout=None,
         catch_exceptions=True,
         parsed_options=None,
@@ -77,7 +78,7 @@ class Environment:
             self.events = events
         else:
             self.events = Events()
-        
+
         self.user_classes = user_classes
         self.tags = tags
         self.exclude_tags = exclude_tags
@@ -90,53 +91,45 @@ class Environment:
         self.parsed_options = parsed_options
 
         self._filter_tasks_by_tags()
-    
+
     def _create_runner(self, runner_class, *args, **kwargs):
         if self.runner is not None:
             raise RunnerAlreadyExistsError("Environment.runner already exists (%s)" % self.runner)
         self.runner = runner_class(self, *args, **kwargs)
         return self.runner
-    
+
     def create_local_runner(self):
         """
         Create a :class:`LocalRunner <locust.runners.LocalRunner>` instance for this Environment
         """
         return self._create_runner(LocalRunner)
-        
+
     def create_master_runner(self, master_bind_host="*", master_bind_port=5557):
         """
         Create a :class:`MasterRunner <locust.runners.MasterRunner>` instance for this Environment
-        
-        :param master_bind_host: Interface/host that the master should use for incoming worker connections. 
+
+        :param master_bind_host: Interface/host that the master should use for incoming worker connections.
                                  Defaults to "*" which means all interfaces.
         :param master_bind_port: Port that the master should listen for incoming worker connections on
         """
-        return self._create_runner(
-            MasterRunner,
-            master_bind_host=master_bind_host,
-            master_bind_port=master_bind_port,
-        )
-    
+        return self._create_runner(MasterRunner, master_bind_host=master_bind_host, master_bind_port=master_bind_port,)
+
     def create_worker_runner(self, master_host, master_port):
         """
         Create a :class:`WorkerRunner <locust.runners.WorkerRunner>` instance for this Environment
-        
+
         :param master_host: Host/IP of a running master node
         :param master_port: Port on master node to connect to
         """
         # Create a new RequestStats with use_response_times_cache set to False to save some memory
         # and CPU cycles, since the response_times_cache is not needed for Worker nodes
         self.stats = RequestStats(use_response_times_cache=False)
-        return self._create_runner(
-            WorkerRunner,
-            master_host=master_host,
-            master_port=master_port,
-        )
+        return self._create_runner(WorkerRunner, master_host=master_host, master_port=master_port,)
 
     def create_web_ui(self, host="", port=8089, auth_credentials=None, tls_cert=None, tls_key=None):
         """
         Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server
-        
+
         :param host: Host/interface that the web server should accept connections to. Defaults to ""
                      which means all interfaces
         :param port: Port that the web server should listen to
@@ -148,7 +141,7 @@ class Environment:
         """
         self.web_ui = WebUI(self, host, port, auth_credentials=auth_credentials, tls_cert=tls_cert, tls_key=tls_key)
         return self.web_ui
-    
+
     def _filter_tasks_by_tags(self):
         """
         Filter the tasks on all the user_classes recursively, according to the tags and

--- a/locust/event.py
+++ b/locust/event.py
@@ -2,6 +2,7 @@ import logging
 from . import log
 import traceback
 
+
 class EventHook(object):
     """
     Simple event class used to provide hooks for different types of events in Locust.
@@ -20,11 +21,11 @@ class EventHook(object):
 
     def __init__(self):
         self._handlers = []
-    
+
     def add_listener(self, handler):
         self._handlers.append(handler)
         return handler
-    
+
     def remove_listener(self, handler):
         self._handlers.remove(handler)
 
@@ -45,120 +46,120 @@ class Events:
     request_success = EventHook
     """
     Fired when a request is completed successfully. This event is typically used to report requests
-    when writing custom clients for locust. 
-    
+    when writing custom clients for locust.
+
     Event arguments:
-    
+
     :param request_type: Request type method used
     :param name: Path to the URL that was called (or override name if it was used in the call to the client)
     :param response_time: Response time in milliseconds
     :param response_length: Content-length of the response
     """
-    
+
     request_failure = EventHook
     """
-    Fired when a request fails. This event is typically used to report failed requests when writing 
-    custom clients for locust. 
-    
+    Fired when a request fails. This event is typically used to report failed requests when writing
+    custom clients for locust.
+
     Event arguments:
-    
+
     :param request_type: Request type method used
     :param name: Path to the URL that was called (or override name if it was used in the call to the client)
     :param response_time: Time in milliseconds until exception was thrown
     :param response_length: Content-length of the response
     :param exception: Exception instance that was thrown
     """
-    
+
     user_error = EventHook
     """
     Fired when an exception occurs inside the execution of a User class.
-    
+
     Event arguments:
-    
+
     :param user_instance: User class instance where the exception occurred
     :param exception: Exception that was thrown
     :param tb: Traceback object (from sys.exc_info()[2])
     """
-    
+
     report_to_master = EventHook
     """
     Used when Locust is running in --worker mode. It can be used to attach
     data to the dicts that are regularly sent to the master. It's fired regularly when a report
     is to be sent to the master server.
-    
+
     Note that the keys "stats" and "errors" are used by Locust and shouldn't be overridden.
-    
+
     Event arguments:
-    
+
     :param client_id: The client id of the running locust process.
     :param data: Data dict that can be modified in order to attach data that should be sent to the master.
     """
-    
+
     worker_report = EventHook
     """
     Used when Locust is running in --master mode and is fired when the master
     server receives a report from a Locust worker server.
-    
+
     This event can be used to aggregate data from the locust worker servers.
-    
+
     Event arguments:
-    
+
     :param client_id: Client id of the reporting worker
     :param data: Data dict with the data from the worker node
     """
-    
+
     hatch_complete = EventHook
     """
     Fired when all simulated users has been spawned.
-    
+
     Event arguments:
-    
+
     :param user_count: Number of users that was hatched
     """
-    
+
     quitting = EventHook
     """
     Fired when the locust process is exiting
-    
+
     Event arguments:
-    
+
     :param environment: Environment instance
     """
-    
+
     init = EventHook
     """
-    Fired when Locust is started, once the Environment instance and locust runner instance 
-    have been created. This hook can be used by end-users' code to run code that requires access to 
-    the Envirionment. For example to register listeners to request_success, request_failure 
+    Fired when Locust is started, once the Environment instance and locust runner instance
+    have been created. This hook can be used by end-users' code to run code that requires access to
+    the Envirionment. For example to register listeners to request_success, request_failure
     or other events.
-    
+
     Event arguments:
-    
+
     :param environment: Environment instance
     """
-    
+
     init_command_line_parser = EventHook
     """
     Event that can be used to add command line options to Locust
-    
+
     Event arguments:
-    
+
     :param parser: ArgumentParser instance
     """
-    
+
     test_start = EventHook
     """
-    Fired when a new load test is started. It's not fired again if the number of 
-    users change during a test. When running locust distributed the event is only fired 
-    on the master node and not on each worker node. 
+    Fired when a new load test is started. It's not fired again if the number of
+    users change during a test. When running locust distributed the event is only fired
+    on the master node and not on each worker node.
     """
-    
+
     test_stop = EventHook
     """
-    Fired when a load test is stopped. When running locust distributed the event 
+    Fired when a load test is stopped. When running locust distributed the event
     is only fired on the master node and not on each worker node.
     """
-    
+
     def __init__(self):
         for name, value in vars(type(self)).items():
             if value == EventHook:

--- a/locust/exception.py
+++ b/locust/exception.py
@@ -1,20 +1,24 @@
 class LocustError(Exception):
     pass
 
+
 class ResponseError(Exception):
     pass
+
 
 class CatchResponseError(Exception):
     pass
 
+
 class MissingWaitTimeError(LocustError):
     pass
+
 
 class InterruptTaskSet(Exception):
     """
     Exception that will interrupt a User when thrown inside a task
     """
-    
+
     def __init__(self, reschedule=True):
         """
         If *reschedule* is True and the InterruptTaskSet is raised inside a nested TaskSet,
@@ -22,21 +26,25 @@ class InterruptTaskSet(Exception):
         """
         self.reschedule = reschedule
 
+
 class StopUser(Exception):
     pass
+
 
 class RescheduleTask(Exception):
     """
     When raised in a task it's equivalent of a return statement.
-    
-    Used internally by TaskSet. When raised within the task control flow of a TaskSet, 
+
+    Used internally by TaskSet. When raised within the task control flow of a TaskSet,
     but not inside a task, the execution should be handed over to the parent TaskSet.
     """
+
 
 class RescheduleTaskImmediately(Exception):
     """
     When raised in a User task, another User task will be rescheduled immediately
     """
+
 
 class RPCError(Exception):
     """
@@ -45,12 +53,15 @@ class RPCError(Exception):
     When raised from zmqrpc, RPC should be reestablished.
     """
 
+
 class AuthCredentialsError(ValueError):
     """
     Exception when the auth credentials provided
     are not in the correct format
     """
+
     pass
+
 
 class RunnerAlreadyExistsError(Exception):
     pass

--- a/locust/log.py
+++ b/locust/log.py
@@ -11,47 +11,26 @@ unhandled_greenlet_exception = False
 
 def setup_logging(loglevel, logfile=None):
     loglevel = loglevel.upper()
-    
+
     LOGGING_CONFIG = {
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "default": {
-                "format": "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(HOSTNAME),
-            },
-            "plain": {
-                "format": "%(message)s",
-            },
+            "default": {"format": "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(HOSTNAME)},
+            "plain": {"format": "%(message)s"},
         },
         "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "default",
-            },
-            "console_plain": {
-                "class": "logging.StreamHandler",
-                "formatter": "plain",
-            },
+            "console": {"class": "logging.StreamHandler", "formatter": "default"},
+            "console_plain": {"class": "logging.StreamHandler", "formatter": "plain"},
         },
         "loggers": {
-            "locust": {
-                "handlers": ["console"],
-                "level": loglevel,
-                "propagate": False,
-            },
-            "locust.stats_logger": {
-                "handlers": ["console_plain"],
-                "level": "INFO",
-                "propagate": False,
-            },
+            "locust": {"handlers": ["console"], "level": loglevel, "propagate": False},
+            "locust.stats_logger": {"handlers": ["console_plain"], "level": "INFO", "propagate": False},
         },
-        "root": {
-            "handlers": ["console"],
-            "level": loglevel,
-        },
+        "root": {"handlers": ["console"], "level": loglevel},
     }
     if logfile:
-        # if a file has been specified add a file logging handler and set 
+        # if a file has been specified add a file logging handler and set
         # the locust and root loggers to use it
         LOGGING_CONFIG["handlers"]["file"] = {
             "class": "logging.FileHandler",
@@ -60,17 +39,19 @@ def setup_logging(loglevel, logfile=None):
         }
         LOGGING_CONFIG["loggers"]["locust"]["handlers"] = ["file"]
         LOGGING_CONFIG["root"]["handlers"] = ["file"]
-    
+
     logging.config.dictConfig(LOGGING_CONFIG)
 
 
 def greenlet_exception_logger(logger, level=logging.CRITICAL):
     """
-    Return a function that can be used as argument to Greenlet.link_exception() that will log the 
+    Return a function that can be used as argument to Greenlet.link_exception() that will log the
     unhandled exception to the given logger.
     """
+
     def exception_handler(greenlet):
         logger.log(level, "Unhandled exception in greenlet: %s", greenlet, exc_info=greenlet.exc_info)
         global unhandled_greenlet_exception
         unhandled_greenlet_exception = True
+
     return exception_handler

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -6,7 +6,7 @@ class Message(object):
         self.type = message_type
         self.data = data
         self.node_id = node_id
-    
+
     def __repr__(self):
         return "<Message %s:%s>" % (self.type, self.node_id)
 

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -5,6 +5,7 @@ from locust.exception import RPCError
 import zmq.error as zmqerr
 import msgpack.exceptions as msgerr
 
+
 class BaseSocket(object):
     def __init__(self, sock_type):
         context = zmq.Context()
@@ -12,7 +13,7 @@ class BaseSocket(object):
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-    
+
     @retry()
     def send(self, msg):
         try:
@@ -51,6 +52,7 @@ class BaseSocket(object):
     def close(self):
         self.socket.close()
 
+
 class Server(BaseSocket):
     def __init__(self, host, port):
         BaseSocket.__init__(self, zmq.ROUTER)
@@ -61,7 +63,8 @@ class Server(BaseSocket):
                 self.socket.bind("tcp://%s:%i" % (host, port))
                 self.port = port
             except zmqerr.ZMQError as e:
-                raise RPCError("Socket bind failure: %s" % (e) )
+                raise RPCError("Socket bind failure: %s" % (e))
+
 
 class Client(BaseSocket):
     def __init__(self, host, port, identity):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -21,7 +21,15 @@ from .exception import RPCError
 logger = logging.getLogger(__name__)
 
 
-STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_CLEANUP, STATE_STOPPING, STATE_STOPPED, STATE_MISSING = ["ready", "hatching", "running", "cleanup", "stopping", "stopped", "missing"]
+STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_CLEANUP, STATE_STOPPING, STATE_STOPPED, STATE_MISSING = [
+    "ready",
+    "hatching",
+    "running",
+    "cleanup",
+    "stopping",
+    "stopped",
+    "missing",
+]
 WORKER_REPORT_INTERVAL = 3.0
 CPU_MONITOR_INTERVAL = 5.0
 HEARTBEAT_INTERVAL = 1
@@ -35,13 +43,14 @@ greenlet_exception_handler = greenlet_exception_logger(logger)
 class Runner(object):
     """
     Orchestrates the load test by starting and stopping the users.
-    
-    Use one of the :meth:`create_local_runner <locust.env.Environment.create_local_runner>`, 
-    :meth:`create_master_runner <locust.env.Environment.create_master_runner>` or 
+
+    Use one of the :meth:`create_local_runner <locust.env.Environment.create_local_runner>`,
+    :meth:`create_master_runner <locust.env.Environment.create_master_runner>` or
     :meth:`create_worker_runner <locust.env.Environment.create_worker_runner>` methods on
-    the :class:`Environment <locust.env.Environment>` instance to create a runner of the 
+    the :class:`Environment <locust.env.Environment>` instance to create a runner of the
     desired type.
     """
+
     def __init__(self, environment):
         self.environment = environment
         self.user_greenlets = Group()
@@ -54,15 +63,15 @@ class Runner(object):
         self.greenlet.spawn(self.monitor_cpu).link_exception(greenlet_exception_handler)
         self.exceptions = {}
         self.target_user_count = None
-        
+
         # set up event listeners for recording requests
         def on_request_success(request_type, name, response_time, response_length, **kwargs):
             self.stats.log_request(request_type, name, response_time, response_length)
-        
+
         def on_request_failure(request_type, name, response_time, response_length, exception, **kwargs):
             self.stats.log_request(request_type, name, response_time, response_length)
             self.stats.log_error(request_type, name, exception)
-        
+
         self.environment.events.request_success.add_listener(on_request_success)
         self.environment.events.request_failure.add_listener(on_request_failure)
         self.connection_broken = False
@@ -73,25 +82,26 @@ class Runner(object):
             if environment.reset_stats:
                 logger.info("Resetting stats\n")
                 self.stats.reset_all()
+
         self.environment.events.hatch_complete.add_listener(on_hatch_complete)
-    
+
     def __del__(self):
         # don't leave any stray greenlets if runner is removed
         if self.greenlet and len(self.greenlet) > 0:
             self.greenlet.kill(block=False)
-    
+
     @property
     def user_classes(self):
         return self.environment.user_classes
-    
+
     @property
     def stats(self) -> RequestStats:
         return self.environment.stats
-    
+
     @property
     def errors(self):
         return self.stats.errors
-    
+
     @property
     def user_count(self):
         """
@@ -102,7 +112,9 @@ class Runner(object):
     def cpu_log_warning(self):
         """Called at the end of the test to repeat the warning & return the status"""
         if self.cpu_warning_emitted:
-            logger.warning("CPU usage was too high at some point during the test! See https://docs.locust.io/en/stable/running-locust-distributed.html for how to distribute the load over multiple CPU cores or machines")
+            logger.warning(
+                "CPU usage was too high at some point during the test! See https://docs.locust.io/en/stable/running-locust-distributed.html for how to distribute the load over multiple CPU cores or machines"
+            )
             return True
         return False
 
@@ -130,11 +142,13 @@ class Runner(object):
             # and we do this by iterating over each of the User classes - starting with the one
             # where the residual from the rounding was the largest - and creating one of each until
             # we get the correct amount
-            for user in [l for l, r in sorted(residuals.items(), key=lambda x:x[1], reverse=True)][:amount-len(bucket)]:
+            for user in [l for l, r in sorted(residuals.items(), key=lambda x: x[1], reverse=True)][
+                : amount - len(bucket)
+            ]:
                 bucket.append(user)
         elif len(bucket) > amount:
             # We've got too many users due to rounding errors so we need to remove some
-            for user in [l for l, r in sorted(residuals.items(), key=lambda x:x[1])][:len(bucket)-amount]:
+            for user in [l for l, r in sorted(residuals.items(), key=lambda x: x[1])][: len(bucket) - amount]:
                 bucket.remove(user)
 
         return bucket
@@ -144,23 +158,29 @@ class Runner(object):
         spawn_count = len(bucket)
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.state = STATE_HATCHING
-        
+
         existing_count = len(self.user_greenlets)
-        logger.info("Hatching and swarming %i users at the rate %g users/s (%i users already running)..." % (spawn_count, hatch_rate, existing_count))
+        logger.info(
+            "Hatching and swarming %i users at the rate %g users/s (%i users already running)..."
+            % (spawn_count, hatch_rate, existing_count)
+        )
         occurrence_count = dict([(l.__name__, 0) for l in self.user_classes])
-        
+
         def hatch():
             sleep_time = 1.0 / hatch_rate
             while True:
                 if not bucket:
-                    logger.info("All users hatched: %s (%i already running)" % (
-                        ", ".join(["%s: %d" % (name, count) for name, count in occurrence_count.items()]), 
-                        existing_count,
-                    ))
+                    logger.info(
+                        "All users hatched: %s (%i already running)"
+                        % (
+                            ", ".join(["%s: %d" % (name, count) for name, count in occurrence_count.items()]),
+                            existing_count,
+                        )
+                    )
                     self.environment.events.hatch_complete.fire(user_count=len(self.user_greenlets))
                     return
 
-                user_class = bucket.pop(random.randint(0, len(bucket)-1))
+                user_class = bucket.pop(random.randint(0, len(bucket) - 1))
                 occurrence_count[user_class.__name__] += 1
                 new_user = user_class(self.environment)
                 new_user.start(self.user_greenlets)
@@ -168,7 +188,7 @@ class Runner(object):
                     logger.debug("%i users hatched" % len(self.user_greenlets))
                 if bucket:
                     gevent.sleep(sleep_time)
-        
+
         hatch()
         if wait:
             self.user_greenlets.join()
@@ -185,14 +205,13 @@ class Runner(object):
         for g in self.user_greenlets:
             for l in bucket:
                 user = g.args[0]
-                if l == type(user):
+                if isinstance(user, l):
                     to_stop.append(user)
                     bucket.remove(l)
                     break
         self.stop_user_instances(to_stop)
         self.environment.events.hatch_complete.fire(user_count=self.user_count)
-    
-    
+
     def stop_user_instances(self, users):
         if self.environment.stop_timeout:
             stopping = Group()
@@ -202,29 +221,34 @@ class Runner(object):
                     # to add it's greenlet to our stopping Group so we can wait for it to finish it's task
                     stopping.add(user._greenlet)
             if not stopping.join(timeout=self.environment.stop_timeout):
-                logger.info("Not all users finished their tasks & terminated in %s seconds. Stopping them..." % self.environment.stop_timeout)
+                logger.info(
+                    "Not all users finished their tasks & terminated in %s seconds. Stopping them..."
+                    % self.environment.stop_timeout
+                )
             stopping.kill(block=True)
         else:
             for user in users:
                 user.stop(self.user_greenlets, force=True)
-        
+
     def monitor_cpu(self):
         process = psutil.Process()
         while True:
             self.current_cpu_usage = process.cpu_percent()
             if self.current_cpu_usage > 90 and not self.cpu_warning_emitted:
-                logging.warning("CPU usage above 90%! This may constrain your throughput and may even give inconsistent response time measurements! See https://docs.locust.io/en/stable/running-locust-distributed.html for how to distribute the load over multiple CPU cores or machines")
+                logging.warning(
+                    "CPU usage above 90%! This may constrain your throughput and may even give inconsistent response time measurements! See https://docs.locust.io/en/stable/running-locust-distributed.html for how to distribute the load over multiple CPU cores or machines"
+                )
                 self.cpu_warning_emitted = True
             gevent.sleep(CPU_MONITOR_INTERVAL)
 
     def start(self, user_count, hatch_rate, wait=False):
         """
         Start running a load test
-        
+
         :param user_count: Number of users to start
         :param hatch_rate: Number of users to spawn per second
         :param wait: If True calls to this method will block until all users are spawned.
-                     If False (the default), a greenlet that spawns the users will be 
+                     If False (the default), a greenlet that spawns the users will be
                      started and the call to this method will return immediately.
         """
         if self.state != STATE_RUNNING and self.state != STATE_HATCHING:
@@ -253,14 +277,20 @@ class Runner(object):
 
     def start_stepload(self, user_count, hatch_rate, step_user_count, step_duration):
         if user_count < step_user_count:
-            logger.error("Invalid parameters: total user count of %d is smaller than step user count of %d" % (user_count, step_user_count))
+            logger.error(
+                "Invalid parameters: total user count of %d is smaller than step user count of %d"
+                % (user_count, step_user_count)
+            )
             return
         self.total_users = user_count
-        
+
         if self.stepload_greenlet:
             logger.info("There is an ongoing swarming in Step Load mode, will stop it now.")
             self.stepload_greenlet.kill()
-        logger.info("Start a new swarming in Step Load mode: total user count of %d, hatch rate of %d, step user count of %d, step duration of %d " % (user_count, hatch_rate, step_user_count, step_duration))
+        logger.info(
+            "Start a new swarming in Step Load mode: total user count of %d, hatch rate of %d, step user count of %d, step duration of %d "
+            % (user_count, hatch_rate, step_user_count, step_duration)
+        )
         self.state = STATE_INIT
         self.stepload_greenlet = self.greenlet.spawn(self.stepload_worker, hatch_rate, step_user_count, step_duration)
         self.stepload_greenlet.link_exception(greenlet_exception_handler)
@@ -270,10 +300,10 @@ class Runner(object):
         while self.state == STATE_INIT or self.state == STATE_HATCHING or self.state == STATE_RUNNING:
             current_num_users += step_users_growth
             if current_num_users > int(self.total_users):
-                logger.info('Step Load is finished.')
+                logger.info("Step Load is finished.")
                 break
             self.start(current_num_users, hatch_rate)
-            logger.info('Step loading: start hatch job of %d user.' % (current_num_users))
+            logger.info("Step loading: start hatch job of %d user." % (current_num_users))
             gevent.sleep(step_duration)
 
     def stop(self):
@@ -287,7 +317,7 @@ class Runner(object):
         self.stop_user_instances([g.args[0] for g in self.user_greenlets])
         self.state = STATE_STOPPED
         self.cpu_log_warning()
-    
+
     def quit(self):
         """
         Stop any running load test and kill all greenlets for the runner
@@ -307,6 +337,7 @@ class LocalRunner(Runner):
     """
     Runner for running single process load test
     """
+
     def __init__(self, environment):
         """
         :param environment: Environment instance
@@ -317,23 +348,28 @@ class LocalRunner(Runner):
         def on_user_error(user_instance, exception, tb):
             formatted_tb = "".join(traceback.format_tb(tb))
             self.log_exception("local", str(exception), formatted_tb)
+
         self.environment.events.user_error.add_listener(on_user_error)
 
     def start(self, user_count, hatch_rate, wait=False):
         self.target_user_count = user_count
         if hatch_rate > 100:
-            logger.warning("Your selected hatch rate is very high (>100), and this is known to sometimes cause issues. Do you really need to ramp up that fast?")
-        
+            logger.warning(
+                "Your selected hatch rate is very high (>100), and this is known to sometimes cause issues. Do you really need to ramp up that fast?"
+            )
+
         if self.state != STATE_RUNNING and self.state != STATE_HATCHING:
             # if we're not already running we'll fire the test_start event
             self.environment.events.test_start.fire(environment=self.environment)
-        
+
         if self.hatching_greenlet:
             # kill existing hatching_greenlet before we start a new one
             self.hatching_greenlet.kill(block=True)
-        self.hatching_greenlet = self.greenlet.spawn(lambda: super(LocalRunner, self).start(user_count, hatch_rate, wait=wait))
+        self.hatching_greenlet = self.greenlet.spawn(
+            lambda: super(LocalRunner, self).start(user_count, hatch_rate, wait=wait)
+        )
         self.hatching_greenlet.link_exception(greenlet_exception_handler)
-    
+
     def stop(self):
         if self.state == STATE_STOPPED:
             return
@@ -346,6 +382,7 @@ class DistributedRunner(Runner):
         super().__init__(*args, **kwargs)
         setup_distributed_stats_event_listeners(self.environment.events, self.stats)
 
+
 class WorkerNode(object):
     def __init__(self, id, state=STATE_INIT, heartbeat_liveness=HEARTBEAT_LIVENESS):
         self.id = id
@@ -355,15 +392,17 @@ class WorkerNode(object):
         self.cpu_usage = 0
         self.cpu_warning_emitted = False
 
+
 class MasterRunner(DistributedRunner):
     """
     Runner used to run distributed load tests across multiple processes and/or machines.
-    
+
     MasterRunner doesn't spawn any user greenlets itself. Instead it expects
     :class:`WorkerRunners <WorkerRunner>` to connect to it, which it will then direct
     to start and stop user greenlets. Stats sent back from the
     :class:`WorkerRunners <WorkerRunner>` will aggregated.
     """
+
     def __init__(self, environment, master_bind_host, master_bind_port):
         """
         :param environment: Environment instance
@@ -378,7 +417,7 @@ class MasterRunner(DistributedRunner):
         class WorkerNodesDict(dict):
             def get_by_state(self, state):
                 return [c for c in self.values() if c.state == state]
-            
+
             @property
             def all(self):
                 return self.values()
@@ -386,11 +425,11 @@ class MasterRunner(DistributedRunner):
             @property
             def ready(self):
                 return self.get_by_state(STATE_INIT)
-            
+
             @property
             def hatching(self):
                 return self.get_by_state(STATE_HATCHING)
-            
+
             @property
             def running(self):
                 return self.get_by_state(STATE_RUNNING)
@@ -398,14 +437,16 @@ class MasterRunner(DistributedRunner):
             @property
             def missing(self):
                 return self.get_by_state(STATE_MISSING)
-        
+
         self.clients = WorkerNodesDict()
         try:
             self.server = rpc.Server(master_bind_host, master_bind_port)
         except RPCError as e:
             if e.args[0] == "Socket bind failure: Address already in use":
                 port_string = master_bind_host + ":" + master_bind_port if master_bind_host != "*" else master_bind_port
-                logger.error(f"The Locust master port ({port_string}) was busy. Close any applications using that port - perhaps an old instance of Locust master is still running? ({e.args[0]})")
+                logger.error(
+                    f"The Locust master port ({port_string}) was busy. Close any applications using that port - perhaps an old instance of Locust master is still running? ({e.args[0]})"
+                )
                 sys.exit(1)
             else:
                 raise
@@ -420,17 +461,19 @@ class MasterRunner(DistributedRunner):
                 return
 
             self.clients[client_id].user_count = data["user_count"]
+
         self.environment.events.worker_report.add_listener(on_worker_report)
-        
+
         # register listener that sends quit message to worker nodes
         def on_quitting(environment, **kw):
             self.quit()
+
         self.environment.events.quitting.add_listener(on_quitting)
-    
+
     @property
     def user_count(self):
         return sum([c.user_count for c in self.clients.values()])
-    
+
     def cpu_log_warning(self):
         warning_emitted = Runner.cpu_log_warning(self)
         if self.worker_cpu_warning_emitted:
@@ -442,8 +485,10 @@ class MasterRunner(DistributedRunner):
         self.target_user_count = user_count
         num_workers = len(self.clients.ready) + len(self.clients.running) + len(self.clients.hatching)
         if not num_workers:
-            logger.warning("You are running in distributed mode but have no worker servers connected. "
-                           "Please connect workers prior to swarming.")
+            logger.warning(
+                "You are running in distributed mode but have no worker servers connected. "
+                "Please connect workers prior to swarming."
+            )
             return
 
         self.hatch_rate = hatch_rate
@@ -451,17 +496,22 @@ class MasterRunner(DistributedRunner):
         worker_hatch_rate = float(hatch_rate) / (num_workers or 1)
         remaining = user_count % num_workers
 
-        logger.info("Sending hatch jobs of %d users and %.2f hatch rate to %d ready clients" % (worker_num_users, worker_hatch_rate, num_workers))
+        logger.info(
+            "Sending hatch jobs of %d users and %.2f hatch rate to %d ready clients"
+            % (worker_num_users, worker_hatch_rate, num_workers)
+        )
 
         if worker_hatch_rate > 100:
-            logger.warning("Your selected hatch rate is very high (>100/worker), and this is known to sometimes cause issues. Do you really need to ramp up that fast?")
+            logger.warning(
+                "Your selected hatch rate is very high (>100/worker), and this is known to sometimes cause issues. Do you really need to ramp up that fast?"
+            )
 
         if self.state != STATE_RUNNING and self.state != STATE_HATCHING:
             self.stats.clear_all()
             self.exceptions = {}
             self.environment.events.test_start.fire(environment=self.environment)
-        
-        for client in (self.clients.ready + self.clients.running + self.clients.hatching):
+
+        for client in self.clients.ready + self.clients.running + self.clients.hatching:
             data = {
                 "hatch_rate": worker_hatch_rate,
                 "num_users": worker_num_users,
@@ -474,7 +524,7 @@ class MasterRunner(DistributedRunner):
                 remaining -= 1
 
             self.server.send_to_client(Message("hatch", data, client.id))
-        
+
         self.state = STATE_HATCHING
 
     def stop(self):
@@ -483,22 +533,23 @@ class MasterRunner(DistributedRunner):
             for client in self.clients.all:
                 self.server.send_to_client(Message("stop", None, client.id))
             self.environment.events.test_stop.fire(environment=self.environment)
-    
+
     def quit(self):
         if self.state not in [STATE_INIT, STATE_STOPPED, STATE_STOPPING]:
             # fire test_stop event if state isn't already stopped
             self.environment.events.test_stop.fire(environment=self.environment)
-            
+
         for client in self.clients.all:
             self.server.send_to_client(Message("quit", None, client.id))
-        gevent.sleep(0.5) # wait for final stats report from all workers
+        gevent.sleep(0.5)  # wait for final stats report from all workers
         self.greenlet.kill(block=True)
 
     def check_stopped(self):
-        if not self.state == STATE_INIT and all(map(lambda x: x.state != STATE_RUNNING and x.state != STATE_HATCHING, self.clients.all)):
+        if not self.state == STATE_INIT and all(
+            map(lambda x: x.state != STATE_RUNNING and x.state != STATE_HATCHING, self.clients.all)
+        ):
             self.state = STATE_STOPPED
 
-    
     def heartbeat_worker(self):
         while True:
             gevent.sleep(HEARTBEAT_INTERVAL)
@@ -508,7 +559,7 @@ class MasterRunner(DistributedRunner):
 
             for client in self.clients.all:
                 if client.heartbeat < 0 and client.state != STATE_MISSING:
-                    logger.info('Worker %s failed to send heartbeat, setting state to missing.' % str(client.id))
+                    logger.info("Worker %s failed to send heartbeat, setting state to missing." % str(client.id))
                     client.state = STATE_MISSING
                     client.user_count = 0
                     if self.worker_count - len(self.clients.missing) <= 0:
@@ -524,14 +575,14 @@ class MasterRunner(DistributedRunner):
             self.server.close()
             self.server = rpc.Server(self.master_bind_host, self.master_bind_port)
         except RPCError as e:
-            logger.error("Temporay failure when resetting connection: %s, will retry later." % ( e ) )
+            logger.error("Temporay failure when resetting connection: %s, will retry later." % (e))
 
     def client_listener(self):
         while True:
-            try: 
+            try:
                 client_id, msg = self.server.recv_from_client()
             except RPCError as e:
-                logger.error("RPCError found when receiving from client: %s" % ( e ) )
+                logger.error("RPCError found when receiving from client: %s" % (e))
                 self.connection_broken = True
                 gevent.sleep(FALLBACK_INTERVAL)
                 continue
@@ -540,12 +591,15 @@ class MasterRunner(DistributedRunner):
             if msg.type == "client_ready":
                 id = msg.node_id
                 self.clients[id] = WorkerNode(id, heartbeat_liveness=HEARTBEAT_LIVENESS)
-                logger.info("Client %r reported as ready. Currently %i clients ready to swarm." % (id, len(self.clients.ready + self.clients.running + self.clients.hatching)))
+                logger.info(
+                    "Client %r reported as ready. Currently %i clients ready to swarm."
+                    % (id, len(self.clients.ready + self.clients.running + self.clients.hatching))
+                )
                 if self.state == STATE_RUNNING or self.state == STATE_HATCHING:
                     # balance the load distribution when new client joins
                     self.start(self.target_user_count, self.hatch_rate)
-                ## emit a warning if the worker's clock seem to be out of sync with our clock
-                #if abs(time() - msg.data["time"]) > 5.0:
+                # emit a warning if the worker's clock seem to be out of sync with our clock
+                # if abs(time() - msg.data["time"]) > 5.0:
                 #    warnings.warn("The worker node's clock seem to be out of sync. For the statistics to be correct the different locust servers need to have synchronized clocks.")
             elif msg.type == "client_stopped":
                 del self.clients[msg.node_id]
@@ -554,12 +608,14 @@ class MasterRunner(DistributedRunner):
                 if msg.node_id in self.clients:
                     c = self.clients[msg.node_id]
                     c.heartbeat = HEARTBEAT_LIVENESS
-                    c.state = msg.data['state']
-                    c.cpu_usage = msg.data['current_cpu_usage']
+                    c.state = msg.data["state"]
+                    c.cpu_usage = msg.data["current_cpu_usage"]
                     if not c.cpu_warning_emitted and c.cpu_usage > 90:
-                        self.worker_cpu_warning_emitted = True # used to fail the test in the end
-                        c.cpu_warning_emitted = True          # used to suppress logging for this node
-                        logger.warning("Worker %s exceeded cpu threshold (will only log this once per worker)" % (msg.node_id))
+                        self.worker_cpu_warning_emitted = True  # used to fail the test in the end
+                        c.cpu_warning_emitted = True  # used to suppress logging for this node
+                        logger.warning(
+                            "Worker %s exceeded cpu threshold (will only log this once per worker)" % (msg.node_id)
+                        )
             elif msg.type == "stats":
                 self.environment.events.worker_report.fire(client_id=msg.node_id, data=msg.data)
             elif msg.type == "hatching":
@@ -573,7 +629,9 @@ class MasterRunner(DistributedRunner):
             elif msg.type == "quit":
                 if msg.node_id in self.clients:
                     del self.clients[msg.node_id]
-                    logger.info("Client %r quit. Currently %i clients connected." % (msg.node_id, len(self.clients.ready)))
+                    logger.info(
+                        "Client %r quit. Currently %i clients connected." % (msg.node_id, len(self.clients.ready))
+                    )
                     if self.worker_count - len(self.clients.missing) <= 0:
                         logger.info("The last worker quit, stopping test.")
                         self.stop()
@@ -584,20 +642,20 @@ class MasterRunner(DistributedRunner):
 
             self.check_stopped()
 
-
     @property
     def worker_count(self):
         return len(self.clients.ready) + len(self.clients.hatching) + len(self.clients.running)
 
+
 class WorkerRunner(DistributedRunner):
     """
     Runner used to run distributed load tests across multiple processes and/or machines.
-    
+
     WorkerRunner connects to a :class:`MasterRunner` from which it'll receive
     instructions to start and stop user greenlets. The WorkerRunner will preiodically
     take the stats generated by the running users and send back to the :class:`MasterRunner`.
     """
-    
+
     def __init__(self, environment, master_host, master_port):
         """
         :param environment: Environment instance
@@ -614,35 +672,45 @@ class WorkerRunner(DistributedRunner):
         self.client.send(Message("client_ready", None, self.client_id))
         self.worker_state = STATE_INIT
         self.greenlet.spawn(self.stats_reporter).link_exception(greenlet_exception_handler)
-        
+
         # register listener for when all users have hatched, and report it to the master node
         def on_hatch_complete(user_count):
-            self.client.send(Message("hatch_complete", {"count":user_count}, self.client_id))
+            self.client.send(Message("hatch_complete", {"count": user_count}, self.client_id))
             self.worker_state = STATE_RUNNING
+
         self.environment.events.hatch_complete.add_listener(on_hatch_complete)
-        
+
         # register listener that adds the current number of spawned users to the report that is sent to the master node
         def on_report_to_master(client_id, data):
             data["user_count"] = self.user_count
+
         self.environment.events.report_to_master.add_listener(on_report_to_master)
-        
+
         # register listener that sends quit message to master
         def on_quitting(environment, **kw):
             self.client.send(Message("quit", None, self.client_id))
+
         self.environment.events.quitting.add_listener(on_quitting)
 
         # register listener thats sends user exceptions to master
         def on_user_error(user_instance, exception, tb):
             formatted_tb = "".join(traceback.format_tb(tb))
-            self.client.send(Message("exception", {"msg" : str(exception), "traceback" : formatted_tb}, self.client_id))
+            self.client.send(Message("exception", {"msg": str(exception), "traceback": formatted_tb}, self.client_id))
+
         self.environment.events.user_error.add_listener(on_user_error)
 
     def heartbeat(self):
         while True:
             try:
-                self.client.send(Message('heartbeat', {'state': self.worker_state, 'current_cpu_usage': self.current_cpu_usage}, self.client_id))
+                self.client.send(
+                    Message(
+                        "heartbeat",
+                        {"state": self.worker_state, "current_cpu_usage": self.current_cpu_usage},
+                        self.client_id,
+                    )
+                )
             except RPCError as e:
-                logger.error("RPCError found when sending heartbeat: %s" % ( e ) )
+                logger.error("RPCError found when sending heartbeat: %s" % (e))
                 self.reset_connection()
             gevent.sleep(HEARTBEAT_INTERVAL)
 
@@ -652,14 +720,14 @@ class WorkerRunner(DistributedRunner):
             self.client.close()
             self.client = rpc.Client(self.master_host, self.master_port, self.client_id)
         except RPCError as e:
-            logger.error("Temporary failure when resetting connection: %s, will retry later." % ( e ) )
+            logger.error("Temporary failure when resetting connection: %s, will retry later." % (e))
 
     def worker(self):
         while True:
             try:
                 msg = self.client.recv()
             except RPCError as e:
-                logger.error("RPCError found when receiving from master: %s" % ( e ) )
+                logger.error("RPCError found when receiving from master: %s" % (e))
                 continue
             if msg.type == "hatch":
                 self.worker_state = STATE_HATCHING
@@ -672,7 +740,9 @@ class WorkerRunner(DistributedRunner):
                 if self.hatching_greenlet:
                     # kill existing hatching greenlet before we launch new one
                     self.hatching_greenlet.kill(block=True)
-                self.hatching_greenlet = self.greenlet.spawn(lambda: self.start(user_count=job["num_users"], hatch_rate=job["hatch_rate"]))
+                self.hatching_greenlet = self.greenlet.spawn(
+                    lambda: self.start(user_count=job["num_users"], hatch_rate=job["hatch_rate"])
+                )
                 self.hatching_greenlet.link_exception(greenlet_exception_handler)
             elif msg.type == "stop":
                 self.stop()
@@ -682,7 +752,7 @@ class WorkerRunner(DistributedRunner):
             elif msg.type == "quit":
                 logger.info("Got quit message from master, shutting down...")
                 self.stop()
-                self._send_stats() # send a final report, in case there were any samples not yet reported
+                self._send_stats()  # send a final report, in case there were any samples not yet reported
                 self.greenlet.kill(block=True)
 
     def stats_reporter(self):
@@ -690,7 +760,7 @@ class WorkerRunner(DistributedRunner):
             try:
                 self._send_stats()
             except RPCError as e:
-                logger.error("Temporary connection lost to master server: %s, will retry later." % (e))            
+                logger.error("Temporary connection lost to master server: %s, will retry later." % (e))
             gevent.sleep(WORKER_REPORT_INTERVAL)
 
     def _send_stats(self):

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -10,6 +10,7 @@ import gevent
 from .exception import StopUser
 
 import logging
+
 console_logger = logging.getLogger("locust.stats_logger")
 
 STATS_NAME_WIDTH = 60
@@ -23,7 +24,7 @@ CSV_STATS_INTERVAL_SEC = 2
 CONSOLE_STATS_INTERVAL_SEC = 2
 
 """
-Default window size/resolution - in seconds - when calculating the current 
+Default window size/resolution - in seconds - when calculating the current
 response time percentile
 """
 CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW = 10
@@ -31,20 +32,7 @@ CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW = 10
 
 CachedResponseTimes = namedtuple("CachedResponseTimes", ["response_times", "num_requests"])
 
-PERCENTILES_TO_REPORT = [
-    0.50,
-    0.66,
-    0.75,
-    0.80,
-    0.90,
-    0.95,
-    0.98,
-    0.99,
-    0.999,
-    0.9999,
-    0.99999,
-    1.0
-]
+PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 0.9999, 0.99999, 1.0]
 
 
 class RequestStatsAdditionError(Exception):
@@ -55,9 +43,9 @@ def calculate_response_time_percentile(response_times, num_requests, percent):
     """
     Get the response time that a certain number of percent of the requests
     finished within. Arguments:
-    
+
     response_times: A StatsEntry.response_times dict
-    num_requests: Number of request made (could be derived from response_times, 
+    num_requests: Number of request made (could be derived from response_times,
                   but we save some CPU cycles by using the value which we already store)
     percent: The percentile we want to calculate. Specified in range: 0.0 - 1.0
     """
@@ -66,7 +54,7 @@ def calculate_response_time_percentile(response_times, num_requests, percent):
     processed_count = 0
     for response_time in sorted(response_times.keys(), reverse=True):
         processed_count += response_times[response_time]
-        if(num_requests - processed_count <= num_of_request):
+        if num_requests - processed_count <= num_of_request:
             return response_time
     # if all response times were None
     return 0
@@ -75,9 +63,9 @@ def calculate_response_time_percentile(response_times, num_requests, percent):
 def diff_response_time_dicts(latest, old):
     """
     Returns the delta between two {response_times:request_count} dicts.
-    
-    Used together with the response_times cache to get the response times for the 
-    last X seconds, which in turn is used to calculate the current response time 
+
+    Used together with the response_times cache to get the response times for the
+    last X seconds, which in turn is used to calculate the current response time
     percentiles.
     """
     new = {}
@@ -92,22 +80,23 @@ class RequestStats(object):
     """
     Class that holds the request statistics.
     """
+
     def __init__(self, use_response_times_cache=True):
         """
         :param use_response_times_cache: The value of use_response_times_cache will be set for each StatsEntry()
-                                         when they are created. Settings it to False saves some memory and CPU 
-                                         cycles which we can do on Worker nodes where the response_times_cache 
+                                         when they are created. Settings it to False saves some memory and CPU
+                                         cycles which we can do on Worker nodes where the response_times_cache
                                          is not needed.
         """
         self.use_response_times_cache = use_response_times_cache
         self.entries = {}
         self.errors = {}
         self.total = StatsEntry(self, "Aggregated", None, use_response_times_cache=self.use_response_times_cache)
-    
+
     @property
     def num_requests(self):
         return self.total.num_requests
-    
+
     @property
     def num_none_requests(self):
         return self.total.num_none_requests
@@ -115,23 +104,23 @@ class RequestStats(object):
     @property
     def num_failures(self):
         return self.total.num_failures
-    
+
     @property
     def last_request_timestamp(self):
         return self.total.last_request_timestamp
-    
+
     @property
     def start_time(self):
         return self.total.start_time
-    
+
     def log_request(self, method, name, response_time, content_length):
         self.total.log(response_time, content_length)
         self.get(name, method).log(response_time, content_length)
-    
+
     def log_error(self, method, name, error):
         self.total.log_error(error)
         self.get(name, method).log_error(error)
-        
+
         # store error in errors dict
         key = StatsError.create_key(method, name, error)
         entry = self.errors.get(key)
@@ -139,7 +128,7 @@ class RequestStats(object):
             entry = StatsError(method, name, error)
             self.errors[key] = entry
         entry.occurred()
-    
+
     def get(self, name, method):
         """
         Retrieve a StatsEntry instance by name and method
@@ -149,7 +138,7 @@ class RequestStats(object):
             entry = StatsEntry(self, name, method, use_response_times_cache=self.use_response_times_cache)
             self.entries[(name, method)] = entry
         return entry
-    
+
     def reset_all(self):
         """
         Go through all stats entries and reset them to zero
@@ -158,7 +147,7 @@ class RequestStats(object):
         self.errors = {}
         for r in self.entries.values():
             r.reset()
-    
+
     def clear_all(self):
         """
         Remove all stats entries and errors
@@ -166,90 +155,94 @@ class RequestStats(object):
         self.total = StatsEntry(self, "Aggregated", None, use_response_times_cache=self.use_response_times_cache)
         self.entries = {}
         self.errors = {}
-    
+
     def serialize_stats(self):
-        return [self.entries[key].get_stripped_report() for key in self.entries.keys() if not (self.entries[key].num_requests == 0 and self.entries[key].num_failures == 0)]
-    
+        return [
+            self.entries[key].get_stripped_report()
+            for key in self.entries.keys()
+            if not (self.entries[key].num_requests == 0 and self.entries[key].num_failures == 0)
+        ]
+
     def serialize_errors(self):
         return dict([(k, e.to_dict()) for k, e in self.errors.items()])
-        
+
 
 class StatsEntry(object):
     """
     Represents a single stats entry (name and method)
     """
-    
+
     name = None
     """ Name (URL) of this stats entry """
-    
+
     method = None
     """ Method (GET, POST, PUT, etc.) """
-    
+
     num_requests = None
     """ The number of requests made """
-    
+
     num_none_requests = None
     """ The number of requests made with a None response time (typically async requests) """
 
     num_failures = None
     """ Number of failed request """
-    
+
     total_response_time = None
     """ Total sum of the response times """
-    
+
     min_response_time = None
     """ Minimum response time """
-    
+
     max_response_time = None
     """ Maximum response time """
-    
+
     num_reqs_per_sec = None
     """ A {second => request_count} dict that holds the number of requests made per second """
 
     num_fail_per_sec = None
-    """ A (second => failure_count) dict that hold the number of failures per second """    
-    
+    """ A (second => failure_count) dict that hold the number of failures per second """
+
     response_times = None
     """
     A {response_time => count} dict that holds the response time distribution of all
     the requests.
-    
-    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90, 
+
+    The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90,
     100, 200 .. 900, 1000, 2000 ... 9000, in order to save memory.
-    
+
     This dict is used to calculate the median and percentile response times.
     """
-    
+
     use_response_times_cache = False
     """
-    If set to True, the copy of the response_time dict will be stored in response_times_cache 
-    every second, and kept for 20 seconds (by default, will be CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + 10). 
-    We can use this dict to calculate the *current*  median response time, as well as other response 
+    If set to True, the copy of the response_time dict will be stored in response_times_cache
+    every second, and kept for 20 seconds (by default, will be CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + 10).
+    We can use this dict to calculate the *current*  median response time, as well as other response
     time percentiles.
     """
-    
+
     response_times_cache = None
     """
-    If use_response_times_cache is set to True, this will be a {timestamp => CachedResponseTimes()} 
+    If use_response_times_cache is set to True, this will be a {timestamp => CachedResponseTimes()}
     OrderedDict that holds a copy of the response_times dict for each of the last 20 seconds.
     """
-    
+
     total_content_length = None
     """ The sum of the content length of all the requests for this entry """
-    
+
     start_time = None
     """ Time of the first request for this entry """
-    
+
     last_request_timestamp = None
     """ Time of the last request for this entry """
-    
+
     def __init__(self, stats, name, method, use_response_times_cache=False):
         self.stats = stats
         self.name = name
         self.method = method
         self.use_response_times_cache = use_response_times_cache
         self.reset()
-    
+
     def reset(self):
         self.start_time = time.time()
         self.num_requests = 0
@@ -266,16 +259,16 @@ class StatsEntry(object):
         if self.use_response_times_cache:
             self.response_times_cache = OrderedDict()
             self._cache_response_times(int(time.time()))
-    
+
     def log(self, response_time, content_length):
         # get the time
         current_time = time.time()
         t = int(current_time)
-        
+
         if self.use_response_times_cache and self.last_request_timestamp and t > int(self.last_request_timestamp):
             # see if we shall make a copy of the respone_times dict and store in the cache
-            self._cache_response_times(t-1)
-        
+            self._cache_response_times(t - 1)
+
         self.num_requests += 1
         self._log_time_of_request(current_time)
         self._log_response_time(response_time)
@@ -345,9 +338,9 @@ class StatsEntry(object):
             return 0
         median = median_from_dict(self.num_requests - self.num_none_requests, self.response_times) or 0
 
-        # Since we only use two digits of precision when calculating the median response time 
-        # while still using the exact values for min and max response times, the following checks 
-        # makes sure that we don't report a median > max or median < min when a StatsEntry only 
+        # Since we only use two digits of precision when calculating the median response time
+        # while still using the exact values for min and max response times, the following checks
+        # makes sure that we don't report a median > max or median < min when a StatsEntry only
         # have one (or very few) really slow requests
         if median > self.max_response_time:
             median = self.max_response_time
@@ -362,7 +355,9 @@ class StatsEntry(object):
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
-        reqs = [self.num_reqs_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp)-2)]
+        reqs = [
+            self.num_reqs_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp) - 2)
+        ]
         return avg(reqs)
 
     @property
@@ -371,7 +366,9 @@ class StatsEntry(object):
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
-        reqs = [self.num_fail_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp)-2)]
+        reqs = [
+            self.num_fail_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp) - 2)
+        ]
         return avg(reqs)
 
     @property
@@ -382,7 +379,7 @@ class StatsEntry(object):
             return self.num_requests / (self.stats.last_request_timestamp - self.stats.start_time)
         except ZeroDivisionError:
             return 0.0
-    
+
     @property
     def total_fail_per_sec(self):
         if not self.stats.last_request_timestamp or not self.stats.start_time:
@@ -398,16 +395,16 @@ class StatsEntry(object):
             return self.total_content_length / self.num_requests
         except ZeroDivisionError:
             return 0
-    
+
     def extend(self, other):
         """
         Extend the data from the current StatsEntry with the stats from another
-        StatsEntry instance. 
+        StatsEntry instance.
         """
         # save the old last_request_timestamp, to see if we should store a new copy
         # of the response times in the response times cache
         old_last_request_timestamp = self.last_request_timestamp
-        
+
         if self.last_request_timestamp is not None and other.last_request_timestamp is not None:
             self.last_request_timestamp = max(self.last_request_timestamp, other.last_request_timestamp)
         elif other.last_request_timestamp is not None:
@@ -432,18 +429,18 @@ class StatsEntry(object):
             self.num_reqs_per_sec[key] = self.num_reqs_per_sec.get(key, 0) + other.num_reqs_per_sec[key]
         for key in other.num_fail_per_sec:
             self.num_fail_per_sec[key] = self.num_fail_per_sec.get(key, 0) + other.num_fail_per_sec[key]
-        
+
         if self.use_response_times_cache:
-            # If we've entered a new second, we'll cache the response times. Note that there 
+            # If we've entered a new second, we'll cache the response times. Note that there
             # might still be reports from other worker nodes - that contains requests for the same
-            # time periods - that hasn't been received/accounted for yet. This will cause the cache to 
-            # lag behind a second or two, but since StatsEntry.current_response_time_percentile() 
-            # (which is what the response times cache is used for) uses an approximation of the 
-            # last 10 seconds anyway, it should be fine to ignore this. 
+            # time periods - that hasn't been received/accounted for yet. This will cause the cache to
+            # lag behind a second or two, but since StatsEntry.current_response_time_percentile()
+            # (which is what the response times cache is used for) uses an approximation of the
+            # last 10 seconds anyway, it should be fine to ignore this.
             last_time = self.last_request_timestamp and int(self.last_request_timestamp) or None
             if last_time and last_time > (old_last_request_timestamp and int(old_last_request_timestamp) or 0):
                 self._cache_response_times(last_time)
-    
+
     def serialize(self):
         return {
             "name": self.name,
@@ -461,7 +458,7 @@ class StatsEntry(object):
             "num_reqs_per_sec": self.num_reqs_per_sec,
             "num_fail_per_sec": self.num_fail_per_sec,
         }
-    
+
     @classmethod
     def unserialize(cls, data):
         obj = cls(None, data["name"], data["method"])
@@ -481,7 +478,7 @@ class StatsEntry(object):
         ]:
             setattr(obj, key, data[key])
         return obj
-    
+
     def get_stripped_report(self):
         """
         Return the serialized version of this StatsEntry, and then clear the current stats.
@@ -489,11 +486,11 @@ class StatsEntry(object):
         report = self.serialize()
         self.reset()
         return report
-    
+
     def to_string(self, current=True):
         """
-        Return the stats as a string suitable for console output. If current is True, it'll show 
-        the RPS and failure rait for the last 10 seconds. If it's false, it'll show the total stats 
+        Return the stats as a string suitable for console output. If current is True, it'll show
+        the RPS and failure rait for the last 10 seconds. If it's false, it'll show the total stats
         for the whole run.
         """
         if current:
@@ -513,62 +510,71 @@ class StatsEntry(object):
             rps or 0,
             fail_per_sec or 0,
         )
-    
+
     def __str__(self):
         return self.to_string(current=True)
-    
+
     def get_response_time_percentile(self, percent):
         """
         Get the response time that a certain number of percent of the requests
         finished within.
-        
+
         Percent specified in range: 0.0 - 1.0
         """
         return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
-    
+
     def get_current_response_time_percentile(self, percent):
         """
-        Calculate the *current* response time for a certain percentile. We use a sliding 
-        window of (approximately) the last 10 seconds (specified by CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW) 
+        Calculate the *current* response time for a certain percentile. We use a sliding
+        window of (approximately) the last 10 seconds (specified by CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
         when calculating this.
         """
         if not self.use_response_times_cache:
-            raise ValueError("StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile")
-        # First, we want to determine which of the cached response_times dicts we should 
-        # use to get response_times for approximately 10 seconds ago. 
+            raise ValueError(
+                "StatsEntry.use_response_times_cache must be set to True if we should be able to calculate the _current_ response time percentile"
+            )
+        # First, we want to determine which of the cached response_times dicts we should
+        # use to get response_times for approximately 10 seconds ago.
         t = int(time.time())
-        # Since we can't be sure that the cache contains an entry for every second. 
-        # We'll construct a list of timestamps which we consider acceptable keys to be used 
-        # when trying to fetch the cached response_times. We construct this list in such a way 
-        # that it's ordered by preference by starting to add t-10, then t-11, t-9, t-12, t-8, 
+        # Since we can't be sure that the cache contains an entry for every second.
+        # We'll construct a list of timestamps which we consider acceptable keys to be used
+        # when trying to fetch the cached response_times. We construct this list in such a way
+        # that it's ordered by preference by starting to add t-10, then t-11, t-9, t-12, t-8,
         # and so on
         acceptable_timestamps = []
-        acceptable_timestamps.append(t-CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
+        acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
         for i in range(1, 9):
-            acceptable_timestamps.append(t-CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW-i)
-            acceptable_timestamps.append(t-CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW+i)
-        
+            acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW - i)
+            acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + i)
+
         cached = None
         for ts in acceptable_timestamps:
             if ts in self.response_times_cache:
                 cached = self.response_times_cache[ts]
                 break
-        
+
         if cached:
-            # If we fond an acceptable cached response times, we'll calculate a new response 
-            # times dict of the last 10 seconds (approximately) by diffing it with the current 
-            # total response times. Then we'll use that to calculate a response time percentile 
+            # If we fond an acceptable cached response times, we'll calculate a new response
+            # times dict of the last 10 seconds (approximately) by diffing it with the current
+            # total response times. Then we'll use that to calculate a response time percentile
             # for that timeframe
             return calculate_response_time_percentile(
-                diff_response_time_dicts(self.response_times, cached.response_times), 
-                self.num_requests - cached.num_requests, 
+                diff_response_time_dicts(self.response_times, cached.response_times),
+                self.num_requests - cached.num_requests,
                 percent,
             )
-    
-    def percentile(self, tpl=" %-" + str(STATS_TYPE_WIDTH) + "s %-" + str(STATS_NAME_WIDTH) + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d %6d %6d"):
+
+    def percentile(
+        self,
+        tpl=" %-"
+        + str(STATS_TYPE_WIDTH)
+        + "s %-"
+        + str(STATS_NAME_WIDTH)
+        + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d %6d %6d",
+    ):
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
-        
+
         return tpl % (
             self.method,
             self.name,
@@ -583,22 +589,20 @@ class StatsEntry(object):
             self.get_response_time_percentile(0.99),
             self.get_response_time_percentile(0.999),
             self.get_response_time_percentile(0.9999),
-            self.get_response_time_percentile(1.00)
+            self.get_response_time_percentile(1.00),
         )
-    
+
     def _cache_response_times(self, t):
         self.response_times_cache[t] = CachedResponseTimes(
-            response_times=copy(self.response_times),
-            num_requests=self.num_requests,
+            response_times=copy(self.response_times), num_requests=self.num_requests,
         )
-        
-        
+
         # We'll use a cache size of CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + 10 since - in the extreme case -
-        # we might still use response times (from the cache) for t-CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW-10 
-        # to calculate the current response time percentile, if we're missing cached values for the subsequent 
+        # we might still use response times (from the cache) for t-CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW-10
+        # to calculate the current response time percentile, if we're missing cached values for the subsequent
         # 20 seconds
         cache_size = CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + 10
-        
+
         if len(self.response_times_cache) > cache_size:
             # only keep the latest 20 response_times dicts
             for i in range(len(self.response_times_cache) - cache_size):
@@ -629,35 +633,30 @@ class StatsError(object):
     @classmethod
     def create_key(cls, method, name, error):
         key = "%s.%s.%r" % (method, name, StatsError.parse_error(error))
-        return hashlib.md5(key.encode('utf-8')).hexdigest()
+        return hashlib.md5(key.encode("utf-8")).hexdigest()
 
     def occurred(self):
         self.occurrences += 1
 
     def to_name(self):
-        return "%s %s: %r" % (self.method, 
-            self.name, repr(self.error))
+        return "%s %s: %r" % (self.method, self.name, repr(self.error))
 
     def to_dict(self):
         return {
             "method": self.method,
             "name": self.name,
             "error": StatsError.parse_error(self.error),
-            "occurrences": self.occurrences
+            "occurrences": self.occurrences,
         }
 
     @classmethod
     def from_dict(cls, data):
-        return cls(
-            data["method"], 
-            data["name"], 
-            data["error"], 
-            data["occurrences"]
-        )
+        return cls(data["method"], data["name"], data["error"], data["occurrences"])
 
 
 def avg(values):
     return sum(values, 0.0) / max(len(values), 1)
+
 
 def median_from_dict(total, count):
     """
@@ -675,31 +674,34 @@ def setup_distributed_stats_event_listeners(events, stats):
     def on_report_to_master(client_id, data):
         data["stats"] = stats.serialize_stats()
         data["stats_total"] = stats.total.get_stripped_report()
-        data["errors"] =  stats.serialize_errors()
+        data["errors"] = stats.serialize_errors()
         stats.errors = {}
-    
+
     def on_worker_report(client_id, data):
         for stats_data in data["stats"]:
             entry = StatsEntry.unserialize(stats_data)
             request_key = (entry.name, entry.method)
-            if not request_key in stats.entries:
+            if request_key not in stats.entries:
                 stats.entries[request_key] = StatsEntry(stats, entry.name, entry.method, use_response_times_cache=True)
             stats.entries[request_key].extend(entry)
-    
+
         for error_key, error in data["errors"].items():
             if error_key not in stats.errors:
                 stats.errors[error_key] = StatsError.from_dict(error)
             else:
                 stats.errors[error_key].occurrences += error["occurrences"]
-        
+
         stats.total.extend(StatsEntry.unserialize(data["stats_total"]))
-        
+
     events.report_to_master.add_listener(on_report_to_master)
     events.worker_report.add_listener(on_worker_report)
 
 
 def print_stats(stats, current=True):
-    console_logger.info((" %-" + str(STATS_NAME_WIDTH) + "s %7s %12s %7s %7s %7s  | %7s %7s %7s") % ('Name', '# reqs', '# fails', 'Avg', 'Min', 'Max', 'Median', 'req/s', 'failures/s'))
+    console_logger.info(
+        (" %-" + str(STATS_NAME_WIDTH) + "s %7s %12s %7s %7s %7s  | %7s %7s %7s")
+        % ("Name", "# reqs", "# fails", "Avg", "Min", "Max", "Median", "req/s", "failures/s")
+    )
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
@@ -711,22 +713,16 @@ def print_stats(stats, current=True):
 
 def print_percentile_stats(stats):
     console_logger.info("Percentage of the requests completed within given times")
-    console_logger.info((" %-" + str(STATS_TYPE_WIDTH) + "s %-" + str(STATS_NAME_WIDTH) + "s %8s %6s %6s %6s %6s %6s %6s %6s %6s %6s %6s %6s") % (
-        'Type',
-        'Name',
-        '# reqs',
-        '50%',
-        '66%',
-        '75%',
-        '80%',
-        '90%',
-        '95%',
-        '98%',
-        '99%',
-        '99.9%',
-        '99.99%',
-        '100%',
-    ))
+    console_logger.info(
+        (
+            " %-"
+            + str(STATS_TYPE_WIDTH)
+            + "s %-"
+            + str(STATS_NAME_WIDTH)
+            + "s %8s %6s %6s %6s %6s %6s %6s %6s %6s %6s %6s %6s"
+        )
+        % ("Type", "Name", "# reqs", "50%", "66%", "75%", "80%", "90%", "95%", "98%", "99%", "99.9%", "99.99%", "100%",)
+    )
     console_logger.info("-" * (90 + STATS_NAME_WIDTH))
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
@@ -737,6 +733,7 @@ def print_percentile_stats(stats):
     if stats.total.response_times:
         console_logger.info(stats.total.percentile())
     console_logger.info("")
+
 
 def print_error_report(stats):
     if not len(stats.errors):
@@ -749,16 +746,19 @@ def print_error_report(stats):
     console_logger.info("-" * (80 + STATS_NAME_WIDTH))
     console_logger.info("")
 
+
 def stats_printer(stats):
     def stats_printer_func():
         while True:
             print_stats(stats)
             gevent.sleep(CONSOLE_STATS_INTERVAL_SEC)
+
     return stats_printer_func
+
 
 def stats_writer(environment, base_filepath, full_history=False):
     """Writes the csv files for the locust run."""
-    with open(base_filepath + '_stats_history.csv', 'w') as f:
+    with open(base_filepath + "_stats_history.csv", "w") as f:
         f.write(stats_history_csv_header())
     while True:
         write_csv_files(environment, base_filepath, full_history)
@@ -767,14 +767,14 @@ def stats_writer(environment, base_filepath, full_history=False):
 
 def write_csv_files(environment, base_filepath, full_history=False):
     """Writes the requests, distribution, and failures csvs."""
-    with open(base_filepath + '_stats.csv', 'w') as f:
+    with open(base_filepath + "_stats.csv", "w") as f:
         csv_writer = csv.writer(f)
         requests_csv(environment.stats, csv_writer)
 
-    with open(base_filepath + '_stats_history.csv', 'a') as f:
+    with open(base_filepath + "_stats_history.csv", "a") as f:
         f.write(stats_history_csv(environment, full_history) + "\n")
 
-    with open(base_filepath + '_failures.csv', 'w') as f:
+    with open(base_filepath + "_failures.csv", "w") as f:
         csv_writer = csv.writer(f)
         failures_csv(environment.stats, csv_writer)
 
@@ -785,31 +785,33 @@ def sort_stats(stats):
 
 def requests_csv(stats, csv_writer):
     """Returns the contents of the 'requests' & 'distribution' tab as CSV."""
-    csv_writer.writerow([
-        "Type",
-        "Name",
-        "Request Count",
-        "Failure Count",
-        "Median Response Time",
-        "Average Response Time",
-        "Min Response Time",
-        "Max Response Time",
-        "Average Content Size",
-        "Requests/s",
-        "Failures/s",
-        "50%",
-        "66%",
-        "75%",
-        "80%",
-        "90%",
-        "95%",
-        "98%",
-        "99%",
-        "99.9%",
-        "99.99%",
-        "99.999%",
-        "100%",
-    ])
+    csv_writer.writerow(
+        [
+            "Type",
+            "Name",
+            "Request Count",
+            "Failure Count",
+            "Median Response Time",
+            "Average Response Time",
+            "Min Response Time",
+            "Max Response Time",
+            "Average Content Size",
+            "Requests/s",
+            "Failures/s",
+            "50%",
+            "66%",
+            "75%",
+            "80%",
+            "90%",
+            "95%",
+            "98%",
+            "99%",
+            "99.9%",
+            "99.99%",
+            "99.999%",
+            "100%",
+        ]
+    )
 
     for s in chain(sort_stats(stats.entries), [stats.total]):
         if s.num_requests:
@@ -833,41 +835,48 @@ def requests_csv(stats, csv_writer):
 
         csv_writer.writerow(stats_row + percentile_row)
 
+
 def stats_history_csv_header():
     """Headers for the stats history CSV"""
 
-    return ','.join((
-        '"Timestamp"',
-        '"User Count"',
-        '"Type"',
-        '"Name"',
-        '"Requests/s"',
-        '"Failures/s"',
-        '"50%"',
-        '"66%"',
-        '"75%"',
-        '"80%"',
-        '"90%"',
-        '"95%"',
-        '"98%"',
-        '"99%"',
-        '"99.9%"',
-        '"99.99%"',
-        '"99.999%"',
-        '"100%"',
-        '"Total Request Count"',
-        '"Total Failure Count"',
-        '"Total Median Response Time"',
-        '"Total Average Response Time"',
-        '"Total Min Response Time"',
-        '"Total Max Response Time"',
-        '"Total Average Content Size"',
-    )) + '\n'
+    return (
+        ",".join(
+            (
+                '"Timestamp"',
+                '"User Count"',
+                '"Type"',
+                '"Name"',
+                '"Requests/s"',
+                '"Failures/s"',
+                '"50%"',
+                '"66%"',
+                '"75%"',
+                '"80%"',
+                '"90%"',
+                '"95%"',
+                '"98%"',
+                '"99%"',
+                '"99.9%"',
+                '"99.99%"',
+                '"99.999%"',
+                '"100%"',
+                '"Total Request Count"',
+                '"Total Failure Count"',
+                '"Total Median Response Time"',
+                '"Total Average Response Time"',
+                '"Total Min Response Time"',
+                '"Total Max Response Time"',
+                '"Total Average Content Size"',
+            )
+        )
+        + "\n"
+    )
+
 
 def stats_history_csv(environment, all_entries=False):
     """
-    Return a string of CSV rows with the *current* stats. By default only includes the 
-    Aggregated stats entry, but if all_entries is set to True, a row for each entry will 
+    Return a string of CSV rows with the *current* stats. By default only includes the
+    Aggregated stats entry, but if all_entries is set to True, a row for each entry will
     will be included.
     """
     stats = environment.stats
@@ -875,47 +884,42 @@ def stats_history_csv(environment, all_entries=False):
     stats_entries = []
     if all_entries:
         stats_entries = sort_stats(stats.entries)
-    
+
     rows = []
     for s in chain(stats_entries, [stats.total]):
         if s.num_requests:
-            percentile_str = ','.join([
-                str(int(s.get_current_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT])
+            percentile_str = ",".join(
+                [str(int(s.get_current_response_time_percentile(x) or 0)) for x in PERCENTILES_TO_REPORT]
+            )
         else:
-            percentile_str = ','.join(['"N/A"'] * len(PERCENTILES_TO_REPORT))
+            percentile_str = ",".join(['"N/A"'] * len(PERCENTILES_TO_REPORT))
 
-        rows.append('"%i","%i","%s","%s",%.2f,%.2f,%s,%i,%i,%i,%i,%i,%i,%i' % (
-            timestamp,
-            environment.runner.user_count,
-            s.method or "",
-            s.name,
-            s.current_rps,
-            s.current_fail_per_sec,
-            percentile_str,
-            s.num_requests,
-            s.num_failures,
-            s.median_response_time,
-            s.avg_response_time,
-            s.min_response_time or 0,
-            s.max_response_time,
-            s.avg_content_length,
-        ))
+        rows.append(
+            '"%i","%i","%s","%s",%.2f,%.2f,%s,%i,%i,%i,%i,%i,%i,%i'
+            % (
+                timestamp,
+                environment.runner.user_count,
+                s.method or "",
+                s.name,
+                s.current_rps,
+                s.current_fail_per_sec,
+                percentile_str,
+                s.num_requests,
+                s.num_failures,
+                s.median_response_time,
+                s.avg_response_time,
+                s.min_response_time or 0,
+                s.max_response_time,
+                s.avg_content_length,
+            )
+        )
 
     return "\n".join(rows)
 
+
 def failures_csv(stats, csv_writer):
     """"Return the contents of the 'failures' tab as a CSV."""
-    csv_writer.writerow([
-        "Method",
-        "Name",
-        "Error",
-        "Occurrences",
-    ])
+    csv_writer.writerow(["Method", "Name", "Error", "Occurrences"])
 
     for s in sort_stats(stats.errors):
-        csv_writer.writerow([
-            s.method,
-            s.name,
-            s.error,
-            s.occurrences,
-        ])
+        csv_writer.writerow([s.method, s.name, s.error, s.occurrences])

--- a/locust/test/mock_locustfile.py
+++ b/locust/test/mock_locustfile.py
@@ -34,6 +34,7 @@ class NotUserSubclass():
 
 '''
 
+
 class MockedLocustfile:
     __slots__ = ["filename", "directory", "file_path"]
 
@@ -42,15 +43,11 @@ class MockedLocustfile:
 def mock_locustfile(filename_prefix="mock_locustfile", content=MOCK_LOUCSTFILE_CONTENT):
     mocked = MockedLocustfile()
     mocked.directory = os.path.dirname(os.path.abspath(__file__))
-    mocked.filename = "%s_%s_%i.py" % (
-        filename_prefix, 
-        str(time.time()).replace(".", "_"), 
-        random.randint(0,100000),
-    )
+    mocked.filename = "%s_%s_%i.py" % (filename_prefix, str(time.time()).replace(".", "_"), random.randint(0, 100000),)
     mocked.file_path = os.path.join(mocked.directory, mocked.filename)
-    with open(mocked.file_path, 'w') as file:
+    with open(mocked.file_path, "w") as file:
         file.write(content)
-    
+
     try:
         yield mocked
     finally:

--- a/locust/test/mock_logging.py
+++ b/locust/test/mock_logging.py
@@ -10,7 +10,7 @@ class MockedLoggingHandler(logging.Handler):
 
     def emit(self, record):
         if record.exc_info:
-            value = {"message":record.getMessage(), "exc_info":record.exc_info}
+            value = {"message": record.getMessage(), "exc_info": record.exc_info}
         else:
             value = record.getMessage()
         getattr(self.__class__, record.levelname.lower()).append(value)

--- a/locust/test/test_client.py
+++ b/locust/test/test_client.py
@@ -1,5 +1,4 @@
-from requests.exceptions import (InvalidSchema, InvalidURL, MissingSchema,
-                                 RequestException)
+from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema, RequestException
 
 
 from locust.clients import HttpSession
@@ -17,12 +16,12 @@ class TestHttpSession(WebserverTestCase):
             request_success=self.environment.events.request_success,
             request_failure=self.environment.events.request_failure,
         )
-    
+
     def test_get(self):
         s = self.get_client()
         r = s.get("/ultra_fast")
         self.assertEqual(200, r.status_code)
-    
+
     def test_connection_error(self):
         s = self.get_client(base_url="http://localhost:1")
         r = s.get("/", timeout=0.1)
@@ -32,35 +31,35 @@ class TestHttpSession(WebserverTestCase):
 
     def test_wrong_url(self):
         for url, exception in (
-                (u"http://\x94", InvalidURL),
-                ("telnet://127.0.0.1", InvalidSchema),
-                ("127.0.0.1", MissingSchema), 
-            ):
+            ("http://\x94", InvalidURL),
+            ("telnet://127.0.0.1", InvalidSchema),
+            ("127.0.0.1", MissingSchema),
+        ):
             s = self.get_client(base_url=url)
             try:
                 self.assertRaises(exception, s.get, "/")
             except KeyError:
                 self.fail("Invalid URL %s was not propagated" % url)
-    
+
     def test_streaming_response(self):
         """
         Test a request to an endpoint that returns a streaming response
         """
         s = self.get_client()
         r = s.get("/streaming/30")
-        
+
         # verify that the time reported includes the download time of the whole streamed response
         self.assertGreater(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 250)
         self.runner.stats.clear_all()
-        
+
         # verify that response time does NOT include whole download time, when using stream=True
         r = s.get("/streaming/30", stream=True)
         self.assertGreater(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 0)
         self.assertLess(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 250)
-        
+
         # download the content of the streaming response (so we don't get an ugly exception in the log)
         _ = r.content
-    
+
     def test_slow_redirect(self):
         s = self.get_client()
         url = "/redirect?url=/redirect&delay=0.5"
@@ -68,7 +67,7 @@ class TestHttpSession(WebserverTestCase):
         stats = self.runner.stats.get(url, method="GET")
         self.assertEqual(1, stats.num_requests)
         self.assertGreater(stats.avg_response_time, 500)
-    
+
     def test_post_redirect(self):
         s = self.get_client()
         url = "/redirect"
@@ -78,66 +77,66 @@ class TestHttpSession(WebserverTestCase):
         get_stats = self.runner.stats.get(url, method="GET")
         self.assertEqual(1, post_stats.num_requests)
         self.assertEqual(0, get_stats.num_requests)
-    
+
     def test_cookie(self):
         s = self.get_client()
         r = s.post("/set_cookie?name=testcookie&value=1337")
         self.assertEqual(200, r.status_code)
         r = s.get("/get_cookie?name=testcookie")
-        self.assertEqual('1337', r.content.decode())
-    
+        self.assertEqual("1337", r.content.decode())
+
     def test_head(self):
         s = self.get_client()
         r = s.head("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("", r.content.decode())
-    
+
     def test_delete(self):
         s = self.get_client()
         r = s.delete("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("DELETE", r.content.decode())
-    
+
     def test_options(self):
         s = self.get_client()
         r = s.options("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("", r.content.decode())
         self.assertEqual(
-            set(["OPTIONS", "DELETE", "PUT", "GET", "POST", "HEAD", "PATCH"]),
-            set(r.headers["allow"].split(", ")),
+            set(["OPTIONS", "DELETE", "PUT", "GET", "POST", "HEAD", "PATCH"]), set(r.headers["allow"].split(", ")),
         )
 
     def test_error_message_with_name_replacment(self):
         s = self.get_client()
         kwargs = {}
+
         def on_error(**kw):
             kwargs.update(kw)
 
         self.environment.events.request_failure.add_listener(on_error)
-        s.request('get', '/wrong_url/01', name='replaced_url_name')
-        self.assertIn('for url: replaced_url_name', str(kwargs['exception']))
-    
+        s.request("get", "/wrong_url/01", name="replaced_url_name")
+        self.assertIn("for url: replaced_url_name", str(kwargs["exception"]))
+
     def test_get_with_params(self):
         s = self.get_client()
-        r = s.get("/get_arg", params={"arg":"test_123"})
+        r = s.get("/get_arg", params={"arg": "test_123"})
         self.assertEqual(200, r.status_code)
         self.assertEqual("test_123", r.text)
-    
+
     def test_catch_response_fail_successful_request(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
             r.failure("nope")
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_requests)
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_failures)
-    
+
     def test_catch_response_pass_failed_request(self):
         s = self.get_client()
         with s.get("/fail", catch_response=True) as r:
             r.success()
         self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(0, self.environment.stats.total.num_failures)    
-    
+        self.assertEqual(0, self.environment.stats.total.num_failures)
+
     def test_catch_response_multiple_failure_and_success(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
@@ -147,11 +146,11 @@ class TestHttpSession(WebserverTestCase):
             r.success()
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(0, self.environment.stats.total.num_failures)
-    
+
     def test_catch_response_pass_failed_request_with_other_exception_within_block(self):
         class OtherException(Exception):
             pass
-        
+
         s = self.get_client()
         try:
             with s.get("/fail", catch_response=True) as r:
@@ -161,10 +160,10 @@ class TestHttpSession(WebserverTestCase):
             pass
         else:
             self.fail("OtherException should have been raised")
-        
+
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(0, self.environment.stats.total.num_failures)
-    
+
     def test_catch_response_response_error(self):
         s = self.get_client()
         try:
@@ -172,20 +171,20 @@ class TestHttpSession(WebserverTestCase):
                 raise ResponseError("response error")
         except ResponseError as e:
             self.fail("ResponseError should not have been raised")
-        
+
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
-    
+
     def test_catch_response_default_success(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
             pass
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_requests)
         self.assertEqual(0, self.environment.stats.get("/ultra_fast", "GET").num_failures)
-    
+
     def test_catch_response_default_fail(self):
         s = self.get_client()
         with s.get("/fail", catch_response=True) as r:
             pass
         self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(1, self.environment.stats.total.num_failures)   
+        self.assertEqual(1, self.environment.stats.total.num_failures)

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -13,12 +13,12 @@ from .util import create_tls_cert
 class TestFastHttpSession(WebserverTestCase):
     def get_client(self):
         return FastHttpSession(self.environment, base_url="http://127.0.0.1:%i" % self.port)
-    
+
     def test_get(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.get("/ultra_fast")
         self.assertEqual(200, r.status_code)
-    
+
     def test_connection_error(self):
         s = FastHttpSession(self.environment, "http://localhost:1")
         r = s.get("/", timeout=0.1)
@@ -27,39 +27,39 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertEqual(1, len(self.runner.stats.errors))
         self.assertTrue(isinstance(r.error, ConnectionRefusedError))
         self.assertTrue(isinstance(next(iter(self.runner.stats.errors.values())).error, ConnectionRefusedError))
-    
+
     def test_404(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.get("/does_not_exist")
         self.assertEqual(404, r.status_code)
         self.assertEqual(1, self.runner.stats.get("/does_not_exist", "GET").num_failures)
-    
+
     def test_204(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.get("/status/204")
         self.assertEqual(204, r.status_code)
         self.assertEqual(1, self.runner.stats.get("/status/204", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/status/204", "GET").num_failures)
-    
+
     def test_streaming_response(self):
         """
         Test a request to an endpoint that returns a streaming response
         """
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.get("/streaming/30")
-        
+
         # verify that the time reported includes the download time of the whole streamed response
         self.assertGreater(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 250)
         self.runner.stats.clear_all()
-        
+
         # verify that response time does NOT include whole download time, when using stream=True
         r = s.get("/streaming/30", stream=True)
         self.assertGreaterEqual(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 0)
         self.assertLess(self.runner.stats.get("/streaming/30", method="GET").avg_response_time, 250)
-        
+
         # download the content of the streaming response (so we don't get an ugly exception in the log)
         _ = r.content
-    
+
     def test_slow_redirect(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         url = "/redirect?url=/redirect&delay=0.5"
@@ -67,7 +67,7 @@ class TestFastHttpSession(WebserverTestCase):
         stats = self.runner.stats.get(url, method="GET")
         self.assertEqual(1, stats.num_requests)
         self.assertGreater(stats.avg_response_time, 500)
-    
+
     def test_post_redirect(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         url = "/redirect"
@@ -77,61 +77,60 @@ class TestFastHttpSession(WebserverTestCase):
         get_stats = self.runner.stats.get(url, method="GET")
         self.assertEqual(1, post_stats.num_requests)
         self.assertEqual(0, get_stats.num_requests)
-    
+
     def test_cookie(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.post("/set_cookie?name=testcookie&value=1337")
         self.assertEqual(200, r.status_code)
         r = s.get("/get_cookie?name=testcookie")
-        self.assertEqual('1337', r.content.decode())
-    
+        self.assertEqual("1337", r.content.decode())
+
     def test_head(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.head("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("", r.content.decode())
-    
+
     def test_delete(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.delete("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("DELETE", r.content.decode())
-    
+
     def test_patch(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.patch("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("PATCH", r.content.decode())
-    
+
     def test_options(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.options("/request_method")
         self.assertEqual(200, r.status_code)
         self.assertEqual("", r.content.decode())
         self.assertEqual(
-            set(["OPTIONS", "DELETE", "PUT", "GET", "POST", "HEAD", "PATCH"]),
-            set(r.headers["allow"].split(", ")),
+            set(["OPTIONS", "DELETE", "PUT", "GET", "POST", "HEAD", "PATCH"]), set(r.headers["allow"].split(", ")),
         )
 
     def test_json_payload(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         r = s.post("/request_method", json={"foo": "bar"})
         self.assertEqual(200, r.status_code)
-    
+
     def test_catch_response_fail_successful_request(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
             r.failure("nope")
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_requests)
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_failures)
-    
+
     def test_catch_response_pass_failed_request(self):
         s = self.get_client()
         with s.get("/fail", catch_response=True) as r:
             r.success()
         self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(0, self.environment.stats.total.num_failures)    
-    
+        self.assertEqual(0, self.environment.stats.total.num_failures)
+
     def test_catch_response_multiple_failure_and_success(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
@@ -141,11 +140,11 @@ class TestFastHttpSession(WebserverTestCase):
             r.success()
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(0, self.environment.stats.total.num_failures)
-    
+
     def test_catch_response_pass_failed_request_with_other_exception_within_block(self):
         class OtherException(Exception):
             pass
-        
+
         s = self.get_client()
         try:
             with s.get("/fail", catch_response=True) as r:
@@ -155,80 +154,89 @@ class TestFastHttpSession(WebserverTestCase):
             pass
         else:
             self.fail("OtherException should have been raised")
-        
+
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(0, self.environment.stats.total.num_failures)
-    
+
     def test_catch_response_default_success(self):
         s = self.get_client()
         with s.get("/ultra_fast", catch_response=True) as r:
             pass
         self.assertEqual(1, self.environment.stats.get("/ultra_fast", "GET").num_requests)
         self.assertEqual(0, self.environment.stats.get("/ultra_fast", "GET").num_failures)
-    
+
     def test_catch_response_default_fail(self):
         s = self.get_client()
         with s.get("/fail", catch_response=True) as r:
             pass
         self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(1, self.environment.stats.total.num_failures)   
+        self.assertEqual(1, self.environment.stats.total.num_failures)
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def test_request_stats_content_length(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyUser(self.environment)
         locust.client.get("/ultra_fast")
-        self.assertEqual(self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
+        self.assertEqual(
+            self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response")
+        )
         locust.client.get("/ultra_fast")
-        self.assertEqual(self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
-    
+        self.assertEqual(
+            self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response")
+        )
+
     def test_request_stats_no_content_length(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
+
         l = MyUser(self.environment)
         path = "/no_content_length"
         r = l.client.get(path)
-        self.assertEqual(self.runner.stats.get(path, "GET").avg_content_length, len("This response does not have content-length in the header"))
-    
+        self.assertEqual(
+            self.runner.stats.get(path, "GET").avg_content_length,
+            len("This response does not have content-length in the header"),
+        )
+
     def test_request_stats_no_content_length_streaming(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
+
         l = MyUser(self.environment)
         path = "/no_content_length"
         r = l.client.get(path, stream=True)
         self.assertEqual(0, self.runner.stats.get(path, "GET").avg_content_length)
-    
+
     def test_request_stats_named_endpoint(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyUser(self.environment)
         locust.client.get("/ultra_fast", name="my_custom_name")
         self.assertEqual(1, self.runner.stats.get("my_custom_name", "GET").num_requests)
-    
+
     def test_request_stats_query_variables(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyUser(self.environment)
         locust.client.get("/ultra_fast?query=1")
         self.assertEqual(1, self.runner.stats.get("/ultra_fast?query=1", "GET").num_requests)
-    
+
     def test_request_stats_put(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyUser(self.environment)
         locust.client.put("/put")
         self.assertEqual(1, self.runner.stats.get("/put", "PUT").num_requests)
-    
+
     def test_request_connection_error(self):
         class MyUser(FastHttpUser):
             host = "http://localhost:1"
-        
+
         locust = MyUser(self.environment)
         response = locust.client.get("/", timeout=0.1)
         self.assertEqual(response.status_code, 0)
@@ -240,11 +248,13 @@ class TestFastHttpUserClass(WebserverTestCase):
     def test_is_abstract(self):
         self.assertTrue(FastHttpUser.abstract)
         self.assertFalse(is_user_class(FastHttpUser))
-        
+
     def test_get_request(self):
         self.response = ""
+
         def t1(l):
             self.response = l.client.get("/ultra_fast")
+
         class MyUser(FastHttpUser):
             tasks = [t1]
             host = "http://127.0.0.1:%i" % self.port
@@ -258,7 +268,7 @@ class TestFastHttpUserClass(WebserverTestCase):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("hello", locust.client.get("/request_header_test", headers={"X-Header-Test":"hello"}).text)
+        self.assertEqual("hello", locust.client.get("/request_header_test", headers={"X-Header-Test": "hello"}).text)
 
     def test_client_get(self):
         class MyUser(FastHttpUser):
@@ -266,7 +276,7 @@ class TestFastHttpUserClass(WebserverTestCase):
 
         locust = MyUser(self.environment)
         self.assertEqual("GET", locust.client.get("/request_method").text)
-    
+
     def test_client_get_absolute_url(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
@@ -279,16 +289,16 @@ class TestFastHttpUserClass(WebserverTestCase):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("POST", locust.client.post("/request_method", {"arg":"hello world"}).text)
-        self.assertEqual("hello world", locust.client.post("/post", {"arg":"hello world"}).text)
+        self.assertEqual("POST", locust.client.post("/request_method", {"arg": "hello world"}).text)
+        self.assertEqual("hello world", locust.client.post("/post", {"arg": "hello world"}).text)
 
     def test_client_put(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("PUT", locust.client.put("/request_method", {"arg":"hello world"}).text)
-        self.assertEqual("hello world", locust.client.put("/put", {"arg":"hello world"}).text)
+        self.assertEqual("PUT", locust.client.put("/request_method", {"arg": "hello world"}).text)
+        self.assertEqual("hello world", locust.client.put("/put", {"arg": "hello world"}).text)
 
     def test_client_delete(self):
         class MyUser(FastHttpUser):
@@ -304,53 +314,58 @@ class TestFastHttpUserClass(WebserverTestCase):
 
         locust = MyUser(self.environment)
         self.assertEqual(200, locust.client.head("/request_method").status_code)
-    
+
     def test_log_request_name_argument(self):
         self.response = ""
-        
+
         class MyUser(FastHttpUser):
             tasks = []
             host = "http://127.0.0.1:%i" % self.port
-            
+
             @task()
             def t1(l):
                 self.response = l.client.get("/ultra_fast", name="new name!")
 
         my_locust = MyUser(self.environment)
         my_locust.t1()
-        
+
         self.assertEqual(1, self.runner.stats.get("new name!", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/ultra_fast", "GET").num_requests)
-    
+
     def test_redirect_url_original_path_as_name(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         l = MyUser(self.environment)
         l.client.get("/redirect")
-        
+
         self.assertEqual(1, len(self.runner.stats.entries))
         self.assertEqual(1, self.runner.stats.get("/redirect", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/ultra_fast", "GET").num_requests)
-    
+
     def test_network_timeout_setting(self):
         class MyUser(FastHttpUser):
             network_timeout = 0.5
             host = "http://127.0.0.1:%i" % self.port
 
         l = MyUser(self.environment)
-        
-        timeout = gevent.Timeout(seconds=0.6, exception=AssertionError("Request took longer than 0.6 even though FastHttpUser.network_timeout was set to 0.5"))
+
+        timeout = gevent.Timeout(
+            seconds=0.6,
+            exception=AssertionError(
+                "Request took longer than 0.6 even though FastHttpUser.network_timeout was set to 0.5"
+            ),
+        )
         timeout.start()
         r = l.client.get("/redirect?url=/redirect&delay=5.0")
         timeout.cancel()
-        
+
         self.assertTrue(isinstance(r.error.original, socket.timeout))
         self.assertEqual(1, self.runner.stats.get("/redirect?url=/redirect&delay=5.0", "GET").num_failures)
 
     def test_max_redirect_setting(self):
         class MyUser(FastHttpUser):
-            max_redirects = 1 # max_redirects and max_retries are funny names, because they are actually max attempts
+            max_redirects = 1  # max_redirects and max_retries are funny names, because they are actually max attempts
             host = "http://127.0.0.1:%i" % self.port
 
         l = MyUser(self.environment)
@@ -360,12 +375,13 @@ class TestFastHttpUserClass(WebserverTestCase):
     def test_allow_redirects_override(self):
         class MyLocust(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
+
         l = MyLocust(self.environment)
         resp = l.client.get("/redirect", allow_redirects=False)
-        self.assertEqual("http://127.0.0.1:%i/ultra_fast" % self.port, resp.headers['location'])
-        resp = l.client.get("/redirect") # ensure redirect still works
+        self.assertEqual("http://127.0.0.1:%i/ultra_fast" % self.port, resp.headers["location"])
+        resp = l.client.get("/redirect")  # ensure redirect still works
         self.assertFalse("location" in resp.headers)
-        
+
     def test_slow_redirect(self):
         s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
         url = "/redirect?url=/redirect&delay=0.5"
@@ -397,43 +413,48 @@ class TestFastHttpUserClass(WebserverTestCase):
 class TestFastHttpCatchResponse(WebserverTestCase):
     def setUp(self):
         super(TestFastHttpCatchResponse, self).setUp()
-        
+
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         self.locust = MyUser(self.environment)
-        
+
         self.num_failures = 0
         self.num_success = 0
+
         def on_failure(request_type, name, response_time, response_length, exception):
             self.num_failures += 1
             self.last_failure_exception = exception
+
         def on_success(**kwargs):
             self.num_success += 1
+
         self.environment.events.request_failure.add_listener(on_failure)
         self.environment.events.request_success.add_listener(on_success)
-        
+
     def test_catch_response(self):
         self.assertEqual(500, self.locust.client.get("/fail").status_code)
         self.assertEqual(1, self.num_failures)
         self.assertEqual(0, self.num_success)
-        
-        with self.locust.client.get("/ultra_fast", catch_response=True) as response: pass
+
+        with self.locust.client.get("/ultra_fast", catch_response=True) as response:
+            pass
         self.assertEqual(1, self.num_failures)
         self.assertEqual(1, self.num_success)
         self.assertIn("ultra fast", str(response.content))
-        
+
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             raise ResponseError("Not working")
-        
+
         self.assertEqual(2, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_catch_response_http_fail(self):
-        with self.locust.client.get("/fail", catch_response=True) as response: pass
+        with self.locust.client.get("/fail", catch_response=True) as response:
+            pass
         self.assertEqual(1, self.num_failures)
         self.assertEqual(0, self.num_success)
-    
+
     def test_catch_response_http_manual_fail(self):
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             response.failure("Haha!")
@@ -441,15 +462,15 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.assertEqual(0, self.num_success)
         self.assertTrue(
             isinstance(self.last_failure_exception, CatchResponseError),
-            "Failure event handler should have been passed a CatchResponseError instance"
+            "Failure event handler should have been passed a CatchResponseError instance",
         )
-    
+
     def test_catch_response_http_manual_success(self):
         with self.locust.client.get("/fail", catch_response=True) as response:
             response.success()
         self.assertEqual(0, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_catch_response_allow_404(self):
         with self.locust.client.get("/does/not/exist", catch_response=True) as response:
             self.assertEqual(404, response.status_code)
@@ -457,26 +478,28 @@ class TestFastHttpCatchResponse(WebserverTestCase):
                 response.success()
         self.assertEqual(0, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_interrupt_taskset_with_catch_response(self):
         class MyTaskSet(TaskSet):
             @task
             def interrupted_task(self):
                 with self.client.get("/ultra_fast", catch_response=True) as r:
                     raise InterruptTaskSet()
+
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:%i" % self.port
             tasks = [MyTaskSet]
-        
+
         l = MyUser(self.environment)
         ts = MyTaskSet(l)
         self.assertRaises(InterruptTaskSet, lambda: ts.interrupted_task())
         self.assertEqual(0, self.num_failures)
         self.assertEqual(0, self.num_success)
-    
+
     def test_catch_response_connection_error_success(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:1"
+
         l = MyUser(self.environment)
         with l.client.get("/", catch_response=True) as r:
             self.assertEqual(r.status_code, 0)
@@ -484,10 +507,11 @@ class TestFastHttpCatchResponse(WebserverTestCase):
             r.success()
         self.assertEqual(1, self.num_success)
         self.assertEqual(0, self.num_failures)
-    
+
     def test_catch_response_connection_error_fail(self):
         class MyUser(FastHttpUser):
             host = "http://127.0.0.1:1"
+
         l = MyUser(self.environment)
         with l.client.get("/", catch_response=True) as r:
             self.assertEqual(r.status_code, 0)
@@ -503,26 +527,23 @@ class TestFastHttpSsl(LocustTestCase):
         tls_cert, tls_key = create_tls_cert("127.0.0.1")
         self.tls_cert_file = NamedTemporaryFile()
         self.tls_key_file = NamedTemporaryFile()
-        with open(self.tls_cert_file.name, 'w') as f:
+        with open(self.tls_cert_file.name, "w") as f:
             f.write(tls_cert.decode())
-        with open(self.tls_key_file.name, 'w') as f:
+        with open(self.tls_key_file.name, "w") as f:
             f.write(tls_key.decode())
-        
+
         self.web_ui = self.environment.create_web_ui(
-            "127.0.0.1", 0, 
-            tls_cert=self.tls_cert_file.name, 
-            tls_key=self.tls_key_file.name,
+            "127.0.0.1", 0, tls_cert=self.tls_cert_file.name, tls_key=self.tls_key_file.name,
         )
         gevent.sleep(0.01)
         self.web_port = self.web_ui.server.server_port
-    
+
     def tearDown(self):
         super().tearDown()
         self.web_ui.stop()
-    
+
     def test_ssl_request_insecure(self):
         s = FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, insecure=True)
         r = s.get("/")
         self.assertEqual(200, r.status_code)
         self.assertIn("<title>Locust</title>", r.content.decode("utf-8"))
-

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -5,8 +5,7 @@ from gevent.pool import Group
 from locust.exception import InterruptTaskSet, ResponseError
 from locust import HttpUser, User, TaskSet, task, constant
 from locust.env import Environment
-from locust.exception import (CatchResponseError, LocustError, RescheduleTask,
-                              RescheduleTaskImmediately, StopUser)
+from locust.exception import CatchResponseError, LocustError, RescheduleTask, RescheduleTaskImmediately, StopUser
 
 from .testcases import LocustTestCase, WebserverTestCase
 
@@ -14,17 +13,19 @@ from .testcases import LocustTestCase, WebserverTestCase
 class TestTaskSet(LocustTestCase):
     def setUp(self):
         super(TestTaskSet, self).setUp()
-        
+
         class MyUser(User):
             host = "127.0.0.1"
+
         self.locust = MyUser(self.environment)
 
     def test_task_ratio(self):
         t1 = lambda l: None
         t2 = lambda l: None
+
         class MyTasks(TaskSet):
-            tasks = {t1:5, t2:2}
-        
+            tasks = {t1: 5, t2: 2}
+
         l = MyTasks(self.locust)
 
         t1_count = len([t for t in l.tasks if t == t1])
@@ -32,7 +33,7 @@ class TestTaskSet(LocustTestCase):
 
         self.assertEqual(t1_count, 5)
         self.assertEqual(t2_count, 2)
-    
+
     def test_tasks_missing_gives_user_friendly_exception(self):
         class MyTasks(TaskSet):
             tasks = None
@@ -40,7 +41,7 @@ class TestTaskSet(LocustTestCase):
         class MyUser(User):
             wait_time = constant(0.5)
             tasks = [MyTasks]
-        
+
         l = MyTasks(MyUser(self.environment))
         self.assertRaisesRegex(Exception, "No tasks defined.*", l.run)
         l.tasks = []
@@ -49,18 +50,18 @@ class TestTaskSet(LocustTestCase):
     def test_task_decorator_ratio(self):
         t1 = lambda l: None
         t2 = lambda l: None
+
         class MyTasks(TaskSet):
-            tasks = {t1:5, t2:2}
+            tasks = {t1: 5, t2: 2}
             host = ""
-            
+
             @task(3)
             def t3(self):
                 pass
-            
+
             @task(13)
             def t4(self):
                 pass
-            
 
         l = MyTasks(self.locust)
 
@@ -73,64 +74,76 @@ class TestTaskSet(LocustTestCase):
         self.assertEqual(t2_count, 2)
         self.assertEqual(t3_count, 3)
         self.assertEqual(t4_count, 13)
-    
+
     def test_tasks_on_locust(self):
         class MyUser(User):
             @task(2)
             def t1(self):
                 pass
+
             @task(3)
             def t2(self):
                 pass
+
         l = MyUser(self.environment)
         self.assertEqual(2, len([t for t in l.tasks if t.__name__ == MyUser.t1.__name__]))
         self.assertEqual(3, len([t for t in l.tasks if t.__name__ == MyUser.t2.__name__]))
-    
+
     def test_tasks_on_abstract_locust(self):
         class AbstractUser(User):
             abstract = True
+
             @task(2)
             def t1(self):
                 pass
+
         class MyUser(AbstractUser):
             @task(3)
             def t2(self):
                 pass
+
         l = MyUser(self.environment)
         self.assertEqual(2, len([t for t in l.tasks if t.__name__ == MyUser.t1.__name__]))
         self.assertEqual(3, len([t for t in l.tasks if t.__name__ == MyUser.t2.__name__]))
 
     def test_taskset_on_abstract_locust(self):
         v = [0]
+
         class AbstractUser(User):
             abstract = True
+
             @task
             class task_set(TaskSet):
                 @task
                 def t1(self):
                     v[0] = 1
                     raise StopUser()
+
         class MyUser(AbstractUser):
             pass
+
         l = MyUser(self.environment)
         # check that the User can be run
         l.run()
         self.assertEqual(1, v[0])
-    
+
     def test_task_decorator_on_taskset(self):
         state = [0]
+
         class MyUser(User):
             wait_time = constant(0)
+
             @task
             def t1(self):
                 pass
+
             @task
             class MyTaskSet(TaskSet):
                 @task
                 def subtask(self):
                     state[0] = 1
                     raise StopUser()
-        
+
         self.assertEqual([MyUser.t1, MyUser.MyTaskSet], MyUser.tasks)
         MyUser(self.environment).run()
         self.assertEqual(1, state[0])
@@ -139,13 +152,13 @@ class TestTaskSet(LocustTestCase):
         class MyTasks(TaskSet):
             t1_executed = False
             t2_executed = False
-            
+
             def on_start(self):
                 self.t1()
-            
+
             def t1(self):
                 self.t1_executed = True
-            
+
             @task
             def t2(self):
                 self.t2_executed = True
@@ -155,25 +168,25 @@ class TestTaskSet(LocustTestCase):
         self.assertRaises(RescheduleTask, lambda: l.run())
         self.assertTrue(l.t1_executed)
         self.assertTrue(l.t2_executed)
-    
+
     def test_on_stop_interrupt(self):
         class MyTasks(TaskSet):
             t2_executed = False
             on_stop_executed = False
-    
+
             def on_stop(self):
                 self.on_stop_executed = True
-    
+
             @task
             def t2(self):
                 self.t2_executed = True
                 self.interrupt(reschedule=False)
-        
+
         ts = MyTasks(self.locust)
         self.assertRaises(RescheduleTask, lambda: ts.run())
         self.assertTrue(ts.t2_executed)
         self.assertTrue(ts.on_stop_executed)
-    
+
     def test_on_stop_interrupt_reschedule(self):
         class MyTasks(TaskSet):
             t2_executed = False
@@ -191,7 +204,7 @@ class TestTaskSet(LocustTestCase):
         self.assertRaises(RescheduleTaskImmediately, lambda: ts.run())
         self.assertTrue(ts.t2_executed)
         self.assertTrue(ts.on_stop_executed)
-    
+
     def test_on_stop_when_locust_stops(self):
         class MyTasks(TaskSet):
             def on_stop(self):
@@ -200,21 +213,21 @@ class TestTaskSet(LocustTestCase):
             @task
             def t2(self):
                 self.user.t2_executed = True
-        
+
         class MyUser(User):
             t2_executed = False
             on_stop_executed = False
-            
+
             tasks = [MyTasks]
             wait_time = constant(0.1)
-        
+
         group = Group()
         user = MyUser(self.environment)
         user.start(group)
         sleep(0.05)
         user.stop(group)
         sleep(0)
-        
+
         self.assertTrue(user.t2_executed)
         self.assertTrue(user.on_stop_executed)
 
@@ -239,145 +252,156 @@ class TestTaskSet(LocustTestCase):
         taskset.schedule_task(t2)
         taskset.execute_next_task()
         self.assertEqual("t2 argument", self.t2_arg)
-    
+
     def test_schedule_task_bound_method(self):
         class MyTasks(TaskSet):
             host = ""
-            
+
             @task()
             def t1(self):
                 self.t1_executed = True
                 self.schedule_task(self.t2)
+
             def t2(self):
                 self.t2_executed = True
-        
+
         taskset = MyTasks(self.locust)
         taskset.schedule_task(taskset.get_next_task())
         taskset.execute_next_task()
         self.assertTrue(taskset.t1_executed)
         taskset.execute_next_task()
         self.assertTrue(taskset.t2_executed)
-        
-    
+
     def test_taskset_inheritance(self):
         def t1(l):
             pass
+
         class MyBaseTaskSet(TaskSet):
             tasks = [t1]
             host = ""
+
         class MySubTaskSet(MyBaseTaskSet):
             @task
             def t2(self):
                 pass
-        
+
         l = MySubTaskSet(self.locust)
         self.assertEqual(2, len(l.tasks))
         self.assertEqual([t1, MySubTaskSet.t2], l.tasks)
-    
+
     def test_task_decorator_with_or_without_argument(self):
         class MyTaskSet(TaskSet):
             @task
             def t1(self):
                 pass
+
         taskset = MyTaskSet(self.locust)
         self.assertEqual(len(taskset.tasks), 1)
-        
+
         class MyTaskSet2(TaskSet):
             @task()
             def t1(self):
                 pass
+
         taskset = MyTaskSet2(self.locust)
         self.assertEqual(len(taskset.tasks), 1)
-        
+
         class MyTaskSet3(TaskSet):
             @task(3)
             def t1(self):
                 pass
+
         taskset = MyTaskSet3(self.locust)
         self.assertEqual(len(taskset.tasks), 3)
-    
-    
+
     def test_wait_function(self):
         class MyTaskSet(TaskSet):
             a = 1
             b = 2
-            wait_time = lambda self: 1 + (self.b-self.a)
+            wait_time = lambda self: 1 + (self.b - self.a)
+
         taskset = MyTaskSet(self.locust)
         self.assertEqual(taskset.wait_time(), 2.0)
-    
+
     def test_sub_taskset(self):
         class MySubTaskSet(TaskSet):
             constant(1)
+
             @task()
             def a_task(self):
                 self.user.sub_locust_task_executed = True
                 self.interrupt()
-            
+
         class MyTaskSet(TaskSet):
             tasks = [MySubTaskSet]
-        
+
         self.sub_locust_task_executed = False
         loc = MyTaskSet(self.locust)
         loc.schedule_task(loc.get_next_task())
         self.assertRaises(RescheduleTaskImmediately, lambda: loc.execute_next_task())
         self.assertTrue(self.locust.sub_locust_task_executed)
-    
+
     def test_sub_taskset_tasks_decorator(self):
         class MyTaskSet(TaskSet):
             @task
             class MySubTaskSet(TaskSet):
                 wait_time = constant(0.001)
+
                 @task()
                 def a_task(self):
                     self.user.sub_locust_task_executed = True
                     self.interrupt()
-        
+
         self.sub_locust_task_executed = False
         loc = MyTaskSet(self.locust)
         loc.schedule_task(loc.get_next_task())
         self.assertRaises(RescheduleTaskImmediately, lambda: loc.execute_next_task())
         self.assertTrue(self.locust.sub_locust_task_executed)
-    
+
     def test_on_start_interrupt(self):
         class SubTaskSet(TaskSet):
             def on_start(self):
                 self.interrupt(reschedule=False)
+
         class RescheduleSubTaskSet(TaskSet):
             def on_start(self):
                 self.interrupt(reschedule=True)
+
         class MyUser(User):
             host = ""
             tasks = [SubTaskSet]
-        
+
         l = MyUser(Environment())
         task_set = SubTaskSet(l)
         reschedule_task_set = RescheduleSubTaskSet(l)
         self.assertRaises(RescheduleTaskImmediately, lambda: reschedule_task_set.run())
         self.assertRaises(RescheduleTask, lambda: task_set.run())
 
-    
     def test_parent_attribute(self):
         from locust.exception import StopUser
+
         parents = {}
-        
+
         class SubTaskSet(TaskSet):
             def on_start(self):
                 parents["sub"] = self.parent
-            
+
             @task
             class SubSubTaskSet(TaskSet):
                 def on_start(self):
                     parents["subsub"] = self.parent
+
                 @task
                 def stop(self):
                     raise StopUser()
+
         class RootTaskSet(TaskSet):
             tasks = [SubTaskSet]
-        
+
         class MyUser(User):
             host = ""
             tasks = [RootTaskSet]
-        
+
         l = MyUser(Environment())
         l.run()
         self.assertTrue(isinstance(parents["sub"], RootTaskSet))
@@ -386,6 +410,7 @@ class TestTaskSet(LocustTestCase):
     def test_user_is_read_only(self):
         class MyTaskSet(TaskSet):
             raised_attribute_error = False
+
             @task
             def overwrite_user(self):
                 try:
@@ -398,7 +423,7 @@ class TestTaskSet(LocustTestCase):
             wait_time = constant(0)
             host = ""
             tasks = [MyTaskSet]
-        
+
         MyUser(Environment()).run()
         self.assertTrue(MyTaskSet.raised_attribute_error)
 
@@ -406,8 +431,10 @@ class TestTaskSet(LocustTestCase):
 class TestLocustClass(LocustTestCase):
     def test_locust_wait(self):
         log = []
+
         class TestUser(User):
             wait_time = constant(0.01)
+
             @task
             def t(self):
                 log.append(0)
@@ -417,29 +444,29 @@ class TestLocustClass(LocustTestCase):
 
         l = TestUser(self.environment)
         l.run()
-        self.assertEqual([0,1], log)
+        self.assertEqual([0, 1], log)
 
     def test_locust_on_start(self):
         class MyUser(User):
             t1_executed = False
             t2_executed = False
-    
+
             def on_start(self):
                 self.t1()
-    
+
             def t1(self):
                 self.t1_executed = True
-    
+
             @task
             def t2(self):
                 self.t2_executed = True
                 raise StopUser()
-    
+
         l = MyUser(self.environment)
         l.run()
         self.assertTrue(l.t1_executed)
         self.assertTrue(l.t2_executed)
-    
+
     def test_locust_on_stop(self):
         class MyUser(User):
             on_stop_executed = False
@@ -457,16 +484,18 @@ class TestLocustClass(LocustTestCase):
         l.run()
         self.assertTrue(l.on_stop_executed)
         self.assertTrue(l.t2_executed)
-    
+
     def test_locust_start(self):
         class TestUser(User):
             wait_time = constant(0.1)
             test_state = 0
+
             @task
             def t(self):
                 self.test_state = 1
                 sleep(0.1)
                 raise StopUser()
+
         group = Group()
         user = TestUser(self.environment)
         greenlet = user.start(group)
@@ -478,23 +507,24 @@ class TestLocustClass(LocustTestCase):
         timeout.start()
         group.join()
         timeout.cancel()
-    
+
     def test_locust_graceful_stop(self):
         class TestUser(User):
             wait_time = constant(0)
             test_state = 0
+
             @task
             def t(self):
                 self.test_state = 1
                 sleep(0.1)
                 self.test_state = 2
-        
+
         group = Group()
         user = TestUser(self.environment)
         greenlet = user.start(group)
         sleep(0)
         self.assertEqual(1, user.test_state)
-        
+
         # stop User gracefully
         user.stop(group, force=False)
         sleep(0)
@@ -505,52 +535,60 @@ class TestLocustClass(LocustTestCase):
         # check that locust instance has now died and that the task got to finish
         self.assertEqual(0, len(group))
         self.assertEqual(2, user.test_state)
-    
+
     def test_locust_forced_stop(self):
         class TestUser(User):
             wait_time = constant(0)
             test_state = 0
+
             @task
             def t(self):
                 self.test_state = 1
                 sleep(0.1)
                 self.test_state = 2
-    
+
         group = Group()
         user = TestUser(self.environment)
         greenlet = user.start(group)
         sleep(0)
         self.assertIn(greenlet, group)
         self.assertEqual(1, user.test_state)
-    
+
         # stop User gracefully
         user.stop(group, force=True)
         sleep(0)
         # make sure instance is killed right away, and that the task did NOT get to finish
         self.assertEqual(0, len(group))
         self.assertEqual(1, user.test_state)
-    
+
     def test_deprecated_locust_class(self):
         def test_locust():
             from locust import Locust
+
             class MyLocust(Locust):
                 pass
 
         def test_http_locust():
             from locust import HttpLocust
+
             class WebLocust(HttpLocust):
                 pass
-        
+
         def test_fast_http_locust():
             from locust.contrib.fasthttp import FastHttpLocust
+
             class FastLocust(FastHttpLocust):
                 pass
-        
+
         def assert_importing_locust_class_raises(func):
             try:
                 func()
             except ImportError as e:
-                self.assertIn("Locust class has been renamed to", e.args[0], "ImportError was raised, but with the wrong error message")
+                self.assertIn(
+                    "Locust class has been renamed to",
+                    e.args[0],
+                    "ImportError was raised, but with the wrong error message",
+                )
             else:
                 self.fail("ImportError was not raised")
 
@@ -562,8 +600,10 @@ class TestLocustClass(LocustTestCase):
 class TestWebLocustClass(WebserverTestCase):
     def test_get_request(self):
         self.response = ""
+
         def t1(l):
             self.response = l.client.get("/ultra_fast")
+
         class MyUser(HttpUser):
             tasks = [t1]
             host = "http://127.0.0.1:%i" % self.port
@@ -577,7 +617,7 @@ class TestWebLocustClass(WebserverTestCase):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("hello", locust.client.get("/request_header_test", headers={"X-Header-Test":"hello"}).text)
+        self.assertEqual("hello", locust.client.get("/request_header_test", headers={"X-Header-Test": "hello"}).text)
 
     def test_client_get(self):
         class MyUser(HttpUser):
@@ -585,7 +625,7 @@ class TestWebLocustClass(WebserverTestCase):
 
         locust = MyUser(self.environment)
         self.assertEqual("GET", locust.client.get("/request_method").text)
-    
+
     def test_client_get_absolute_url(self):
         class MyUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
@@ -598,16 +638,16 @@ class TestWebLocustClass(WebserverTestCase):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("POST", locust.client.post("/request_method", {"arg":"hello world"}).text)
-        self.assertEqual("hello world", locust.client.post("/post", {"arg":"hello world"}).text)
+        self.assertEqual("POST", locust.client.post("/request_method", {"arg": "hello world"}).text)
+        self.assertEqual("hello world", locust.client.post("/post", {"arg": "hello world"}).text)
 
     def test_client_put(self):
         class MyUserHttpUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUserHttpUser(self.environment)
-        self.assertEqual("PUT", locust.client.put("/request_method", {"arg":"hello world"}).text)
-        self.assertEqual("hello world", locust.client.put("/put", {"arg":"hello world"}).text)
+        self.assertEqual("PUT", locust.client.put("/request_method", {"arg": "hello world"}).text)
+        self.assertEqual("hello world", locust.client.put("/put", {"arg": "hello world"}).text)
 
     def test_client_delete(self):
         class MyUser(HttpUser):
@@ -642,45 +682,45 @@ class TestWebLocustClass(WebserverTestCase):
         self.assertEqual("Authorized", response.text)
         self.assertEqual(401, locust.client.get("/basic_auth").status_code)
         self.assertEqual(401, unauthorized.client.get("/basic_auth").status_code)
-    
+
     def test_log_request_name_argument(self):
         class MyUser(HttpUser):
             tasks = []
             host = "http://127.0.0.1:%i" % self.port
-            
+
             @task()
             def t1(l):
                 l.client.get("/ultra_fast", name="new name!")
 
         my_locust = MyUser(self.environment)
         my_locust.t1()
-        
+
         self.assertEqual(1, self.runner.stats.get("new name!", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/ultra_fast", "GET").num_requests)
-    
+
     def test_locust_client_error(self):
         class MyTaskSet(TaskSet):
             @task
             def t1(self):
                 self.client.get("/")
                 self.interrupt()
-        
+
         class MyUser(User):
             host = "http://127.0.0.1:%i" % self.port
             tasks = [MyTaskSet]
-        
+
         my_locust = MyUser(self.environment)
         self.assertRaises(LocustError, lambda: my_locust.client.get("/"))
         my_taskset = MyTaskSet(my_locust)
         self.assertRaises(LocustError, lambda: my_taskset.client.get("/"))
-    
+
     def test_redirect_url_original_path_as_name(self):
         class MyUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         l = MyUser(self.environment)
         l.client.get("/redirect")
-        
+
         self.assertEqual(1, len(self.runner.stats.entries))
         self.assertEqual(1, self.runner.stats.get("/redirect", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/ultra_fast", "GET").num_requests)
@@ -689,42 +729,47 @@ class TestWebLocustClass(WebserverTestCase):
 class TestCatchResponse(WebserverTestCase):
     def setUp(self):
         super(TestCatchResponse, self).setUp()
-        
+
         class MyUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
 
         self.locust = MyUser(self.environment)
-        
+
         self.num_failures = 0
         self.num_success = 0
+
         def on_failure(request_type, name, response_time, response_length, exception):
             self.num_failures += 1
             self.last_failure_exception = exception
+
         def on_success(**kwargs):
             self.num_success += 1
+
         self.environment.events.request_failure.add_listener(on_failure)
         self.environment.events.request_success.add_listener(on_success)
-        
+
     def test_catch_response(self):
         self.assertEqual(500, self.locust.client.get("/fail").status_code)
         self.assertEqual(1, self.num_failures)
         self.assertEqual(0, self.num_success)
-        
-        with self.locust.client.get("/ultra_fast", catch_response=True) as response: pass
+
+        with self.locust.client.get("/ultra_fast", catch_response=True) as response:
+            pass
         self.assertEqual(1, self.num_failures)
         self.assertEqual(1, self.num_success)
-        
+
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             raise ResponseError("Not working")
-        
+
         self.assertEqual(2, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_catch_response_http_fail(self):
-        with self.locust.client.get("/fail", catch_response=True) as response: pass
+        with self.locust.client.get("/fail", catch_response=True) as response:
+            pass
         self.assertEqual(1, self.num_failures)
         self.assertEqual(0, self.num_success)
-    
+
     def test_catch_response_http_manual_fail(self):
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             response.failure("Haha!")
@@ -732,15 +777,15 @@ class TestCatchResponse(WebserverTestCase):
         self.assertEqual(0, self.num_success)
         self.assertTrue(
             isinstance(self.last_failure_exception, CatchResponseError),
-            "Failure event handler should have been passed a CatchResponseError instance"
+            "Failure event handler should have been passed a CatchResponseError instance",
         )
-    
+
     def test_catch_response_http_manual_success(self):
         with self.locust.client.get("/fail", catch_response=True) as response:
             response.success()
         self.assertEqual(0, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_catch_response_allow_404(self):
         with self.locust.client.get("/does/not/exist", catch_response=True) as response:
             self.assertEqual(404, response.status_code)
@@ -748,26 +793,28 @@ class TestCatchResponse(WebserverTestCase):
                 response.success()
         self.assertEqual(0, self.num_failures)
         self.assertEqual(1, self.num_success)
-    
+
     def test_interrupt_taskset_with_catch_response(self):
         class MyTaskSet(TaskSet):
             @task
             def interrupted_task(self):
                 with self.client.get("/ultra_fast", catch_response=True) as r:
                     raise InterruptTaskSet()
+
         class MyUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
             tasks = [MyTaskSet]
-        
+
         l = MyUser(self.environment)
         ts = MyTaskSet(l)
         self.assertRaises(InterruptTaskSet, lambda: ts.interrupted_task())
         self.assertEqual(0, self.num_failures)
         self.assertEqual(0, self.num_success)
-    
+
     def test_catch_response_connection_error_success(self):
         class MyUser(HttpUser):
             host = "http://127.0.0.1:1"
+
         l = MyUser(self.environment)
         with l.client.get("/", catch_response=True) as r:
             self.assertEqual(r.status_code, 0)
@@ -775,10 +822,11 @@ class TestCatchResponse(WebserverTestCase):
             r.success()
         self.assertEqual(1, self.num_success)
         self.assertEqual(0, self.num_failures)
-    
+
     def test_catch_response_connection_error_fail(self):
         class MyUser(HttpUser):
             host = "http://127.0.0.1:1"
+
         l = MyUser(self.environment)
         with l.client.get("/", catch_response=True) as r:
             self.assertEqual(r.status_code, 0)

--- a/locust/test/test_log.py
+++ b/locust/test/test_log.py
@@ -18,8 +18,10 @@ class TestGreenletExceptionLogger(LocustTestCase):
     @mock.patch("sys.stderr.write")
     def test_greenlet_exception_logger(self, mocked_stderr):
         self.assertFalse(log.unhandled_greenlet_exception)
+
         def thread():
             raise ValueError("Boom!?")
+
         logger = getLogger("greenlet_test_logger")
         g = gevent.spawn(thread)
         g.link_exception(greenlet_exception_logger(logger))
@@ -34,12 +36,14 @@ class TestGreenletExceptionLogger(LocustTestCase):
 
 class TestLoggingOptions(LocustTestCase):
     def test_logging_output(self):
-        with temporary_file(textwrap.dedent("""
+        with temporary_file(
+            textwrap.dedent(
+                """
             import logging
             from locust import User, task, constant
-            
+
             custom_logger = logging.getLogger("custom_logger")
-            
+
             class MyUser(User):
                 wait_time = constant(2)
                 @task
@@ -47,115 +51,119 @@ class TestLoggingOptions(LocustTestCase):
                     print("running my_task")
                     logging.info("custom log message")
                     custom_logger.info("test")
-        """)) as file_path:
-            output = subprocess.check_output([
-                "locust", 
-                "-f", file_path, 
-                "-u", "1",
-                "-r", "1",
-                "-t", "1",
-                "--headless",
-            ], stderr=subprocess.STDOUT, timeout=10).decode("utf-8")
-        
+        """
+            )
+        ) as file_path:
+            output = subprocess.check_output(
+                ["locust", "-f", file_path, "-u", "1", "-r", "1", "-t", "1", "--headless"],
+                stderr=subprocess.STDOUT,
+                timeout=10,
+            ).decode("utf-8")
+
         self.assertIn(
-            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(),
-            output,
+            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(), output,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(),
-            output,
+            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(), output,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
-            output,
+            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(), output,
         )
         self.assertIn(
-            "\nrunning my_task\n",
-            output,
+            "\nrunning my_task\n", output,
         )
         # check that custom message of root logger is also printed
         self.assertIn(
-            "%s/INFO/root: custom log message" % socket.gethostname(),
-            output,
+            "%s/INFO/root: custom log message" % socket.gethostname(), output,
         )
         # check that custom message of custom_logger is also printed
         self.assertIn(
-            "%s/INFO/custom_logger: test" % socket.gethostname(),
-            output,
+            "%s/INFO/custom_logger: test" % socket.gethostname(), output,
         )
 
     def test_skip_logging(self):
-        with temporary_file(textwrap.dedent("""
+        with temporary_file(
+            textwrap.dedent(
+                """
             from locust import User, task, constant
-            
+
             class MyUser(User):
                 wait_time = constant(2)
                 @task
                 def my_task(self):
                     print("running my_task")
-        """)) as file_path:
-            output = subprocess.check_output([
-                "locust", 
-                "-f", file_path, 
-                "-u", "1",
-                "-r", "1",
-                "-t", "1",
-                "--headless",
-                "--skip-log-setup",
-            ], stderr=subprocess.STDOUT, timeout=10).decode("utf-8")
+        """
+            )
+        ) as file_path:
+            output = subprocess.check_output(
+                ["locust", "-f", file_path, "-u", "1", "-r", "1", "-t", "1", "--headless", "--skip-log-setup"],
+                stderr=subprocess.STDOUT,
+                timeout=10,
+            ).decode("utf-8")
         self.assertEqual("running my_task", output.strip())
-    
+
     def test_log_to_file(self):
-        with temporary_file(textwrap.dedent("""
+        with temporary_file(
+            textwrap.dedent(
+                """
             import logging
             from locust import User, task, constant
-            
+
             class MyUser(User):
                 wait_time = constant(2)
                 @task
                 def my_task(self):
                     print("running my_task")
                     logging.info("custom log message")
-        """)) as file_path:
+        """
+            )
+        ) as file_path:
             with temporary_file("", suffix=".log") as log_file_path:
                 try:
-                    output = subprocess.check_output([
-                        "locust", 
-                        "-f", file_path, 
-                        "-u", "1",
-                        "-r", "1",
-                        "-t", "1",
-                        "--headless",
-                        "--logfile", log_file_path,
-                    ], stderr=subprocess.STDOUT, timeout=10).decode("utf-8")
+                    output = subprocess.check_output(
+                        [
+                            "locust",
+                            "-f",
+                            file_path,
+                            "-u",
+                            "1",
+                            "-r",
+                            "1",
+                            "-t",
+                            "1",
+                            "--headless",
+                            "--logfile",
+                            log_file_path,
+                        ],
+                        stderr=subprocess.STDOUT,
+                        timeout=10,
+                    ).decode("utf-8")
                 except subprocess.CalledProcessError as e:
-                    raise AssertionError("Running locust command failed. Output was:\n\n%s" % e.stdout.decode("utf-8")) from e
-                
+                    raise AssertionError(
+                        "Running locust command failed. Output was:\n\n%s" % e.stdout.decode("utf-8")
+                    ) from e
+
                 with open(log_file_path, encoding="utf-8") as f:
                     log_content = f.read()
-        
+
         # make sure print still appears in output
         self.assertIn("running my_task", output)
-        
+
         # check that log messages don't go into output
         self.assertNotIn("Starting Locust", output)
         self.assertNotIn("Run time limit set to 1 seconds", output)
-        
-        # check that log messages goes into file        
+
+        # check that log messages goes into file
         self.assertIn(
-            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(),
-            log_content,
+            "%s/INFO/locust.main: Run time limit set to 1 seconds" % socket.gethostname(), log_content,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(),
-            log_content,
+            "%s/INFO/locust.main: Time limit reached. Stopping Locust." % socket.gethostname(), log_content,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
-            log_content,
+            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(), log_content,
         )
         # check that message of custom logger also went into log file
         self.assertIn(
-            "%s/INFO/root: custom log message" % socket.gethostname(),
-            log_content,
+            "%s/INFO/root: custom log message" % socket.gethostname(), log_content,
         )

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -24,69 +24,69 @@ class TestLoadLocustfile(LocustTestCase):
         self.assertFalse(main.is_user_class(HttpUser))
         self.assertFalse(main.is_user_class({}))
         self.assertFalse(main.is_user_class([]))
-        
+
         class MyTaskSet(TaskSet):
             pass
-        
+
         class MyHttpUser(HttpUser):
             tasks = [MyTaskSet]
-        
+
         class MyUser(User):
             tasks = [MyTaskSet]
-        
+
         self.assertTrue(main.is_user_class(MyHttpUser))
         self.assertTrue(main.is_user_class(MyUser))
-        
+
         class ThriftLocust(User):
             abstract = True
-        
+
         self.assertFalse(main.is_user_class(ThriftLocust))
-    
+
     def test_load_locust_file_from_absolute_path(self):
         with mock_locustfile() as mocked:
             docstring, user_classes = main.load_locustfile(mocked.file_path)
-            self.assertIn('UserSubclass', user_classes)
-            self.assertNotIn('NotUserSubclass', user_classes)
+            self.assertIn("UserSubclass", user_classes)
+            self.assertNotIn("NotUserSubclass", user_classes)
 
     def test_load_locust_file_from_relative_path(self):
         with mock_locustfile() as mocked:
-            docstring, user_classes = main.load_locustfile(os.path.join('./locust/test/', mocked.filename))
+            docstring, user_classes = main.load_locustfile(os.path.join("./locust/test/", mocked.filename))
 
     def test_load_locust_file_with_a_dot_in_filename(self):
         with mock_locustfile(filename_prefix="mocked.locust.file") as mocked:
             docstring, user_classes = main.load_locustfile(mocked.file_path)
-    
+
     def test_return_docstring_and_user_classes(self):
         with mock_locustfile() as mocked:
             docstring, user_classes = main.load_locustfile(mocked.file_path)
             self.assertEqual("This is a mock locust file for unit testing", docstring)
-            self.assertIn('UserSubclass', user_classes)
-            self.assertNotIn('NotUserSubclass', user_classes)
-    
+            self.assertIn("UserSubclass", user_classes)
+            self.assertNotIn("NotUserSubclass", user_classes)
+
     def test_create_environment(self):
-        options = parse_options(args=[
-            "--host", "https://custom-host",
-            "--reset-stats",
-        ])
+        options = parse_options(args=["--host", "https://custom-host", "--reset-stats"])
         env = create_environment([], options)
         self.assertEqual("https://custom-host", env.host)
         self.assertTrue(env.reset_stats)
-        
+
         options = parse_options(args=[])
         env = create_environment([], options)
         self.assertEqual(None, env.host)
         self.assertFalse(env.reset_stats)
 
     def test_specify_config_file(self):
-        with temporary_file(textwrap.dedent("""
+        with temporary_file(
+            textwrap.dedent(
+                """
             host = localhost  # With "="
             u 100             # Short form
             hatch-rate 5      # long form
             headless          # boolean
-        """), suffix=".conf") as conf_file_path:
-            options = parse_options(args=[
-                "--config", conf_file_path,
-            ])
+        """
+            ),
+            suffix=".conf",
+        ) as conf_file_path:
+            options = parse_options(args=["--config", conf_file_path])
             self.assertEqual(conf_file_path, options.config)
             self.assertEqual("localhost", options.host)
             self.assertEqual(100, options.num_users)
@@ -95,20 +95,12 @@ class TestLoadLocustfile(LocustTestCase):
 
     def test_command_line_arguments_override_config_file(self):
         with temporary_file("host=from_file", suffix=".conf") as conf_file_path:
-            options = parse_options(args=[
-                "--config", conf_file_path,
-                "--host", "from_args",
-            ])
+            options = parse_options(args=["--config", conf_file_path, "--host", "from_args"])
             self.assertEqual("from_args", options.host)
 
     def test_locustfile_can_be_set_in_config_file(self):
-        with temporary_file(
-            "locustfile my_locust_file.py",
-            suffix=".conf",
-        ) as conf_file_path:
-            options = parse_options(args=[
-                "--config", conf_file_path,
-            ])
+        with temporary_file("locustfile my_locust_file.py", suffix=".conf",) as conf_file_path:
+            options = parse_options(args=["--config", conf_file_path])
             self.assertEqual("my_locust_file.py", options.locustfile)
 
 
@@ -117,25 +109,25 @@ class LocustProcessIntegrationTest(TestCase):
         super().setUp()
         self.timeout = gevent.Timeout(10)
         self.timeout.start()
-    
+
     def tearDown(self):
         self.timeout.cancel()
         super().tearDown()
-    
+
     def test_help_arg(self):
-        output = subprocess.check_output(
-            ["locust", "--help"],
-            stderr=subprocess.STDOUT,
-            timeout=5,
-        ).decode("utf-8").strip()
+        output = (
+            subprocess.check_output(["locust", "--help"], stderr=subprocess.STDOUT, timeout=5,).decode("utf-8").strip()
+        )
         self.assertTrue(output.startswith("Usage: locust [OPTIONS] [UserClass ...]"))
         self.assertIn("Common options:", output)
         self.assertIn("-f LOCUSTFILE, --locustfile LOCUSTFILE", output)
         self.assertIn("Logging options:", output)
         self.assertIn("--skip-log-setup      Disable Locust's logging setup.", output)
-    
+
     def test_custom_exit_code(self):
-        with temporary_file(content=textwrap.dedent("""
+        with temporary_file(
+            content=textwrap.dedent(
+                """
             from locust import User, task, constant, events
             @events.quitting.add_listener
             def _(environment, **kw):
@@ -145,7 +137,9 @@ class LocustProcessIntegrationTest(TestCase):
                 @task
                 def my_task():
                     print("running my_task()")
-        """)) as file_path:
+        """
+            )
+        ) as file_path:
             proc = subprocess.Popen(["locust", "-f", file_path], stdout=PIPE, stderr=PIPE)
             gevent.sleep(1)
             proc.send_signal(signal.SIGTERM)
@@ -157,14 +151,18 @@ class LocustProcessIntegrationTest(TestCase):
             self.assertIn("Shutting down (exit code 42), bye", stderr)
 
     def test_webserver(self):
-        with temporary_file(content=textwrap.dedent("""
+        with temporary_file(
+            content=textwrap.dedent(
+                """
             from locust import User, task, constant, events
             class TestUser(User):
                 wait_time = constant(3)
                 @task
                 def my_task():
                     print("running my_task()")
-        """)) as file_path:
+        """
+            )
+        ) as file_path:
             proc = subprocess.Popen(["locust", "-f", file_path], stdout=PIPE, stderr=PIPE)
             gevent.sleep(1)
             proc.send_signal(signal.SIGTERM)
@@ -177,15 +175,15 @@ class LocustProcessIntegrationTest(TestCase):
 
     def test_default_headless_hatch_options(self):
         with mock_locustfile() as mocked:
-            output = subprocess.check_output(
-                    ["locust",
-                        "-f", mocked.file_path,
-                        "--host", "https://test.com/",
-                        "--run-time", "1s",
-                        "--headless"],
+            output = (
+                subprocess.check_output(
+                    ["locust", "-f", mocked.file_path, "--host", "https://test.com/", "--run-time", "1s", "--headless"],
                     stderr=subprocess.STDOUT,
                     timeout=2,
-                    ).decode("utf-8").strip()
+                )
+                .decode("utf-8")
+                .strip()
+            )
             self.assertIn("Hatching and swarming 1 users at the rate 1 users/s", output)
 
     def test_web_options(self):
@@ -196,23 +194,21 @@ class LocustProcessIntegrationTest(TestCase):
         else:
             interface = "127.0.0.2"
         with mock_locustfile() as mocked:
-            proc = subprocess.Popen([
-                "locust",
-                "-f", mocked.file_path,
-                "--web-host", interface,
-                "--web-port", str(port)
-            ], stdout=PIPE, stderr=PIPE)
+            proc = subprocess.Popen(
+                ["locust", "-f", mocked.file_path, "--web-host", interface, "--web-port", str(port)],
+                stdout=PIPE,
+                stderr=PIPE,
+            )
             gevent.sleep(1)
             self.assertEqual(200, requests.get("http://%s:%i/" % (interface, port), timeout=1).status_code)
             proc.terminate()
-            
+
         with mock_locustfile() as mocked:
-            proc = subprocess.Popen([
-                "locust",
-                "-f", mocked.file_path,
-                "--web-host", "*",
-                "--web-port", str(port),
-            ], stdout=PIPE, stderr=PIPE)
+            proc = subprocess.Popen(
+                ["locust", "-f", mocked.file_path, "--web-host", "*", "--web-port", str(port)],
+                stdout=PIPE,
+                stderr=PIPE,
+            )
             gevent.sleep(1)
             self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % port, timeout=1).status_code)
             proc.terminate()

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -20,51 +20,51 @@ class TestParser(unittest.TestCase):
         self.assertEqual(opts.skip_log_setup, False)
 
     def test_reset_stats(self):
-        args = [
-            "--reset-stats"
-        ]
+        args = ["--reset-stats"]
         opts = self.parser.parse_args(args)
         self.assertEqual(opts.reset_stats, True)
 
     def test_skip_log_setup(self):
-        args = [
-            "--skip-log-setup"
-        ]
+        args = ["--skip-log-setup"]
         opts = self.parser.parse_args(args)
         self.assertEqual(opts.skip_log_setup, True)
 
     def test_parameter_parsing(self):
-        with tempfile.NamedTemporaryFile(mode='w') as file:
-            os.environ['LOCUST_LOCUSTFILE'] = "locustfile_from_env"
+        with tempfile.NamedTemporaryFile(mode="w") as file:
+            os.environ["LOCUST_LOCUSTFILE"] = "locustfile_from_env"
             file.write("host host_from_config\nweb-host webhost_from_config")
             file.flush()
             parser = get_parser(default_config_files=[file.name])
-            options = parser.parse_args(['-H','host_from_args'])
-            del os.environ['LOCUST_LOCUSTFILE']
-        self.assertEqual(options.web_host, 'webhost_from_config')
-        self.assertEqual(options.locustfile, 'locustfile_from_env')
-        self.assertEqual(options.host, 'host_from_args') # overridden
+            options = parser.parse_args(["-H", "host_from_args"])
+            del os.environ["LOCUST_LOCUSTFILE"]
+        self.assertEqual(options.web_host, "webhost_from_config")
+        self.assertEqual(options.locustfile, "locustfile_from_env")
+        self.assertEqual(options.host, "host_from_args")  # overridden
 
     def test_web_auth(self):
-        args = [
-            "--web-auth", "hello:bye"
-        ]
+        args = ["--web-auth", "hello:bye"]
         opts = self.parser.parse_args(args)
         self.assertEqual(opts.web_auth, "hello:bye")
 
 
-
 class TestArgumentParser(LocustTestCase):
     def test_parse_options(self):
-        options = parse_options(args=[
-            "-f", "locustfile.py",
-            "-u", "100",
-            "-r", "10",
-            "-t", "5m",
-            "--reset-stats",
-            "--stop-timeout", "5",
-            "MyUserClass",
-        ])
+        options = parse_options(
+            args=[
+                "-f",
+                "locustfile.py",
+                "-u",
+                "100",
+                "-r",
+                "10",
+                "-t",
+                "5m",
+                "--reset-stats",
+                "--stop-timeout",
+                "5",
+                "MyUserClass",
+            ]
+        )
         self.assertEqual("locustfile.py", options.locustfile)
         self.assertEqual(100, options.num_users)
         self.assertEqual(10, options.hatch_rate)
@@ -74,77 +74,76 @@ class TestArgumentParser(LocustTestCase):
         self.assertEqual(["MyUserClass"], options.user_classes)
         # check default arg
         self.assertEqual(8089, options.web_port)
-    
+
     def test_parse_locustfile(self):
         with mock_locustfile() as mocked:
-            locustfile = parse_locustfile_option(args=[
-                "-f", mocked.file_path,
-                "-u", "100",
-                "-r", "10",
-                "-t", "5m",
-                "--reset-stats",
-                "--stop-timeout", "5",
-                "MyUserClass",
-            ])
+            locustfile = parse_locustfile_option(
+                args=[
+                    "-f",
+                    mocked.file_path,
+                    "-u",
+                    "100",
+                    "-r",
+                    "10",
+                    "-t",
+                    "5m",
+                    "--reset-stats",
+                    "--stop-timeout",
+                    "5",
+                    "MyUserClass",
+                ]
+            )
             self.assertEqual(mocked.file_path, locustfile)
-            locustfile = parse_locustfile_option(args=[
-                "-f", mocked.file_path,
-            ])
+            locustfile = parse_locustfile_option(args=["-f", mocked.file_path])
             self.assertEqual(mocked.file_path, locustfile)
-    
+
     def test_unknown_command_line_arg(self):
         with self.assertRaises(SystemExit):
             with mock.patch("sys.stderr", new=StringIO()):
-                parse_options(args=[
-                    "-f", "something.py",
-                    "-u", "100",
-                    "-r", "10",
-                    "-t", "5m",
-                    "--reset-stats",
-                    "--stop-timeout", "5",
-                    "--unknown-flag", 
-                    "MyUserClass",
-                ])
-    
+                parse_options(
+                    args=[
+                        "-f",
+                        "something.py",
+                        "-u",
+                        "100",
+                        "-r",
+                        "10",
+                        "-t",
+                        "5m",
+                        "--reset-stats",
+                        "--stop-timeout",
+                        "5",
+                        "--unknown-flag",
+                        "MyUserClass",
+                    ]
+                )
+
     def test_custom_argument(self):
         @locust.events.init_command_line_parser.add_listener
         def _(parser, **kw):
+            parser.add_argument("--custom-bool-arg", action="store_true", help="Custom boolean flag")
             parser.add_argument(
-                '--custom-bool-arg',
-                action='store_true',
-                help="Custom boolean flag"
+                "--custom-string-arg", help="Custom string arg",
             )
-            parser.add_argument(
-                '--custom-string-arg',
-                help="Custom string arg",
-            )
-        
-        options = parse_options(args=[
-            "-u", "666",
-            "--custom-bool-arg",
-            "--custom-string-arg", "HEJ",
-        ])
+
+        options = parse_options(args=["-u", "666", "--custom-bool-arg", "--custom-string-arg", "HEJ"])
         self.assertEqual(666, options.num_users)
         self.assertEqual("HEJ", options.custom_string_arg)
         self.assertTrue(options.custom_bool_arg)
-    
+
     def test_custom_argument_help_message(self):
         @locust.events.init_command_line_parser.add_listener
         def _(parser, **kw):
+            parser.add_argument("--custom-bool-arg", action="store_true", help="Custom boolean flag")
             parser.add_argument(
-                '--custom-bool-arg',
-                action='store_true',
-                help="Custom boolean flag"
+                "--custom-string-arg", help="Custom string arg",
             )
-            parser.add_argument(
-                '--custom-string-arg',
-                help="Custom string arg",
-            )
+
         out = StringIO()
         with mock.patch("sys.stdout", new=out):
             with self.assertRaises(SystemExit):
                 parse_options(args=["--help"])
-        
+
         out.seek(0)
         stdout = out.read()
         self.assertIn("Custom boolean flag", stdout)

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -13,13 +13,22 @@ from locust.env import Environment
 from locust.exception import RPCError, StopUser
 from locust.rpc import Message
 
-from locust.runners import LocalRunner, WorkerNode, WorkerRunner, \
-     STATE_INIT, STATE_HATCHING, STATE_RUNNING, STATE_MISSING, STATE_STOPPED
+from locust.runners import (
+    LocalRunner,
+    WorkerNode,
+    WorkerRunner,
+    STATE_INIT,
+    STATE_HATCHING,
+    STATE_RUNNING,
+    STATE_MISSING,
+    STATE_STOPPED,
+)
 from locust.stats import RequestStats
 from locust.test.testcases import LocustTestCase
 
 
 NETWORK_BROKEN = "network broken"
+
 
 def mocked_rpc():
     class MockedRpcServerClient(object):
@@ -28,7 +37,7 @@ def mocked_rpc():
 
         def __init__(self, *args, **kwargs):
             pass
-        
+
         @classmethod
         def mocked_send(cls, message):
             cls.queue.put(message.serialize())
@@ -40,10 +49,10 @@ def mocked_rpc():
             if msg.data == NETWORK_BROKEN:
                 raise RPCError()
             return msg
-        
+
         def send(self, message):
             self.outbox.append(message)
-    
+
         def send_to_client(self, message):
             self.outbox.append((message.node_id, message))
 
@@ -64,12 +73,12 @@ class mocked_options(object):
     def __init__(self):
         self.hatch_rate = 5
         self.num_users = 5
-        self.host = '/'
+        self.host = "/"
         self.tags = None
         self.exclude_tags = None
-        self.master_host = 'localhost'
+        self.master_host = "localhost"
         self.master_port = 5557
-        self.master_bind_host = '*'
+        self.master_bind_host = "*"
         self.master_bind_port = 5557
         self.heartbeat_liveness = 3
         self.heartbeat_interval = 1
@@ -80,38 +89,40 @@ class mocked_options(object):
     def reset_stats(self):
         pass
 
+
 class HeyAnException(Exception):
     pass
+
 
 class TestLocustRunner(LocustTestCase):
     def assert_locust_class_distribution(self, expected_distribution, classes):
         # Construct a {UserClass => count} dict from a list of user classes
         distribution = {}
         for user_class in classes:
-            if not user_class in distribution:
+            if user_class not in distribution:
                 distribution[user_class] = 0
             distribution[user_class] += 1
-        expected_str = str({k.__name__:v for k,v in expected_distribution.items()})
-        actual_str = str({k.__name__:v for k,v in distribution.items()})
+        expected_str = str({k.__name__: v for k, v in expected_distribution.items()})
+        actual_str = str({k.__name__: v for k, v in distribution.items()})
         self.assertEqual(
             expected_distribution,
             distribution,
-            "Expected a User class distribution of %s but found %s" % (
-                expected_str,
-                actual_str,
-            ),
+            "Expected a User class distribution of %s but found %s" % (expected_str, actual_str),
         )
 
     def test_cpu_warning(self):
         _monitor_interval = runners.CPU_MONITOR_INTERVAL
         runners.CPU_MONITOR_INTERVAL = 2.0
         try:
+
             class CpuUser(User):
                 wait_time = constant(0.001)
+
                 @task
                 def cpu_task(self):
                     for i in range(1000000):
                         _ = 3 / 2
+
             environment = Environment(user_classes=[CpuUser])
             runner = LocalRunner(environment)
             self.assertFalse(runner.cpu_warning_emitted)
@@ -124,43 +135,53 @@ class TestLocustRunner(LocustTestCase):
 
     def test_weight_locusts(self):
         maxDiff = 2048
+
         class BaseUser(User):
             pass
+
         class L1(BaseUser):
             weight = 101
+
         class L2(BaseUser):
             weight = 99
+
         class L3(BaseUser):
             weight = 100
 
         runner = Environment(user_classes=[L1, L2, L3]).create_local_runner()
-        self.assert_locust_class_distribution({L1:10, L2:9, L3:10}, runner.weight_users(29))
-        self.assert_locust_class_distribution({L1:10, L2:10, L3:10}, runner.weight_users(30))
-        self.assert_locust_class_distribution({L1:11, L2:10, L3:10}, runner.weight_users(31))
+        self.assert_locust_class_distribution({L1: 10, L2: 9, L3: 10}, runner.weight_users(29))
+        self.assert_locust_class_distribution({L1: 10, L2: 10, L3: 10}, runner.weight_users(30))
+        self.assert_locust_class_distribution({L1: 11, L2: 10, L3: 10}, runner.weight_users(31))
 
     def test_weight_locusts_fewer_amount_than_user_classes(self):
         class BaseUser(User):
             pass
+
         class L1(BaseUser):
             weight = 101
+
         class L2(BaseUser):
             weight = 99
+
         class L3(BaseUser):
             weight = 100
 
         runner = Environment(user_classes=[L1, L2, L3]).create_local_runner()
         self.assertEqual(1, len(runner.weight_users(1)))
-        self.assert_locust_class_distribution({L1:1}, runner.weight_users(1))
-    
+        self.assert_locust_class_distribution({L1: 1}, runner.weight_users(1))
+
     def test_kill_locusts(self):
         triggered = [False]
+
         class BaseUser(User):
             wait_time = constant(1)
+
             @task
             class task_set(TaskSet):
                 @task
                 def trigger(self):
                     triggered[0] = True
+
         runner = Environment(user_classes=[BaseUser]).create_local_runner()
         runner.spawn_users(2, hatch_rate=2, wait=False)
         self.assertEqual(2, len(runner.user_greenlets))
@@ -171,40 +192,46 @@ class TestLocustRunner(LocustTestCase):
         self.assertTrue(g1.dead)
         self.assertTrue(g2.dead)
         self.assertTrue(triggered[0])
-    
+
     def test_start_event(self):
         class MyUser(User):
             wait_time = constant(1)
             task_run_count = 0
+
             @task
             def my_task(self):
                 MyUser.task_run_count += 1
-        
+
         test_start_run = [0]
-        
+
         environment = Environment(user_classes=[MyUser])
+
         def on_test_start(*args, **kwargs):
             test_start_run[0] += 1
+
         environment.events.test_start.add_listener(on_test_start)
-        
+
         runner = LocalRunner(environment)
         runner.start(user_count=3, hatch_rate=3, wait=False)
         runner.hatching_greenlet.get(timeout=3)
-        
+
         self.assertEqual(1, test_start_run[0])
         self.assertEqual(3, MyUser.task_run_count)
-    
+
     def test_stop_event(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
 
         test_stop_run = [0]
         environment = Environment(user_classes=[User])
+
         def on_test_stop(*args, **kwargs):
             test_stop_run[0] += 1
+
         environment.events.test_stop.add_listener(on_test_stop)
 
         runner = LocalRunner(environment)
@@ -212,18 +239,21 @@ class TestLocustRunner(LocustTestCase):
         self.assertEqual(0, test_stop_run[0])
         runner.stop()
         self.assertEqual(1, test_stop_run[0])
-    
+
     def test_stop_event_quit(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
 
         test_stop_run = [0]
         environment = Environment(user_classes=[User])
+
         def on_test_stop(*args, **kwargs):
             test_stop_run[0] += 1
+
         environment.events.test_stop.add_listener(on_test_stop)
 
         runner = LocalRunner(environment)
@@ -235,14 +265,17 @@ class TestLocustRunner(LocustTestCase):
     def test_stop_event_stop_and_quit(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
 
         test_stop_run = [0]
         environment = Environment(user_classes=[MyUser])
+
         def on_test_stop(*args, **kwargs):
             test_stop_run[0] += 1
+
         environment.events.test_stop.add_listener(on_test_stop)
 
         runner = LocalRunner(environment)
@@ -255,10 +288,11 @@ class TestLocustRunner(LocustTestCase):
     def test_change_user_count_during_hatching(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
-        
+
         environment = Environment(user_classes=[MyUser])
         runner = LocalRunner(environment)
         runner.start(user_count=10, hatch_rate=5, wait=False)
@@ -267,22 +301,20 @@ class TestLocustRunner(LocustTestCase):
         runner.hatching_greenlet.join()
         self.assertEqual(5, len(runner.user_greenlets))
         runner.quit()
-    
+
     def test_reset_stats(self):
         class MyUser(User):
             wait_time = constant(0)
+
             @task
             class task_set(TaskSet):
                 @task
                 def my_task(self):
                     self.user.environment.events.request_success.fire(
-                        request_type="GET",
-                        name="/test",
-                        response_time=666,
-                        response_length=1337,
+                        request_type="GET", name="/test", response_time=666, response_length=1337,
                     )
                     sleep(2)
-        
+
         environment = Environment(user_classes=[MyUser], reset_stats=True)
         runner = LocalRunner(environment)
         runner.start(user_count=6, hatch_rate=12, wait=False)
@@ -291,22 +323,20 @@ class TestLocustRunner(LocustTestCase):
         sleep(0.3)
         self.assertLessEqual(runner.stats.get("/test", "GET").num_requests, 1)
         runner.quit()
-        
+
     def test_no_reset_stats(self):
         class MyUser(User):
             wait_time = constant(0)
+
             @task
             class task_set(TaskSet):
                 @task
                 def my_task(self):
                     self.user.environment.events.request_success.fire(
-                        request_type="GET",
-                        name="/test",
-                        response_time=666,
-                        response_length=1337,
-                    )                    
+                        request_type="GET", name="/test", response_time=666, response_length=1337,
+                    )
                     sleep(2)
-        
+
         environment = Environment(reset_stats=False, user_classes=[MyUser])
         runner = LocalRunner(environment)
         runner.start(user_count=6, hatch_rate=12, wait=False)
@@ -325,9 +355,11 @@ class TestLocustRunner(LocustTestCase):
     def test_users_can_call_runner_quit(self):
         class BaseUser(User):
             wait_time = constant(0)
+
             @task
             def trigger(self):
                 self.environment.runner.quit()
+
         runner = Environment(user_classes=[BaseUser]).create_local_runner()
         runner.spawn_users(1, 1, wait=False)
         timeout = gevent.Timeout(0.5)
@@ -343,19 +375,19 @@ class TestLocustRunner(LocustTestCase):
 class TestMasterWorkerRunners(LocustTestCase):
     def test_distributed_integration_run(self):
         """
-        Full integration test that starts both a MasterRunner and three WorkerRunner instances 
+        Full integration test that starts both a MasterRunner and three WorkerRunner instances
         and makes sure that their stats is sent to the Master.
         """
+
         class TestUser(User):
             wait_time = constant(0.1)
+
             @task
             def incr_stats(l):
                 l.environment.events.request_success.fire(
-                    request_type="GET",
-                    name="/",
-                    response_time=1337,
-                    response_length=666,
+                    request_type="GET", name="/", response_time=1337, response_length=666,
                 )
+
         with mock.patch("locust.runners.WORKER_REPORT_INTERVAL", new=0.3):
             # start a Master runner
             master_env = Environment(user_classes=[TestUser])
@@ -367,7 +399,7 @@ class TestMasterWorkerRunners(LocustTestCase):
                 worker_env = Environment(user_classes=[TestUser])
                 worker = worker_env.create_worker_runner("127.0.0.1", master.server.port)
                 workers.append(worker)
-            
+
             # give workers time to connect
             sleep(0.1)
             # issue start command that should trigger TestUsers to be spawned in the Workers
@@ -382,12 +414,10 @@ class TestMasterWorkerRunners(LocustTestCase):
             # make sure users are killed
             for worker in workers:
                 self.assertEqual(0, worker.user_count)
-        
+
         # check that stats are present in master
         self.assertGreater(
-            master_env.runner.stats.total.num_requests, 
-            20, 
-            "For some reason the master node's stats has not come in",
+            master_env.runner.stats.total.num_requests, 20, "For some reason the master node's stats has not come in",
         )
 
 
@@ -395,40 +425,42 @@ class TestMasterRunner(LocustTestCase):
     def setUp(self):
         super(TestMasterRunner, self).setUp()
         self.environment = Environment(events=locust.events, catch_exceptions=False)
-        
+
     def tearDown(self):
         super(TestMasterRunner, self).tearDown()
-    
+
     def get_runner(self):
         return self.environment.create_master_runner("*", 5557)
-    
+
     def test_worker_connect(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             server.mocked_send(Message("client_ready", None, "zeh_fake_client1"))
             self.assertEqual(1, len(master.clients))
-            self.assertTrue("zeh_fake_client1" in master.clients, "Could not find fake client in master instance's clients dict")
+            self.assertTrue(
+                "zeh_fake_client1" in master.clients, "Could not find fake client in master instance's clients dict"
+            )
             server.mocked_send(Message("client_ready", None, "zeh_fake_client2"))
             server.mocked_send(Message("client_ready", None, "zeh_fake_client3"))
             server.mocked_send(Message("client_ready", None, "zeh_fake_client4"))
             self.assertEqual(4, len(master.clients))
-            
+
             server.mocked_send(Message("quit", None, "zeh_fake_client3"))
             self.assertEqual(3, len(master.clients))
-    
+
     def test_worker_stats_report_median(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             server.mocked_send(Message("client_ready", None, "fake_client"))
-            
+
             master.stats.get("/", "GET").log(100, 23455)
             master.stats.get("/", "GET").log(800, 23455)
             master.stats.get("/", "GET").log(700, 23455)
-            
-            data = {"user_count":1}
+
+            data = {"user_count": 1}
             self.environment.events.report_to_master.fire(client_id="fake_client", data=data)
             master.stats.clear_all()
-            
+
             server.mocked_send(Message("stats", data, "fake_client"))
             s = master.stats.get("/", "GET")
             self.assertEqual(700, s.median_response_time)
@@ -437,7 +469,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             server.mocked_send(Message("client_ready", None, "fake_client"))
-            
+
             master.stats.get("/mixed", "GET").log(0, 23455)
             master.stats.get("/mixed", "GET").log(800, 23455)
             master.stats.get("/mixed", "GET").log(700, 23455)
@@ -446,15 +478,15 @@ class TestMasterRunner(LocustTestCase):
             master.stats.get("/mixed", "GET").log(None, 23455)
             master.stats.get("/mixed", "GET").log(None, 23455)
             master.stats.get("/onlyNone", "GET").log(None, 23455)
-            
-            data = {"user_count":1}
+
+            data = {"user_count": 1}
             self.environment.events.report_to_master.fire(client_id="fake_client", data=data)
             master.stats.clear_all()
-            
+
             server.mocked_send(Message("stats", data, "fake_client"))
             s1 = master.stats.get("/mixed", "GET")
             self.assertEqual(700, s1.median_response_time)
-            self.assertEqual(500, s1.avg_response_time)            
+            self.assertEqual(500, s1.avg_response_time)
             s2 = master.stats.get("/onlyNone", "GET")
             self.assertEqual(0, s2.median_response_time)
             self.assertEqual(0, s2.avg_response_time)
@@ -465,7 +497,7 @@ class TestMasterRunner(LocustTestCase):
             server.mocked_send(Message("client_ready", None, "fake_client"))
             sleep(6)
             # print(master.clients['fake_client'].__dict__)
-            assert master.clients['fake_client'].state == STATE_MISSING
+            assert master.clients["fake_client"].state == STATE_MISSING
 
     def test_last_worker_quitting_stops_test(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
@@ -499,7 +531,7 @@ class TestMasterRunner(LocustTestCase):
             server.mocked_send(Message("hatching", None, "fake_client2"))
 
             sleep(0.3)
-            server.mocked_send(Message("heartbeat", {'state': STATE_RUNNING, 'current_cpu_usage': 50}, "fake_client1"))
+            server.mocked_send(Message("heartbeat", {"state": STATE_RUNNING, "current_cpu_usage": 50}, "fake_client1"))
 
             sleep(0.3)
             self.assertEqual(1, len(master.clients.missing))
@@ -518,18 +550,30 @@ class TestMasterRunner(LocustTestCase):
             stats.log_request("GET", "/1", 800, 56743)
             stats2 = RequestStats()
             stats2.log_request("GET", "/2", 700, 2201)
-            server.mocked_send(Message("stats", {
-                "stats":stats.serialize_stats(), 
-                "stats_total": stats.total.serialize(),
-                "errors":stats.serialize_errors(),
-                "user_count": 1,
-            }, "fake_client"))
-            server.mocked_send(Message("stats", {
-                "stats":stats2.serialize_stats(), 
-                "stats_total": stats2.total.serialize(),
-                "errors":stats2.serialize_errors(),
-                "user_count": 2,
-            }, "fake_client"))
+            server.mocked_send(
+                Message(
+                    "stats",
+                    {
+                        "stats": stats.serialize_stats(),
+                        "stats_total": stats.total.serialize(),
+                        "errors": stats.serialize_errors(),
+                        "user_count": 1,
+                    },
+                    "fake_client",
+                )
+            )
+            server.mocked_send(
+                Message(
+                    "stats",
+                    {
+                        "stats": stats2.serialize_stats(),
+                        "stats_total": stats2.total.serialize(),
+                        "errors": stats2.serialize_errors(),
+                        "user_count": 2,
+                    },
+                    "fake_client",
+                )
+            )
             self.assertEqual(700, master.stats.total.median_response_time)
 
     def test_master_total_stats_with_none_response_times(self):
@@ -545,26 +589,44 @@ class TestMasterRunner(LocustTestCase):
             stats2.log_request("GET", "/2", None, 2201)
             stats3 = RequestStats()
             stats3.log_request("GET", "/3", None, 2201)
-            server.mocked_send(Message("stats", {
-                "stats":stats.serialize_stats(), 
-                "stats_total": stats.total.serialize(),
-                "errors":stats.serialize_errors(),
-                "user_count": 1,
-            }, "fake_client"))
-            server.mocked_send(Message("stats", {
-                "stats":stats2.serialize_stats(), 
-                "stats_total": stats2.total.serialize(),
-                "errors":stats2.serialize_errors(),
-                "user_count": 2,
-            }, "fake_client"))
-            server.mocked_send(Message("stats", {
-                "stats":stats3.serialize_stats(), 
-                "stats_total": stats3.total.serialize(),
-                "errors":stats3.serialize_errors(),
-                "user_count": 2,
-            }, "fake_client"))
+            server.mocked_send(
+                Message(
+                    "stats",
+                    {
+                        "stats": stats.serialize_stats(),
+                        "stats_total": stats.total.serialize(),
+                        "errors": stats.serialize_errors(),
+                        "user_count": 1,
+                    },
+                    "fake_client",
+                )
+            )
+            server.mocked_send(
+                Message(
+                    "stats",
+                    {
+                        "stats": stats2.serialize_stats(),
+                        "stats_total": stats2.total.serialize(),
+                        "errors": stats2.serialize_errors(),
+                        "user_count": 2,
+                    },
+                    "fake_client",
+                )
+            )
+            server.mocked_send(
+                Message(
+                    "stats",
+                    {
+                        "stats": stats3.serialize_stats(),
+                        "stats_total": stats3.total.serialize(),
+                        "errors": stats3.serialize_errors(),
+                        "user_count": 2,
+                    },
+                    "fake_client",
+                )
+            )
             self.assertEqual(700, master.stats.total.median_response_time)
-        
+
     def test_master_current_response_times(self):
         start_time = 1
         with mock.patch("time.time") as mocked_time:
@@ -577,53 +639,73 @@ class TestMasterRunner(LocustTestCase):
                 stats = RequestStats()
                 stats.log_request("GET", "/1", 100, 3546)
                 stats.log_request("GET", "/1", 800, 56743)
-                server.mocked_send(Message("stats", {
-                    "stats":stats.serialize_stats(),
-                    "stats_total": stats.total.get_stripped_report(),
-                    "errors":stats.serialize_errors(),
-                    "user_count": 1,
-                }, "fake_client"))
+                server.mocked_send(
+                    Message(
+                        "stats",
+                        {
+                            "stats": stats.serialize_stats(),
+                            "stats_total": stats.total.get_stripped_report(),
+                            "errors": stats.serialize_errors(),
+                            "user_count": 1,
+                        },
+                        "fake_client",
+                    )
+                )
                 mocked_time.return_value += 1
                 stats2 = RequestStats()
                 stats2.log_request("GET", "/2", 400, 2201)
-                server.mocked_send(Message("stats", {
-                    "stats":stats2.serialize_stats(),
-                    "stats_total": stats2.total.get_stripped_report(),
-                    "errors":stats2.serialize_errors(),
-                    "user_count": 2,
-                }, "fake_client"))
+                server.mocked_send(
+                    Message(
+                        "stats",
+                        {
+                            "stats": stats2.serialize_stats(),
+                            "stats_total": stats2.total.get_stripped_report(),
+                            "errors": stats2.serialize_errors(),
+                            "user_count": 2,
+                        },
+                        "fake_client",
+                    )
+                )
                 mocked_time.return_value += 4
                 self.assertEqual(400, master.stats.total.get_current_response_time_percentile(0.5))
                 self.assertEqual(800, master.stats.total.get_current_response_time_percentile(0.95))
-                
+
                 # let 10 second pass, do some more requests, send it to the master and make
                 # sure the current response time percentiles only accounts for these new requests
                 mocked_time.return_value += 10.10023
                 stats.log_request("GET", "/1", 20, 1)
                 stats.log_request("GET", "/1", 30, 1)
                 stats.log_request("GET", "/1", 3000, 1)
-                server.mocked_send(Message("stats", {
-                    "stats":stats.serialize_stats(),
-                    "stats_total": stats.total.get_stripped_report(),
-                    "errors":stats.serialize_errors(),
-                    "user_count": 2,
-                }, "fake_client"))
+                server.mocked_send(
+                    Message(
+                        "stats",
+                        {
+                            "stats": stats.serialize_stats(),
+                            "stats_total": stats.total.get_stripped_report(),
+                            "errors": stats.serialize_errors(),
+                            "user_count": 2,
+                        },
+                        "fake_client",
+                    )
+                )
                 self.assertEqual(30, master.stats.total.get_current_response_time_percentile(0.5))
                 self.assertEqual(3000, master.stats.total.get_current_response_time_percentile(0.95))
-    
+
     def test_rebalance_locust_users_on_worker_connect(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             server.mocked_send(Message("client_ready", None, "zeh_fake_client1"))
             self.assertEqual(1, len(master.clients))
-            self.assertTrue("zeh_fake_client1" in master.clients, "Could not find fake client in master instance's clients dict")
-            
+            self.assertTrue(
+                "zeh_fake_client1" in master.clients, "Could not find fake client in master instance's clients dict"
+            )
+
             master.start(100, 20)
             self.assertEqual(1, len(server.outbox))
             client_id, msg = server.outbox.pop()
             self.assertEqual(100, msg.data["num_users"])
             self.assertEqual(20, msg.data["hatch_rate"])
-            
+
             # let another worker connect
             server.mocked_send(Message("client_ready", None, "zeh_fake_client2"))
             self.assertEqual(2, len(master.clients))
@@ -634,9 +716,9 @@ class TestMasterRunner(LocustTestCase):
             client_id, msg = server.outbox.pop()
             self.assertEqual(50, msg.data["num_users"])
             self.assertEqual(10, msg.data["hatch_rate"])
-    
+
     def test_sends_hatch_data_to_ready_running_hatching_workers(self):
-        '''Sends hatch job to running, ready, or hatching workers'''
+        """Sends hatch job to running, ready, or hatching workers"""
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             master.clients[1] = WorkerNode(1)
@@ -648,26 +730,27 @@ class TestMasterRunner(LocustTestCase):
             master.start(user_count=5, hatch_rate=5)
 
             self.assertEqual(3, len(server.outbox))
-    
+
     def test_start_event(self):
         """
         Tests that test_start event is fired
         """
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
-            
+
             run_count = [0]
+
             @self.environment.events.test_start.add_listener
             def on_test_start(*a, **kw):
-                run_count[0] += 1            
-            
+                run_count[0] += 1
+
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
-            
+
             master.start(7, 7)
             self.assertEqual(5, len(server.outbox))
             self.assertEqual(1, run_count[0])
-            
+
             # change number of users and check that test_start isn't fired again
             master.start(7, 7)
             self.assertEqual(1, run_count[0])
@@ -685,15 +768,16 @@ class TestMasterRunner(LocustTestCase):
         """
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
-            
+
             run_count = [0]
+
             @self.environment.events.test_stop.add_listener
             def on_test_stop(*a, **kw):
-                run_count[0] += 1            
-            
+                run_count[0] += 1
+
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
-            
+
             master.start(7, 7)
             self.assertEqual(5, len(server.outbox))
             master.stop()
@@ -715,6 +799,7 @@ class TestMasterRunner(LocustTestCase):
             master = self.get_runner()
 
             run_count = [0]
+
             @self.environment.events.test_stop.add_listener
             def on_test_stop(*a, **kw):
                 run_count[0] += 1
@@ -732,17 +817,17 @@ class TestMasterRunner(LocustTestCase):
             @task
             def my_task(self):
                 pass
-            
+
         class MyTestUser(User):
             tasks = [MyTaskSet]
             wait_time = constant(0.1)
-        
+
         environment = Environment(user_classes=[MyTestUser])
         runner = LocalRunner(environment)
-        
+
         timeout = gevent.Timeout(2.0)
         timeout.start()
-        
+
         try:
             runner.start(0, 1, wait=True)
             runner.hatching_greenlet.join()
@@ -750,41 +835,41 @@ class TestMasterRunner(LocustTestCase):
             self.fail("Got Timeout exception. A locust seems to have been spawned, even though 0 was specified.")
         finally:
             timeout.cancel()
-    
+
     def test_spawn_uneven_locusts(self):
         """
-        Tests that we can accurately spawn a certain number of locusts, even if it's not an 
+        Tests that we can accurately spawn a certain number of locusts, even if it's not an
         even number of the connected workers
         """
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
-            
+
             master.start(7, 7)
             self.assertEqual(5, len(server.outbox))
-            
+
             num_users = 0
             for _, msg in server.outbox:
                 num_users += msg.data["num_users"]
-            
+
             self.assertEqual(7, num_users, "Total number of locusts that would have been spawned is not 7")
-    
+
     def test_spawn_fewer_locusts_than_workers(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
             for i in range(5):
                 server.mocked_send(Message("client_ready", None, "fake_client%i" % i))
-            
+
             master.start(2, 2)
             self.assertEqual(5, len(server.outbox))
-            
+
             num_users = 0
             for _, msg in server.outbox:
                 num_users += msg.data["num_users"]
-            
+
             self.assertEqual(2, num_users, "Total number of locusts that would have been spawned is not 2")
-    
+
     def test_spawn_locusts_in_stepload_mode(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()
@@ -802,8 +887,10 @@ class TestMasterRunner(LocustTestCase):
             end_of_last_step = len(server.outbox)
             for _, msg in server.outbox:
                 num_users += msg.data["num_users"]
-            
-            self.assertEqual(5, num_users, "Total number of locusts that would have been spawned for first step is not 5")
+
+            self.assertEqual(
+                5, num_users, "Total number of locusts that would have been spawned for first step is not 5"
+            )
 
             # make sure the first step run is complete
             sleep(2)
@@ -813,60 +900,62 @@ class TestMasterRunner(LocustTestCase):
                 msg = server.outbox[idx][1]
                 num_users += msg.data["num_users"]
                 idx += 1
-            self.assertEqual(10, num_users, "Total number of locusts that would have been spawned for second step is not 10")
+            self.assertEqual(
+                10, num_users, "Total number of locusts that would have been spawned for second step is not 10"
+            )
 
     def test_exception_in_task(self):
         class MyUser(User):
             @task
             def will_error(self):
                 raise HeyAnException(":(")
-        
+
         self.environment.user_classes = [MyUser]
         runner = self.environment.create_local_runner()
-        
+
         l = MyUser(self.environment)
-        
+
         self.assertRaises(HeyAnException, l.run)
         self.assertRaises(HeyAnException, l.run)
         self.assertEqual(1, len(runner.exceptions))
-        
+
         hash_key, exception = runner.exceptions.popitem()
         self.assertTrue("traceback" in exception)
         self.assertTrue("HeyAnException" in exception["traceback"])
         self.assertEqual(2, exception["count"])
-    
+
     def test_exception_is_catched(self):
         """ Test that exceptions are stored, and execution continues """
-        
+
         class MyTaskSet(TaskSet):
             def __init__(self, *a, **kw):
                 super(MyTaskSet, self).__init__(*a, **kw)
                 self._task_queue = [self.will_error, self.will_stop]
-            
+
             @task(1)
             def will_error(self):
                 raise HeyAnException(":(")
-            
+
             @task(1)
             def will_stop(self):
                 raise StopUser()
-        
+
         class MyUser(User):
             wait_time = constant(0.01)
             tasks = [MyTaskSet]
-        
+
         # set config to catch exceptions in locust users
         self.environment.catch_exceptions = True
         self.environment.user_classes = [MyUser]
         runner = LocalRunner(self.environment)
         l = MyUser(self.environment)
-        
+
         # make sure HeyAnException isn't raised
         l.run()
         l.run()
         # make sure we got two entries in the error log
         self.assertEqual(2, len(self.mocked_log.error))
-        
+
         # make sure exception was stored
         self.assertEqual(1, len(runner.exceptions))
         hash_key, exception = runner.exceptions.popitem()
@@ -888,47 +977,48 @@ class TestMasterRunner(LocustTestCase):
                 self.assertEqual(1, len(master.clients))
                 master.quit()
 
+
 class TestWorkerRunner(LocustTestCase):
     def setUp(self):
         super(TestWorkerRunner, self).setUp()
-        #self._report_to_master_event_handlers = [h for h in events.report_to_master._handlers]
-        
+        # self._report_to_master_event_handlers = [h for h in events.report_to_master._handlers]
+
     def tearDown(self):
-        #events.report_to_master._handlers = self._report_to_master_event_handlers
+        # events.report_to_master._handlers = self._report_to_master_event_handlers
         super(TestWorkerRunner, self).tearDown()
-    
+
     def get_runner(self, environment=None, user_classes=[]):
         if environment is None:
             environment = self.environment
         environment.user_classes = user_classes
         return WorkerRunner(environment, master_host="localhost", master_port=5557)
-    
+
     def test_worker_stop_timeout(self):
         class MyTestUser(User):
             _test_state = 0
             wait_time = constant(0)
+
             @task
             def the_task(self):
                 MyTestUser._test_state = 1
                 gevent.sleep(0.2)
                 MyTestUser._test_state = 2
-        
+
         with mock.patch("locust.rpc.rpc.Client", mocked_rpc()) as client:
             environment = Environment()
             test_start_run = [False]
+
             @environment.events.test_start.add_listener
             def on_test_start(**kw):
                 test_start_run[0] = True
+
             worker = self.get_runner(environment=environment, user_classes=[MyTestUser])
             self.assertEqual(1, len(client.outbox))
             self.assertEqual("client_ready", client.outbox[0].type)
-            client.mocked_send(Message("hatch", {
-                "hatch_rate": 1,
-                "num_users": 1,
-                "host": "",
-                "stop_timeout": 1,
-            }, "dummy_client_id"))
-            #print("outbox:", client.outbox)
+            client.mocked_send(
+                Message("hatch", {"hatch_rate": 1, "num_users": 1, "host": "", "stop_timeout": 1}, "dummy_client_id")
+            )
+            # print("outbox:", client.outbox)
             # wait for worker to hatch locusts
             self.assertIn("hatching", [m.type for m in client.outbox])
             worker.hatching_greenlet.join()
@@ -943,11 +1033,12 @@ class TestWorkerRunner(LocustTestCase):
             self.assertEqual(2, MyTestUser._test_state)
             # make sure the test_start was never fired on the worker
             self.assertFalse(test_start_run[0])
-    
+
     def test_worker_without_stop_timeout(self):
         class MyTestUser(User):
             _test_state = 0
             wait_time = constant(0)
+
             @task
             def the_task(self):
                 MyTestUser._test_state = 1
@@ -959,13 +1050,10 @@ class TestWorkerRunner(LocustTestCase):
             worker = self.get_runner(environment=environment, user_classes=[MyTestUser])
             self.assertEqual(1, len(client.outbox))
             self.assertEqual("client_ready", client.outbox[0].type)
-            client.mocked_send(Message("hatch", {
-                "hatch_rate": 1,
-                "num_users": 1,
-                "host": "",
-                "stop_timeout": None,
-            }, "dummy_client_id"))
-            #print("outbox:", client.outbox)
+            client.mocked_send(
+                Message("hatch", {"hatch_rate": 1, "num_users": 1, "host": "", "stop_timeout": None}, "dummy_client_id")
+            )
+            # print("outbox:", client.outbox)
             # wait for worker to hatch locusts
             self.assertIn("hatching", [m.type for m in client.outbox])
             worker.hatching_greenlet.join()
@@ -978,36 +1066,34 @@ class TestWorkerRunner(LocustTestCase):
             worker.user_greenlets.join()
             # check that locust user did not get to finish
             self.assertEqual(1, MyTestUser._test_state)
-    
+
     def test_change_user_count_during_hatching(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
-        
+
         with mock.patch("locust.rpc.rpc.Client", mocked_rpc()) as client:
             environment = Environment()
             worker = self.get_runner(environment=environment, user_classes=[MyUser])
-            
-            client.mocked_send(Message("hatch", {
-                "hatch_rate": 5,
-                "num_users": 10,
-                "host": "",
-                "stop_timeout": None,
-            }, "dummy_client_id"))
+
+            client.mocked_send(
+                Message(
+                    "hatch", {"hatch_rate": 5, "num_users": 10, "host": "", "stop_timeout": None}, "dummy_client_id"
+                )
+            )
             sleep(0.6)
             self.assertEqual(STATE_HATCHING, worker.state)
-            client.mocked_send(Message("hatch", {
-                "hatch_rate": 5,
-                "num_users": 9,
-                "host": "",
-                "stop_timeout": None,
-            }, "dummy_client_id"))
+            client.mocked_send(
+                Message("hatch", {"hatch_rate": 5, "num_users": 9, "host": "", "stop_timeout": None}, "dummy_client_id")
+            )
             sleep(0)
             worker.hatching_greenlet.join()
             self.assertEqual(9, len(worker.user_greenlets))
             worker.quit()
+
 
 class TestMessageSerializing(unittest.TestCase):
     def test_message_serialize(self):
@@ -1021,19 +1107,20 @@ class TestMessageSerializing(unittest.TestCase):
 class TestStopTimeout(LocustTestCase):
     def test_stop_timeout(self):
         short_time = 0.05
+
         class MyTaskSet(TaskSet):
             @task
             def my_task(self):
                 MyTaskSet.state = "first"
                 gevent.sleep(short_time)
-                MyTaskSet.state = "second" # should only run when run time + stop_timeout is > short_time
+                MyTaskSet.state = "second"  # should only run when run time + stop_timeout is > short_time
                 gevent.sleep(short_time)
-                MyTaskSet.state = "third" # should only run when run time + stop_timeout is > short_time * 2
+                MyTaskSet.state = "third"  # should only run when run time + stop_timeout is > short_time * 2
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
             wait_time = constant(0)
-        
+
         environment = Environment(user_classes=[MyTestUser])
         runner = environment.create_local_runner()
         runner.start(1, 1, wait=False)
@@ -1048,7 +1135,7 @@ class TestStopTimeout(LocustTestCase):
         gevent.sleep(short_time)
         runner.quit()
         self.assertEqual("second", MyTaskSet.state)
-        
+
         # allow task iteration to complete, with some margin
         environment = Environment(user_classes=[MyTestUser], stop_timeout=short_time * 3)
         runner = environment.create_local_runner()
@@ -1067,9 +1154,11 @@ class TestStopTimeout(LocustTestCase):
 
     def test_stop_timeout_during_on_start(self):
         short_time = 0.05
+
         class MyTaskSet(TaskSet):
             finished_on_start = False
             my_task_run = False
+
             def on_start(self):
                 gevent.sleep(short_time)
                 MyTaskSet.finished_on_start = True
@@ -1081,7 +1170,7 @@ class TestStopTimeout(LocustTestCase):
         class MyTestUser(User):
             tasks = [MyTaskSet]
             wait_time = constant(0)
-        
+
         environment = create_environment([MyTestUser], mocked_options())
         environment.stop_timeout = short_time
         runner = environment.create_local_runner()
@@ -1094,6 +1183,7 @@ class TestStopTimeout(LocustTestCase):
 
     def test_stop_timeout_exit_during_wait(self):
         short_time = 0.05
+
         class MyTaskSet(TaskSet):
             @task
             def my_task(self):
@@ -1106,7 +1196,7 @@ class TestStopTimeout(LocustTestCase):
         environment = Environment(user_classes=[MyTestUser], stop_timeout=short_time)
         runner = environment.create_local_runner()
         runner.start(1, 1)
-        gevent.sleep(short_time) # sleep to make sure locust has had time to start waiting
+        gevent.sleep(short_time)  # sleep to make sure locust has had time to start waiting
         timeout = gevent.Timeout(short_time)
         timeout.start()
         try:
@@ -1119,6 +1209,7 @@ class TestStopTimeout(LocustTestCase):
 
     def test_stop_timeout_with_interrupt(self):
         short_time = 0.05
+
         class MySubTaskSet(TaskSet):
             @task
             def a_task(self):
@@ -1127,7 +1218,7 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTaskSet(TaskSet):
             tasks = [MySubTaskSet]
-        
+
         class MyTestUser(User):
             tasks = [MyTaskSet]
             wait_time = constant(0)
@@ -1146,16 +1237,17 @@ class TestStopTimeout(LocustTestCase):
             self.fail("Got Timeout exception. Interrupted locusts should exit immediately during stop_timeout.")
         finally:
             timeout.cancel()
-    
+
     def test_stop_timeout_with_interrupt_no_reschedule(self):
         state = [0]
+
         class MySubTaskSet(TaskSet):
             @task
             def a_task(self):
                 gevent.sleep(0.1)
                 state[0] = 1
                 self.interrupt(reschedule=False)
-        
+
         class MyTestUser(User):
             tasks = [MySubTaskSet]
             wait_time = constant(3)
@@ -1175,22 +1267,23 @@ class TestStopTimeout(LocustTestCase):
         finally:
             timeout.cancel()
         self.assertEqual(1, state[0])
-    
+
     def test_kill_locusts_with_stop_timeout(self):
         short_time = 0.05
+
         class MyTaskSet(TaskSet):
             @task
             def my_task(self):
                 MyTaskSet.state = "first"
                 gevent.sleep(short_time)
-                MyTaskSet.state = "second" # should only run when run time + stop_timeout is > short_time
+                MyTaskSet.state = "second"  # should only run when run time + stop_timeout is > short_time
                 gevent.sleep(short_time)
-                MyTaskSet.state = "third" # should only run when run time + stop_timeout is > short_time * 2
+                MyTaskSet.state = "third"  # should only run when run time + stop_timeout is > short_time * 2
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
             wait_time = constant(0)
-        
+
         environment = create_environment([MyTestUser], mocked_options())
         runner = environment.create_local_runner()
         runner.start(1, 1)
@@ -1200,7 +1293,7 @@ class TestStopTimeout(LocustTestCase):
         runner.quit()
         environment.runner = None
 
-        environment.stop_timeout = short_time / 2 # exit with timeout
+        environment.stop_timeout = short_time / 2  # exit with timeout
         runner = environment.create_local_runner()
         runner.start(1, 1)
         gevent.sleep(short_time)
@@ -1209,7 +1302,7 @@ class TestStopTimeout(LocustTestCase):
         runner.quit()
         environment.runner = None
 
-        environment.stop_timeout = short_time * 3 # allow task iteration to complete, with some margin
+        environment.stop_timeout = short_time * 3  # allow task iteration to complete, with some margin
         runner = environment.create_local_runner()
         runner.start(1, 1)
         gevent.sleep(short_time)
@@ -1227,11 +1320,13 @@ class TestStopTimeout(LocustTestCase):
     def test_users_can_call_runner_quit_with_stop_timeout(self):
         class BaseUser(User):
             wait_time = constant(1)
+
             @task
             def trigger(self):
                 self.environment.runner.quit()
+
         runner = Environment(user_classes=[BaseUser]).create_local_runner()
-        runner.environment.stop_timeout = 1 
+        runner.environment.stop_timeout = 1
         runner.spawn_users(1, 1, wait=False)
         timeout = gevent.Timeout(0.5)
         timeout.start()
@@ -1245,14 +1340,17 @@ class TestStopTimeout(LocustTestCase):
     def test_gracefully_handle_exceptions_in_listener(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task
             def my_task(self):
                 pass
 
         test_stop_run = [0]
         environment = Environment(user_classes=[User])
+
         def on_test_stop_ok(*args, **kwargs):
             test_stop_run[0] += 1
+
         def on_test_stop_fail(*args, **kwargs):
             assert 0
 

--- a/locust/test/test_sequential_taskset.py
+++ b/locust/test/test_sequential_taskset.py
@@ -7,18 +7,22 @@ from .testcases import LocustTestCase
 class TestTaskSet(LocustTestCase):
     def setUp(self):
         super(TestTaskSet, self).setUp()
+
         class MyUser(User):
             host = "127.0.0.1"
             wait_time = constant(0)
+
         self.locust = MyUser(self.environment)
 
     def test_task_sequence_with_list(self):
         log = []
-        
+
         def t1(ts):
             log.append(1)
+
         def t2(ts):
             log.append(2)
+
         def t3(ts):
             log.append(3)
             ts.interrupt(reschedule=False)
@@ -28,17 +32,20 @@ class TestTaskSet(LocustTestCase):
 
         l = MyTaskSequence(self.locust)
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEqual([1,2,3], log)
-    
+        self.assertEqual([1, 2, 3], log)
+
     def test_task_sequence_with_methods(self):
         log = []
+
         class MyTaskSequence(SequentialTaskSet):
             @task
             def t1(self):
                 log.append(1)
+
             @task
             def t2(self):
                 log.append(2)
+
             @task(1)
             def t3(self):
                 log.append(3)
@@ -46,24 +53,28 @@ class TestTaskSet(LocustTestCase):
 
         l = MyTaskSequence(self.locust)
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEqual([1,2,3], log)
-    
+        self.assertEqual([1, 2, 3], log)
+
     def test_task_sequence_with_methods_and_list(self):
         log = []
+
         def func_t1(ts):
             log.append(101)
+
         def func_t2(ts):
             log.append(102)
+
         class MyTaskSequence(SequentialTaskSet):
             @task
             def t1(self):
                 log.append(1)
+
             @task
             def t2(self):
                 log.append(2)
-            
+
             tasks = [func_t1, func_t2]
-            
+
             @task(1)
             def t3(self):
                 log.append(3)
@@ -71,20 +82,25 @@ class TestTaskSet(LocustTestCase):
 
         l = MyTaskSequence(self.locust)
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEqual([1,2, 101,102,3], log)
-    
+        self.assertEqual([1, 2, 101, 102, 3], log)
+
     def test_task_sequence_with_inheritance(self):
         log = []
+
         class TS1(SequentialTaskSet):
             @task
             def t1(self):
                 log.append(1)
+
             tasks = [lambda ts: log.append(30)]
+
         class TS2(TS1):
             tasks = [lambda ts: log.append(20)]
+
             @task
             def t2(self):
                 log.append(2)
+
         class TS3(TS2):
             @task
             def t3(self):
@@ -93,26 +109,29 @@ class TestTaskSet(LocustTestCase):
 
         l = TS3(self.locust)
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEqual([1,30,20,2,3], log)
-    
+        self.assertEqual([1, 30, 20, 2, 3], log)
+
     def test_task_sequence_multiple_iterations(self):
         log = []
+
         class TS(SequentialTaskSet):
             iteration_count = 0
+
             @task
             def t1(self):
                 log.append(1)
+
             @task
             def t2(self):
                 log.append(2)
+
             @task(1)
             def t3(self):
                 log.append(3)
                 self.iteration_count += 1
                 if self.iteration_count == 3:
                     self.interrupt(reschedule=False)
-    
+
         l = TS(self.locust)
         self.assertRaises(RescheduleTask, lambda: l.run())
-        self.assertEqual([1,2,3,1,2,3,1,2,3], log)
-
+        self.assertEqual([1, 2, 3, 1, 2, 3, 1, 2, 3], log)

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -22,23 +22,26 @@ from .test_runners import mocked_rpc
 class TestRequestStats(unittest.TestCase):
     def setUp(self):
         self.stats = RequestStats()
+
         def log(response_time, size):
             self.stats.log_request("GET", "test_entry", response_time, size)
+
         def log_error(exc):
             self.stats.log_error("GET", "test_entry", exc)
+
         log(45, 1)
         log(135, 1)
         log(44, 1)
-        log(None, 1)        
+        log(None, 1)
         log_error(Exception("dummy fail"))
         log_error(Exception("dummy fail"))
         log(375, 1)
         log(601, 1)
         log(35, 1)
         log(79, 1)
-        log(None, 1)        
+        log(None, 1)
         log_error(Exception("dummy fail"))
-        self.s = self.stats.get("test_entry",  "GET")
+        self.s = self.stats.get("test_entry", "GET")
 
     def test_percentile(self):
         s = StatsEntry(self.stats, "percentile_test", "GET")
@@ -69,10 +72,10 @@ class TestRequestStats(unittest.TestCase):
         self.s.last_request_timestamp = 4.0
         self.stats.total.start_time = 1.0
         self.stats.total.last_request_timestamp = 6.0
-        self.assertEqual(self.s.total_rps, 9/5.0)
-        self.assertAlmostEqual(s2.total_rps, 1/5.0)
-        self.assertEqual(self.stats.total.total_rps, 10/5.0)
-    
+        self.assertEqual(self.s.total_rps, 9 / 5.0)
+        self.assertAlmostEqual(s2.total_rps, 1 / 5.0)
+        self.assertEqual(self.stats.total.total_rps, 10 / 5.0)
+
     def test_rps_less_than_one_second(self):
         s = StatsEntry(self.stats, "percentile_test", "GET")
         for i in range(10):
@@ -120,7 +123,7 @@ class TestRequestStats(unittest.TestCase):
         self.assertNotEqual(None, self.s.last_request_timestamp)
         self.s.reset()
         self.assertEqual(None, self.s.last_request_timestamp)
-    
+
     def test_avg_only_none(self):
         self.s.reset()
         self.s.log(None, 123)
@@ -162,21 +165,21 @@ class TestRequestStats(unittest.TestCase):
 
     def test_aggregation_with_rounding(self):
         s1 = StatsEntry(self.stats, "round me!", "GET")
-        s1.log(122, 0)    # (rounded 120) min
-        s1.log(992, 0)    # (rounded 990) max
-        s1.log(142, 0)    # (rounded 140)
-        s1.log(552, 0)    # (rounded 550)
-        s1.log(557, 0)    # (rounded 560)
-        s1.log(387, 0)    # (rounded 390)
-        s1.log(557, 0)    # (rounded 560)
-        s1.log(977, 0)    # (rounded 980)
+        s1.log(122, 0)  # (rounded 120) min
+        s1.log(992, 0)  # (rounded 990) max
+        s1.log(142, 0)  # (rounded 140)
+        s1.log(552, 0)  # (rounded 550)
+        s1.log(557, 0)  # (rounded 560)
+        s1.log(387, 0)  # (rounded 390)
+        s1.log(557, 0)  # (rounded 560)
+        s1.log(977, 0)  # (rounded 980)
 
         self.assertEqual(s1.num_requests, 8)
         self.assertEqual(s1.median_response_time, 550)
         self.assertEqual(s1.avg_response_time, 535.75)
         self.assertEqual(s1.min_response_time, 122)
         self.assertEqual(s1.max_response_time, 992)
-    
+
     def test_aggregation_with_decimal_rounding(self):
         s1 = StatsEntry(self.stats, "round me!", "GET")
         s1.log(1.1, 0)
@@ -184,7 +187,7 @@ class TestRequestStats(unittest.TestCase):
         s1.log(3.1, 0)
         self.assertEqual(s1.num_requests, 3)
         self.assertEqual(s1.median_response_time, 2)
-        self.assertEqual(s1.avg_response_time, (1.1+1.99+3.1)/3)
+        self.assertEqual(s1.avg_response_time, (1.1 + 1.99 + 3.1) / 3)
         self.assertEqual(s1.min_response_time, 1.1)
         self.assertEqual(s1.max_response_time, 3.1)
 
@@ -195,7 +198,7 @@ class TestRequestStats(unittest.TestCase):
         s2 = StatsEntry(self.stats, "min", "GET")
         s1.extend(s2)
         self.assertEqual(10, s1.min_response_time)
-    
+
     def test_aggregation_last_request_timestamp(self):
         s1 = StatsEntry(self.stats, "r", "GET")
         s2 = StatsEntry(self.stats, "r", "GET")
@@ -220,44 +223,51 @@ class TestRequestStats(unittest.TestCase):
 
     def test_percentile_rounded_down(self):
         s1 = StatsEntry(self.stats, "rounding down!", "GET")
-        s1.log(122, 0)    # (rounded 120) min
+        s1.log(122, 0)  # (rounded 120) min
         actual_percentile = s1.percentile()
-        self.assertEqual(actual_percentile, " GET                  rounding down!                                                      1    120    120    120    120    120    120    120    120    120    120    120")
+        self.assertEqual(
+            actual_percentile,
+            " GET                  rounding down!                                                      1    120    120    120    120    120    120    120    120    120    120    120",
+        )
 
     def test_percentile_rounded_up(self):
         s2 = StatsEntry(self.stats, "rounding up!", "GET")
-        s2.log(127, 0)    # (rounded 130) min
+        s2.log(127, 0)  # (rounded 130) min
         actual_percentile = s2.percentile()
-        self.assertEqual(actual_percentile, " GET                  rounding up!                                                        1    130    130    130    130    130    130    130    130    130    130    130")
+        self.assertEqual(
+            actual_percentile,
+            " GET                  rounding up!                                                        1    130    130    130    130    130    130    130    130    130    130    130",
+        )
 
     def test_error_grouping(self):
         # reset stats
         self.stats = RequestStats()
-        
+
         self.stats.log_error("GET", "/some-path", Exception("Exception!"))
         self.stats.log_error("GET", "/some-path", Exception("Exception!"))
-            
+
         self.assertEqual(1, len(self.stats.errors))
         self.assertEqual(2, list(self.stats.errors.values())[0].occurrences)
-        
+
         self.stats.log_error("GET", "/some-path", Exception("Another exception!"))
         self.stats.log_error("GET", "/some-path", Exception("Another exception!"))
         self.stats.log_error("GET", "/some-path", Exception("Third exception!"))
         self.assertEqual(3, len(self.stats.errors))
-    
+
     def test_error_grouping_errors_with_memory_addresses(self):
         # reset stats
         self.stats = RequestStats()
+
         class Dummy(object):
             pass
-        
+
         self.stats.log_error("GET", "/", Exception("Error caused by %r" % Dummy()))
         self.assertEqual(1, len(self.stats.errors))
-    
+
     def test_serialize_through_message(self):
         """
-        Serialize a RequestStats instance, then serialize it through a Message, 
-        and unserialize the whole thing again. This is done "IRL" when stats are sent 
+        Serialize a RequestStats instance, then serialize it through a Message,
+        and unserialize the whole thing again. This is done "IRL" when stats are sent
         from workers to master.
         """
         s1 = StatsEntry(self.stats, "test", "GET")
@@ -265,10 +275,10 @@ class TestRequestStats(unittest.TestCase):
         s1.log(20, 0)
         s1.log(40, 0)
         u1 = StatsEntry.unserialize(s1.serialize())
-        
+
         data = Message.unserialize(Message("dummy", s1.serialize(), "none").serialize()).data
         u1 = StatsEntry.unserialize(data)
-        
+
         self.assertEqual(20, u1.median_response_time)
 
 
@@ -276,7 +286,7 @@ class TestStatsPrinting(LocustTestCase):
     def test_print_percentile_stats(self):
         stats = RequestStats()
         for i in range(100):
-            stats.log_request("GET", "test_entry", i, 2000+i)
+            stats.log_request("GET", "test_entry", i, 2000 + i)
         locust.stats.print_percentile_stats(stats)
         info = self.mocked_log.info
         self.assertEqual(7, len(info))
@@ -312,13 +322,13 @@ class TestCsvStats(LocustTestCase):
         self.assertTrue(os.path.exists(self.STATS_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-    
+
     def test_write_csv_files_full_history(self):
         locust.stats.write_csv_files(self.environment, self.STATS_BASE_NAME, full_history=True)
         self.assertTrue(os.path.exists(self.STATS_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-    
+
     @mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2)
     def test_csv_stats_writer(self):
         greenlet = gevent.spawn(stats_writer, self.environment, self.STATS_BASE_NAME)
@@ -327,15 +337,15 @@ class TestCsvStats(LocustTestCase):
         self.assertTrue(os.path.exists(self.STATS_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-        
+
         with open(self.STATS_HISTORY_FILENAME) as f:
             reader = csv.DictReader(f)
             rows = [r for r in reader]
-        
+
         self.assertEqual(2, len(rows))
         self.assertEqual("Aggregated", rows[0]["Name"])
         self.assertEqual("Aggregated", rows[1]["Name"])
-    
+
     @mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2)
     def test_csv_stats_writer_full_history(self):
         self.runner.stats.log_request("GET", "/", 10, content_length=666)
@@ -345,64 +355,67 @@ class TestCsvStats(LocustTestCase):
         self.assertTrue(os.path.exists(self.STATS_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
         self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-        
+
         with open(self.STATS_HISTORY_FILENAME) as f:
             reader = csv.DictReader(f)
             rows = [r for r in reader]
-        
+
         self.assertEqual(4, len(rows))
         self.assertEqual("/", rows[0]["Name"])
         self.assertEqual("Aggregated", rows[1]["Name"])
         self.assertEqual("/", rows[2]["Name"])
         self.assertEqual("Aggregated", rows[3]["Name"])
-    
+
     def test_csv_stats_on_master_from_aggregated_stats(self):
         # Failing test for: https://github.com/locustio/locust/issues/1315
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             environment = Environment()
             master = environment.create_master_runner(master_bind_host="*", master_bind_port=0)
             server.mocked_send(Message("client_ready", None, "fake_client"))
-            
+
             master.stats.get("/", "GET").log(100, 23455)
             master.stats.get("/", "GET").log(800, 23455)
             master.stats.get("/", "GET").log(700, 23455)
-            
-            data = {"user_count":1}
+
+            data = {"user_count": 1}
             environment.events.report_to_master.fire(client_id="fake_client", data=data)
             master.stats.clear_all()
-            
+
             server.mocked_send(Message("stats", data, "fake_client"))
             s = master.stats.get("/", "GET")
             self.assertEqual(700, s.median_response_time)
-            
+
             locust.stats.write_csv_files(environment, self.STATS_BASE_NAME, full_history=True)
             self.assertTrue(os.path.exists(self.STATS_FILENAME))
             self.assertTrue(os.path.exists(self.STATS_HISTORY_FILENAME))
             self.assertTrue(os.path.exists(self.STATS_FAILURES_FILENAME))
-    
+
     @mock.patch("locust.stats.CSV_STATS_INTERVAL_SEC", new=0.2)
     def test_user_count_in_csv_history_stats(self):
         start_time = int(time.time())
+
         class TestUser(User):
             wait_time = constant(10)
+
             @task
             def t(self):
                 self.environment.runner.stats.log_request("GET", "/", 10, 10)
+
         environment = Environment(user_classes=[TestUser])
         runner = environment.create_local_runner()
-        runner.start(3, 5) # spawn a user every 0.2 second
+        runner.start(3, 5)  # spawn a user every 0.2 second
         gevent.sleep(0.1)
-        
+
         greenlet = gevent.spawn(stats_writer, environment, self.STATS_BASE_NAME, full_history=True)
         gevent.sleep(0.6)
         gevent.kill(greenlet)
-        
+
         runner.stop()
-        
+
         with open(self.STATS_HISTORY_FILENAME) as f:
             reader = csv.DictReader(f)
             rows = [r for r in reader]
-        
+
         self.assertEqual(6, len(rows))
         for i in range(3):
             row = rows.pop(0)
@@ -447,7 +460,7 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
     def setUp(self, *args, **kwargs):
         super(TestStatsEntryResponseTimesCache, self).setUp(*args, **kwargs)
         self.stats = RequestStats()
-    
+
     def test_response_times_cached(self):
         s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
         self.assertEqual(1, len(s.response_times_cache))
@@ -456,11 +469,11 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
         s.last_request_timestamp -= 1
         s.log(666, 1337)
         self.assertEqual(2, len(s.response_times_cache))
-        self.assertEqual(CachedResponseTimes(
-            response_times={11:1}, 
-            num_requests=1,
-        ), s.response_times_cache[int(s.last_request_timestamp)-1])
-    
+        self.assertEqual(
+            CachedResponseTimes(response_times={11: 1}, num_requests=1,),
+            s.response_times_cache[int(s.last_request_timestamp) - 1],
+        )
+
     def test_response_times_not_cached_if_not_enabled(self):
         s = StatsEntry(self.stats, "/", "GET")
         s.log(11, 1337)
@@ -468,7 +481,7 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
         s.last_request_timestamp -= 1
         s.log(666, 1337)
         self.assertEqual(None, s.response_times_cache)
-    
+
     def test_latest_total_response_times_pruned(self):
         """
         Check that RequestStats.latest_total_response_times are pruned when execeeding 20 entries
@@ -476,65 +489,47 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
         s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
         t = int(time.time())
         for i in reversed(range(2, 30)):
-            s.response_times_cache[t-i] = CachedResponseTimes(response_times={}, num_requests=0)
+            s.response_times_cache[t - i] = CachedResponseTimes(response_times={}, num_requests=0)
         self.assertEqual(29, len(s.response_times_cache))
         s.log(17, 1337)
         s.last_request_timestamp -= 1
         s.log(1, 1)
         self.assertEqual(20, len(s.response_times_cache))
         self.assertEqual(
-            CachedResponseTimes(response_times={17:1}, num_requests=1),
-            s.response_times_cache.popitem(last=True)[1],
+            CachedResponseTimes(response_times={17: 1}, num_requests=1), s.response_times_cache.popitem(last=True)[1],
         )
-    
+
     def test_get_current_response_time_percentile(self):
         s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
         t = int(time.time())
-        s.response_times_cache[t-10] = CachedResponseTimes(
-            response_times={i:1 for i in range(100)},
-            num_requests=200
+        s.response_times_cache[t - 10] = CachedResponseTimes(
+            response_times={i: 1 for i in range(100)}, num_requests=200
         )
-        s.response_times_cache[t-10].response_times[1] = 201
-        
-        s.response_times = {i:2 for i in range(100)}
+        s.response_times_cache[t - 10].response_times[1] = 201
+
+        s.response_times = {i: 2 for i in range(100)}
         s.response_times[1] = 202
         s.num_requests = 300
-        
+
         self.assertEqual(95, s.get_current_response_time_percentile(0.95))
-    
+
     def test_diff_response_times_dicts(self):
-        self.assertEqual({1:5, 6:8}, diff_response_time_dicts(
-            {1:6, 6:16, 2:2}, 
-            {1:1, 6:8, 2:2},
-        ))
-        self.assertEqual({}, diff_response_time_dicts(
-            {}, 
-            {},
-        ))
-        self.assertEqual({10:15}, diff_response_time_dicts(
-            {10:15}, 
-            {},
-        ))
-        self.assertEqual({10:10}, diff_response_time_dicts(
-            {10:10}, 
-            {},
-        ))
-        self.assertEqual({}, diff_response_time_dicts(
-            {1:1}, 
-            {1:1},
-        ))
+        self.assertEqual({1: 5, 6: 8}, diff_response_time_dicts({1: 6, 6: 16, 2: 2}, {1: 1, 6: 8, 2: 2},))
+        self.assertEqual({}, diff_response_time_dicts({}, {},))
+        self.assertEqual({10: 15}, diff_response_time_dicts({10: 15}, {},))
+        self.assertEqual({10: 10}, diff_response_time_dicts({10: 10}, {},))
+        self.assertEqual({}, diff_response_time_dicts({1: 1}, {1: 1},))
 
 
 class TestStatsEntry(unittest.TestCase):
-
     def parse_string_output(self, text):
-        tokenlist = re.split('[\s\(\)%|]+', text.strip())
+        tokenlist = re.split(r"[\s\(\)%|]+", text.strip())
         tokens = {
-            'method': tokenlist[0],
-            'name': tokenlist[1],
-            'request_count': int(tokenlist[2]),
-            'failure_count': int(tokenlist[3]),
-            'failure_precentage': float(tokenlist[4]),
+            "method": tokenlist[0],
+            "name": tokenlist[1],
+            "request_count": int(tokenlist[2]),
+            "failure_count": int(tokenlist[3]),
+            "failure_precentage": float(tokenlist[4]),
         }
         return tokens
 
@@ -553,9 +548,9 @@ class TestStatsEntry(unittest.TestCase):
 
         self.assertAlmostEqual(s.fail_ratio, EXPECTED_FAIL_RATIO)
         output_fields = self.parse_string_output(str(s))
-        self.assertEqual(output_fields['request_count'], REQUEST_COUNT)
-        self.assertEqual(output_fields['failure_count'], FAILURE_COUNT)
-        self.assertAlmostEqual(output_fields['failure_precentage'], EXPECTED_FAIL_RATIO*100)
+        self.assertEqual(output_fields["request_count"], REQUEST_COUNT)
+        self.assertEqual(output_fields["failure_count"], FAILURE_COUNT)
+        self.assertAlmostEqual(output_fields["failure_precentage"], EXPECTED_FAIL_RATIO * 100)
 
     def test_fail_ratio_with_all_failures(self):
         REQUEST_COUNT = 10
@@ -568,9 +563,9 @@ class TestStatsEntry(unittest.TestCase):
 
         self.assertAlmostEqual(s.fail_ratio, EXPECTED_FAIL_RATIO)
         output_fields = self.parse_string_output(str(s))
-        self.assertEqual(output_fields['request_count'], REQUEST_COUNT)
-        self.assertEqual(output_fields['failure_count'], FAILURE_COUNT)
-        self.assertAlmostEqual(output_fields['failure_precentage'], EXPECTED_FAIL_RATIO*100)
+        self.assertEqual(output_fields["request_count"], REQUEST_COUNT)
+        self.assertEqual(output_fields["failure_count"], FAILURE_COUNT)
+        self.assertAlmostEqual(output_fields["failure_precentage"], EXPECTED_FAIL_RATIO * 100)
 
     def test_fail_ratio_with_half_failures(self):
         REQUEST_COUNT = 10
@@ -583,50 +578,59 @@ class TestStatsEntry(unittest.TestCase):
 
         self.assertAlmostEqual(s.fail_ratio, EXPECTED_FAIL_RATIO)
         output_fields = self.parse_string_output(str(s))
-        self.assertEqual(output_fields['request_count'], REQUEST_COUNT)
-        self.assertEqual(output_fields['failure_count'], FAILURE_COUNT)
-        self.assertAlmostEqual(output_fields['failure_precentage'], EXPECTED_FAIL_RATIO*100)
+        self.assertEqual(output_fields["request_count"], REQUEST_COUNT)
+        self.assertEqual(output_fields["failure_count"], FAILURE_COUNT)
+        self.assertAlmostEqual(output_fields["failure_precentage"], EXPECTED_FAIL_RATIO * 100)
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def setUp(self):
         super().setUp()
+
         class MyUser(HttpUser):
             host = "http://127.0.0.1:%i" % self.port
+
         self.locust = MyUser(self.environment)
-    
+
     def test_request_stats_content_length(self):
         self.locust.client.get("/ultra_fast")
-        self.assertEqual(self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
+        self.assertEqual(
+            self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response")
+        )
         self.locust.client.get("/ultra_fast")
-        self.assertEqual(self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
-    
+        self.assertEqual(
+            self.runner.stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response")
+        )
+
     def test_request_stats_no_content_length(self):
         path = "/no_content_length"
         r = self.locust.client.get(path)
-        self.assertEqual(self.runner.stats.get(path, "GET").avg_content_length, len("This response does not have content-length in the header"))
-    
+        self.assertEqual(
+            self.runner.stats.get(path, "GET").avg_content_length,
+            len("This response does not have content-length in the header"),
+        )
+
     def test_request_stats_no_content_length_streaming(self):
         path = "/no_content_length"
         r = self.locust.client.get(path, stream=True)
         self.assertEqual(0, self.runner.stats.get(path, "GET").avg_content_length)
-    
+
     def test_request_stats_named_endpoint(self):
         self.locust.client.get("/ultra_fast", name="my_custom_name")
         self.assertEqual(1, self.runner.stats.get("my_custom_name", "GET").num_requests)
-    
+
     def test_request_stats_query_variables(self):
         self.locust.client.get("/ultra_fast?query=1")
         self.assertEqual(1, self.runner.stats.get("/ultra_fast?query=1", "GET").num_requests)
-    
+
     def test_request_stats_put(self):
         self.locust.client.put("/put")
         self.assertEqual(1, self.runner.stats.get("/put", "PUT").num_requests)
-    
+
     def test_request_connection_error(self):
         class MyUser(HttpUser):
             host = "http://localhost:1"
-        
+
         locust = MyUser(self.environment)
         response = locust.client.get("/", timeout=0.1)
         self.assertEqual(response.status_code, 0)
@@ -638,16 +642,18 @@ class MyTaskSet(TaskSet):
     @task(75)
     def root_task(self):
         pass
-    
+
     @task(25)
     class MySubTaskSet(TaskSet):
         @task
         def task1(self):
             pass
+
         @task
         def task2(self):
             pass
-    
+
+
 class TestInspectUser(unittest.TestCase):
     def test_get_task_ratio_dict_relative(self):
         ratio = get_task_ratio_dict([MyTaskSet])
@@ -656,7 +662,7 @@ class TestInspectUser(unittest.TestCase):
         self.assertEqual(0.25, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task1"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task2"]["ratio"])
-    
+
     def test_get_task_ratio_dict_total(self):
         ratio = get_task_ratio_dict([MyTaskSet], total=True)
         self.assertEqual(1.0, ratio["MyTaskSet"]["ratio"])

--- a/locust/test/test_tags.py
+++ b/locust/test/test_tags.py
@@ -3,46 +3,48 @@ from locust.user.task import filter_tasks_by_tags
 from locust.env import Environment
 from .testcases import LocustTestCase
 
+
 class TestTags(LocustTestCase):
     def test_tagging(self):
-        @tag('tag1')
+        @tag("tag1")
         @task
         def tagged():
             pass
 
-        self.assertIn('locust_tag_set', dir(tagged))
-        self.assertEqual(set(['tag1']), tagged.locust_tag_set)
+        self.assertIn("locust_tag_set", dir(tagged))
+        self.assertEqual(set(["tag1"]), tagged.locust_tag_set)
 
-        @tag('tag2', 'tag3')
+        @tag("tag2", "tag3")
         @task
         def tagged_multiple_args():
             pass
 
-        self.assertIn('locust_tag_set', dir(tagged_multiple_args))
-        self.assertEqual(set(['tag2', 'tag3']), tagged_multiple_args.locust_tag_set)
+        self.assertIn("locust_tag_set", dir(tagged_multiple_args))
+        self.assertEqual(set(["tag2", "tag3"]), tagged_multiple_args.locust_tag_set)
 
-        @tag('tag4')
-        @tag('tag5')
+        @tag("tag4")
+        @tag("tag5")
         @task
         def tagged_multiple_times():
             pass
-        self.assertIn('locust_tag_set', dir(tagged_multiple_times))
-        self.assertEqual(set(['tag4', 'tag5']), tagged_multiple_times.locust_tag_set)
+
+        self.assertIn("locust_tag_set", dir(tagged_multiple_times))
+        self.assertEqual(set(["tag4", "tag5"]), tagged_multiple_times.locust_tag_set)
 
     def test_tagging_taskset(self):
-        @tag('taskset')
+        @tag("taskset")
         @task
         class MyTaskSet(TaskSet):
             @task
             def tagged(self):
                 pass
 
-            @tag('task')
+            @tag("task")
             @task
             def tagged_again(self):
                 pass
 
-            @tag('taskset2')
+            @tag("taskset2")
             @task
             class NestedTaskSet(TaskSet):
                 @task
@@ -50,16 +52,16 @@ class TestTags(LocustTestCase):
                     pass
 
         # when tagging taskset, its tasks recieve the tag
-        self.assertIn('locust_tag_set', dir(MyTaskSet.tagged))
-        self.assertEqual(set(['taskset']), MyTaskSet.tagged.locust_tag_set)
+        self.assertIn("locust_tag_set", dir(MyTaskSet.tagged))
+        self.assertEqual(set(["taskset"]), MyTaskSet.tagged.locust_tag_set)
 
         # tagging inner task receives both
-        self.assertIn('locust_tag_set', dir(MyTaskSet.tagged_again))
-        self.assertEqual(set(['taskset', 'task']), MyTaskSet.tagged_again.locust_tag_set)
+        self.assertIn("locust_tag_set", dir(MyTaskSet.tagged_again))
+        self.assertEqual(set(["taskset", "task"]), MyTaskSet.tagged_again.locust_tag_set)
 
         # when tagging nested taskset, its tasks receives both
-        self.assertIn('locust_tag_set', dir(MyTaskSet.NestedTaskSet.nested_task))
-        self.assertEqual(set(['taskset', 'taskset2']), MyTaskSet.NestedTaskSet.nested_task.locust_tag_set)
+        self.assertIn("locust_tag_set", dir(MyTaskSet.NestedTaskSet.nested_task))
+        self.assertEqual(set(["taskset", "taskset2"]), MyTaskSet.NestedTaskSet.nested_task.locust_tag_set)
 
     def test_tagging_without_args_fails(self):
         @task
@@ -74,12 +76,12 @@ class TestTags(LocustTestCase):
 
     def test_including_tags(self):
         class MyTaskSet(TaskSet):
-            @tag('include this', 'other tag')
+            @tag("include this", "other tag")
             @task
             def included(self):
                 pass
 
-            @tag('dont include this', 'other tag')
+            @tag("dont include this", "other tag")
             @task
             def not_included(self):
                 pass
@@ -88,19 +90,21 @@ class TestTags(LocustTestCase):
             def dont_include_this_either(self):
                 pass
 
-        self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.included, MyTaskSet.not_included, MyTaskSet.dont_include_this_either])
+        self.assertListEqual(
+            MyTaskSet.tasks, [MyTaskSet.included, MyTaskSet.not_included, MyTaskSet.dont_include_this_either]
+        )
 
-        filter_tasks_by_tags(MyTaskSet, tags=set(['include this']))
+        filter_tasks_by_tags(MyTaskSet, tags=set(["include this"]))
         self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.included])
 
     def test_excluding_tags(self):
         class MyTaskSet(TaskSet):
-            @tag('exclude this', 'other tag')
+            @tag("exclude this", "other tag")
             @task
             def excluded(self):
                 pass
 
-            @tag('dont exclude this', 'other tag')
+            @tag("dont exclude this", "other tag")
             @task
             def not_excluded(self):
                 pass
@@ -109,9 +113,11 @@ class TestTags(LocustTestCase):
             def dont_exclude_this_either(self):
                 pass
 
-        self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.excluded, MyTaskSet.not_excluded, MyTaskSet.dont_exclude_this_either])
+        self.assertListEqual(
+            MyTaskSet.tasks, [MyTaskSet.excluded, MyTaskSet.not_excluded, MyTaskSet.dont_exclude_this_either]
+        )
 
-        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(['exclude this']))
+        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(["exclude this"]))
         self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.not_excluded, MyTaskSet.dont_exclude_this_either])
 
     def test_including_and_excluding(self):
@@ -120,29 +126,29 @@ class TestTags(LocustTestCase):
             def not_included_or_excluded(self):
                 pass
 
-            @tag('included')
+            @tag("included")
             @task
             def included(self):
                 pass
 
-            @tag('excluded')
+            @tag("excluded")
             @task
             def excluded(self):
                 pass
 
-            @tag('included', 'excluded')
+            @tag("included", "excluded")
             @task
             def included_and_excluded(self):
                 pass
 
-        filter_tasks_by_tags(MyTaskSet, tags=set(['included']), exclude_tags=set(['excluded']))
+        filter_tasks_by_tags(MyTaskSet, tags=set(["included"]), exclude_tags=set(["excluded"]))
         self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.included])
 
     def test_including_tasksets(self):
         class MyTaskSet(TaskSet):
             @task
             class MixedNestedTaskSet(TaskSet):
-                @tag('included')
+                @tag("included")
                 @task
                 def included(self):
                     pass
@@ -151,7 +157,7 @@ class TestTags(LocustTestCase):
                 def not_included(self):
                     pass
 
-            @tag('included')
+            @tag("included")
             @task
             class TaggedNestedTaskSet(TaskSet):
                 @task
@@ -164,7 +170,7 @@ class TestTags(LocustTestCase):
                 def not_included(self):
                     pass
 
-        filter_tasks_by_tags(MyTaskSet, tags=set(['included']))
+        filter_tasks_by_tags(MyTaskSet, tags=set(["included"]))
         self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.MixedNestedTaskSet, MyTaskSet.TaggedNestedTaskSet])
         self.assertListEqual(MyTaskSet.MixedNestedTaskSet.tasks, [MyTaskSet.MixedNestedTaskSet.included])
 
@@ -172,7 +178,7 @@ class TestTags(LocustTestCase):
         class MyTaskSet(TaskSet):
             @task
             class MixedNestedTaskSet(TaskSet):
-                @tag('excluded')
+                @tag("excluded")
                 @task
                 def excluded(self):
                     pass
@@ -183,12 +189,12 @@ class TestTags(LocustTestCase):
 
             @task
             class ExcludedNestedTaskSet(TaskSet):
-                @tag('excluded')
+                @tag("excluded")
                 @task
                 def excluded(self):
                     pass
 
-            @tag('excluded')
+            @tag("excluded")
             @task
             class TaggedNestedTaskSet(TaskSet):
                 @task
@@ -201,23 +207,23 @@ class TestTags(LocustTestCase):
                 def not_excluded(self):
                     pass
 
-        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(['excluded']))
+        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(["excluded"]))
         self.assertListEqual(MyTaskSet.tasks, [MyTaskSet.MixedNestedTaskSet, MyTaskSet.NormalNestedTaskSet])
         self.assertListEqual(MyTaskSet.MixedNestedTaskSet.tasks, [MyTaskSet.MixedNestedTaskSet.not_excluded])
 
     def test_including_tags_with_weights(self):
         class MyTaskSet(TaskSet):
-            @tag('included')
+            @tag("included")
             @task(2)
             def include_twice(self):
                 pass
 
-            @tag('included')
+            @tag("included")
             @task(3)
             def include_3_times(self):
                 pass
 
-            @tag('dont include this')
+            @tag("dont include this")
             @task(4)
             def dont_include_4_times(self):
                 pass
@@ -229,27 +235,39 @@ class TestTags(LocustTestCase):
         self.assertListEqual(
             MyTaskSet.tasks,
             [
-                MyTaskSet.include_twice, MyTaskSet.include_twice,
-                MyTaskSet.include_3_times, MyTaskSet.include_3_times, MyTaskSet.include_3_times,
-                MyTaskSet.dont_include_4_times, MyTaskSet.dont_include_4_times,
-                MyTaskSet.dont_include_4_times, MyTaskSet.dont_include_4_times,
-                MyTaskSet.dont_include_5_times, MyTaskSet.dont_include_5_times,
-                MyTaskSet.dont_include_5_times, MyTaskSet.dont_include_5_times,
-                MyTaskSet.dont_include_5_times
-            ])
+                MyTaskSet.include_twice,
+                MyTaskSet.include_twice,
+                MyTaskSet.include_3_times,
+                MyTaskSet.include_3_times,
+                MyTaskSet.include_3_times,
+                MyTaskSet.dont_include_4_times,
+                MyTaskSet.dont_include_4_times,
+                MyTaskSet.dont_include_4_times,
+                MyTaskSet.dont_include_4_times,
+                MyTaskSet.dont_include_5_times,
+                MyTaskSet.dont_include_5_times,
+                MyTaskSet.dont_include_5_times,
+                MyTaskSet.dont_include_5_times,
+                MyTaskSet.dont_include_5_times,
+            ],
+        )
 
-        filter_tasks_by_tags(MyTaskSet, tags=set(['included']))
+        filter_tasks_by_tags(MyTaskSet, tags=set(["included"]))
 
         self.assertListEqual(
             MyTaskSet.tasks,
             [
-                MyTaskSet.include_twice, MyTaskSet.include_twice,
-                MyTaskSet.include_3_times, MyTaskSet.include_3_times, MyTaskSet.include_3_times
-            ])
+                MyTaskSet.include_twice,
+                MyTaskSet.include_twice,
+                MyTaskSet.include_3_times,
+                MyTaskSet.include_3_times,
+                MyTaskSet.include_3_times,
+            ],
+        )
 
     def test_excluding_tags_with_weights(self):
         class MyTaskSet(TaskSet):
-            @tag('dont exclude this')
+            @tag("dont exclude this")
             @task(2)
             def dont_exclude_twice(self):
                 pass
@@ -258,12 +276,12 @@ class TestTags(LocustTestCase):
             def dont_exclude_3_times(self):
                 pass
 
-            @tag('excluded')
+            @tag("excluded")
             @task(4)
             def exclude_4_times(self):
                 pass
 
-            @tag('excluded')
+            @tag("excluded")
             @task(5)
             def exclude_5_times(self):
                 pass
@@ -271,33 +289,45 @@ class TestTags(LocustTestCase):
         self.assertListEqual(
             MyTaskSet.tasks,
             [
-                MyTaskSet.dont_exclude_twice, MyTaskSet.dont_exclude_twice,
-                MyTaskSet.dont_exclude_3_times, MyTaskSet.dont_exclude_3_times, MyTaskSet.dont_exclude_3_times,
-                MyTaskSet.exclude_4_times, MyTaskSet.exclude_4_times,
-                MyTaskSet.exclude_4_times, MyTaskSet.exclude_4_times,
-                MyTaskSet.exclude_5_times, MyTaskSet.exclude_5_times,
-                MyTaskSet.exclude_5_times, MyTaskSet.exclude_5_times,
-                MyTaskSet.exclude_5_times
-            ])
+                MyTaskSet.dont_exclude_twice,
+                MyTaskSet.dont_exclude_twice,
+                MyTaskSet.dont_exclude_3_times,
+                MyTaskSet.dont_exclude_3_times,
+                MyTaskSet.dont_exclude_3_times,
+                MyTaskSet.exclude_4_times,
+                MyTaskSet.exclude_4_times,
+                MyTaskSet.exclude_4_times,
+                MyTaskSet.exclude_4_times,
+                MyTaskSet.exclude_5_times,
+                MyTaskSet.exclude_5_times,
+                MyTaskSet.exclude_5_times,
+                MyTaskSet.exclude_5_times,
+                MyTaskSet.exclude_5_times,
+            ],
+        )
 
-        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(['excluded']))
+        filter_tasks_by_tags(MyTaskSet, exclude_tags=set(["excluded"]))
 
         self.assertListEqual(
             MyTaskSet.tasks,
             [
-                MyTaskSet.dont_exclude_twice, MyTaskSet.dont_exclude_twice,
-                MyTaskSet.dont_exclude_3_times, MyTaskSet.dont_exclude_3_times, MyTaskSet.dont_exclude_3_times
-            ])
+                MyTaskSet.dont_exclude_twice,
+                MyTaskSet.dont_exclude_twice,
+                MyTaskSet.dont_exclude_3_times,
+                MyTaskSet.dont_exclude_3_times,
+                MyTaskSet.dont_exclude_3_times,
+            ],
+        )
 
     def test_tagged_tasks_shared_across_tasksets(self):
-        @tag('tagged')
+        @tag("tagged")
         def shared_task():
             pass
 
         def untagged_shared_task():
             pass
 
-        @tag('tagged')
+        @tag("tagged")
         class SharedTaskSet(TaskSet):
             @task
             def inner_task(self):
@@ -309,23 +339,23 @@ class TestTags(LocustTestCase):
         class ExcludeTaskSet(TaskSet):
             tasks = [shared_task, untagged_shared_task, SharedTaskSet]
 
-        filter_tasks_by_tags(IncludeTaskSet, tags=set(['tagged']))
+        filter_tasks_by_tags(IncludeTaskSet, tags=set(["tagged"]))
 
         self.assertListEqual(IncludeTaskSet.tasks, [shared_task, SharedTaskSet])
         self.assertListEqual(IncludeTaskSet.tasks[1].tasks, [SharedTaskSet.inner_task])
 
-        filter_tasks_by_tags(ExcludeTaskSet, exclude_tags=set(['tagged']))
+        filter_tasks_by_tags(ExcludeTaskSet, exclude_tags=set(["tagged"]))
 
         self.assertListEqual(ExcludeTaskSet.tasks, [untagged_shared_task])
 
     def test_include_tags_under_user(self):
         class MyUser(User):
-            @tag('include this')
+            @tag("include this")
             @task
             def included(self):
                 pass
 
-            @tag('dont include this')
+            @tag("dont include this")
             @task
             def not_included(self):
                 pass
@@ -334,18 +364,18 @@ class TestTags(LocustTestCase):
             def dont_include_this_either(self):
                 pass
 
-        filter_tasks_by_tags(MyUser, tags=set(['include this']))
+        filter_tasks_by_tags(MyUser, tags=set(["include this"]))
 
         self.assertListEqual(MyUser.tasks, [MyUser.included])
 
     def test_exclude_tags_under_user(self):
         class MyUser(User):
-            @tag('exclude this')
+            @tag("exclude this")
             @task
             def excluded(self):
                 pass
 
-            @tag('dont exclude this')
+            @tag("dont exclude this")
             @task
             def not_excluded(self):
                 pass
@@ -354,18 +384,18 @@ class TestTags(LocustTestCase):
             def dont_exclude_this_either(self):
                 pass
 
-        filter_tasks_by_tags(MyUser, exclude_tags=set(['exclude this']))
+        filter_tasks_by_tags(MyUser, exclude_tags=set(["exclude this"]))
 
         self.assertListEqual(MyUser.tasks, [MyUser.not_excluded, MyUser.dont_exclude_this_either])
 
     def test_env_include_tags(self):
         class MyTaskSet(TaskSet):
-            @tag('include this')
+            @tag("include this")
             @task
             def included(self):
                 pass
 
-            @tag('dont include this')
+            @tag("dont include this")
             @task
             def not_included(self):
                 pass
@@ -377,7 +407,7 @@ class TestTags(LocustTestCase):
         class MyUser(User):
             tasks = [MyTaskSet]
 
-        env = Environment(user_classes=[MyUser], tags=['include this'])
+        env = Environment(user_classes=[MyUser], tags=["include this"])
         env._filter_tasks_by_tags()
 
         self.assertListEqual(MyUser.tasks, [MyTaskSet])
@@ -385,12 +415,12 @@ class TestTags(LocustTestCase):
 
     def test_env_exclude_tags(self):
         class MyTaskSet(User):
-            @tag('exclude this')
+            @tag("exclude this")
             @task
             def excluded(self):
                 pass
 
-            @tag('dont exclude this')
+            @tag("dont exclude this")
             @task
             def not_excluded(self):
                 pass
@@ -402,7 +432,7 @@ class TestTags(LocustTestCase):
         class MyUser(User):
             tasks = [MyTaskSet]
 
-        env = Environment(user_classes=[MyUser], exclude_tags=['exclude this'])
+        env = Environment(user_classes=[MyUser], exclude_tags=["exclude this"])
         env._filter_tasks_by_tags()
 
         self.assertListEqual(MyUser.tasks, [MyTaskSet])

--- a/locust/test/test_taskratio.py
+++ b/locust/test/test_taskratio.py
@@ -10,33 +10,30 @@ class TestTaskRatio(unittest.TestCase):
             @task
             def root_task1(self):
                 pass
-            
+
             @task
             class SubTasks(TaskSet):
                 @task
                 def task1(self):
                     pass
-                
+
                 @task
                 def task2(self):
                     pass
-        
+
         class MyUser(User):
             tasks = [Tasks]
-        
+
         ratio_dict = get_task_ratio_dict(Tasks.tasks, total=True)
-        
-        self.assertEqual({
-            'SubTasks': {
-                'tasks': {
-                    'task1': {'ratio': 0.25},
-                    'task2': {'ratio': 0.25}
-                },
-                'ratio': 0.5
-            }, 
-            'root_task1': {'ratio': 0.5}
-        }, ratio_dict)
-    
+
+        self.assertEqual(
+            {
+                "SubTasks": {"tasks": {"task1": {"ratio": 0.25}, "task2": {"ratio": 0.25}}, "ratio": 0.5},
+                "root_task1": {"ratio": 0.5},
+            },
+            ratio_dict,
+        )
+
     def test_task_ratio_command_with_locust_weight(self):
         class Tasks(TaskSet):
             @task(1)
@@ -56,33 +53,36 @@ class TestTaskRatio(unittest.TestCase):
             tasks = [Tasks]
 
         ratio_dict = get_task_ratio_dict([UnlikelyUser, MoreLikelyUser], total=True)
-        
-        self.assertDictEqual({
-            'UnlikelyUser':   {
-                'ratio': 0.25,
-                'tasks': {
-                    'Tasks': {
-                        'tasks': {
-                            'task1': {'ratio': 0.25*0.25}, 
-                            'task3': {'ratio': 0.25*0.75},
-                            }, 
-                        'ratio': 0.25
-                    }
-                },
-            },
-            'MoreLikelyUser': {
-                'ratio': 0.75,
-                'tasks': {
-                    'Tasks': {
-                        'tasks': {
-                            'task1': {'ratio': 0.75*0.25}, 
-                            'task3': {'ratio': 0.75*0.75},
-                        }, 
-                        'ratio': 0.75,
+
+        self.assertDictEqual(
+            {
+                "UnlikelyUser": {
+                    "ratio": 0.25,
+                    "tasks": {
+                        "Tasks": {
+                            "tasks": {"task1": {"ratio": 0.25 * 0.25}, "task3": {"ratio": 0.25 * 0.75}},
+                            "ratio": 0.25,
+                        }
                     },
                 },
-            }
-        }, ratio_dict)
-        unlikely = ratio_dict['UnlikelyUser']['tasks']['Tasks']['tasks']
-        likely = ratio_dict['MoreLikelyUser']['tasks']['Tasks']['tasks']
-        assert unlikely['task1']['ratio'] + unlikely['task3']['ratio'] + likely['task1']['ratio'] + likely['task3']['ratio'] == 1
+                "MoreLikelyUser": {
+                    "ratio": 0.75,
+                    "tasks": {
+                        "Tasks": {
+                            "tasks": {"task1": {"ratio": 0.75 * 0.25}, "task3": {"ratio": 0.75 * 0.75}},
+                            "ratio": 0.75,
+                        },
+                    },
+                },
+            },
+            ratio_dict,
+        )
+        unlikely = ratio_dict["UnlikelyUser"]["tasks"]["Tasks"]["tasks"]
+        likely = ratio_dict["MoreLikelyUser"]["tasks"]["Tasks"]["tasks"]
+        assert (
+            unlikely["task1"]["ratio"]
+            + unlikely["task3"]["ratio"]
+            + likely["task1"]["ratio"]
+            + likely["task3"]["ratio"]
+            == 1
+        )

--- a/locust/test/test_util.py
+++ b/locust/test/test_util.py
@@ -8,7 +8,7 @@ class TestParseTimespan(unittest.TestCase):
         self.assertRaises(ValueError, parse_timespan, None)
         self.assertRaises(ValueError, parse_timespan, "")
         self.assertRaises(ValueError, parse_timespan, "q")
-    
+
     def test_parse_timespan(self):
         self.assertEqual(7, parse_timespan("7"))
         self.assertEqual(7, parse_timespan("7s"))

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -11,11 +11,13 @@ class TestWaitTime(LocustTestCase):
     def test_between(self):
         class MyUser(User):
             wait_time = between(3, 9)
+
         class TaskSet1(TaskSet):
             pass
+
         class TaskSet2(TaskSet):
             wait_time = between(20.0, 21.0)
-        
+
         u = MyUser(self.environment)
         ts1 = TaskSet1(u)
         ts2 = TaskSet2(u)
@@ -30,36 +32,42 @@ class TestWaitTime(LocustTestCase):
             w = ts2.wait_time()
             self.assertGreaterEqual(w, 20)
             self.assertLessEqual(w, 21)
-    
+
     def test_constant(self):
         class MyUser(User):
             wait_time = constant(13)
+
         class TaskSet1(TaskSet):
             pass
+
         self.assertEqual(13, MyUser(self.environment).wait_time())
         self.assertEqual(13, TaskSet1(MyUser(self.environment)).wait_time())
-    
+
     def test_constant_zero(self):
         class MyUser(User):
             wait_time = constant(0)
+
         class TaskSet1(TaskSet):
             pass
+
         self.assertEqual(0, MyUser(self.environment).wait_time())
         self.assertEqual(0, TaskSet1(MyUser(self.environment)).wait_time())
         taskset = TaskSet1(MyUser(self.environment))
         start_time = time.monotonic()
         taskset.wait()
         self.assertLess(time.monotonic() - start_time, 0.002)
-    
+
     def test_constant_pacing(self):
         class MyUser(User):
             wait_time = constant_pacing(0.1)
+
         class TS(TaskSet):
             pass
+
         ts = TS(MyUser(self.environment))
-        
+
         ts2 = TS(MyUser(self.environment))
-        
+
         previous_time = time.monotonic()
         for i in range(7):
             ts.wait()
@@ -73,7 +81,8 @@ class TestWaitTime(LocustTestCase):
     def test_missing_wait_time(self):
         class MyUser(User):
             pass
+
         class TS(TaskSet):
             pass
-        self.assertRaises(MissingWaitTimeError, lambda: TS(MyUser(self.environment)).wait_time())
 
+        self.assertRaises(MissingWaitTimeError, lambda: TS(MyUser(self.environment)).wait_time())

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -35,15 +35,15 @@ class TestWebUI(LocustTestCase):
         self.web_ui.app.view_functions["request_stats"].clear_cache()
         gevent.sleep(0.01)
         self.web_port = self.web_ui.server.server_port
-    
+
     def tearDown(self):
         super(TestWebUI, self).tearDown()
         self.web_ui.stop()
         self.runner.quit()
-    
+
     def test_web_ui_reference_on_environment(self):
         self.assertEqual(self.web_ui, self.environment.web_ui)
-    
+
     def test_web_ui_no_runner(self):
         env = Environment()
         web_ui = WebUI(env, "127.0.0.1", 0)
@@ -54,17 +54,17 @@ class TestWebUI(LocustTestCase):
             self.assertEqual("Error: Locust Environment does not have any runner", response.text)
         finally:
             web_ui.stop()
-    
+
     def test_index(self):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % self.web_port).status_code)
 
     def test_index_with_hatch_options(self):
         html_to_option = {
-                'user_count':['-u','100'],
-                'hatch_rate':['-r','10.0'],
-                'step_user_count':['--step-users','20'],
-                'step_duration':['--step-time','15'],
-                }
+            "user_count": ["-u", "100"],
+            "hatch_rate": ["-r", "10.0"],
+            "step_user_count": ["--step-users", "20"],
+            "step_duration": ["--step-time", "15"],
+        }
         self.environment.step_load = True
         for html_name_to_test in html_to_option.keys():
             # Test that setting each hatch option individually populates the corresponding field in the html, and none of the others
@@ -73,64 +73,64 @@ class TestWebUI(LocustTestCase):
             response = requests.get("http://127.0.0.1:%i/" % self.web_port)
             self.assertEqual(200, response.status_code)
 
-            d = pq(response.content.decode('utf-8'))
+            d = pq(response.content.decode("utf-8"))
 
             for html_name in html_to_option.keys():
-                start_value = d(f'.start [name={html_name}]').attr('value')
-                edit_value = d(f'.edit [name={html_name}]').attr('value')
+                start_value = d(f".start [name={html_name}]").attr("value")
+                edit_value = d(f".edit [name={html_name}]").attr("value")
                 if html_name_to_test == html_name:
                     self.assertEqual(html_to_option[html_name][1], start_value)
                     self.assertEqual(html_to_option[html_name][1], edit_value)
                 else:
-                    self.assertEqual('', start_value)
-                    self.assertEqual('', edit_value)
+                    self.assertEqual("", start_value)
+                    self.assertEqual("", edit_value)
 
     def test_stats_no_data(self):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code)
-    
+
     def test_stats(self):
         self.stats.log_request("GET", "/<html>", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+
         data = json.loads(response.text)
-        self.assertEqual(2, len(data["stats"])) # one entry plus Aggregated
+        self.assertEqual(2, len(data["stats"]))  # one entry plus Aggregated
         self.assertEqual("/<html>", data["stats"][0]["name"])
         self.assertEqual("/&lt;html&gt;", data["stats"][0]["safe_name"])
         self.assertEqual("GET", data["stats"][0]["method"])
         self.assertEqual(120, data["stats"][0]["avg_response_time"])
-        
+
         self.assertEqual("Aggregated", data["stats"][1]["name"])
         self.assertEqual(1, data["stats"][1]["num_requests"])
         self.assertEqual(120, data["stats"][1]["avg_response_time"])
-        
+
     def test_stats_cache(self):
         self.stats.log_request("GET", "/test", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
         data = json.loads(response.text)
-        self.assertEqual(2, len(data["stats"])) # one entry plus Aggregated
-        
+        self.assertEqual(2, len(data["stats"]))  # one entry plus Aggregated
+
         # add another entry
         self.stats.log_request("GET", "/test2", 120, 5612)
         data = json.loads(requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).text)
-        self.assertEqual(2, len(data["stats"])) # old value should be cached now
-        
+        self.assertEqual(2, len(data["stats"]))  # old value should be cached now
+
         self.web_ui.app.view_functions["request_stats"].clear_cache()
-        
+
         data = json.loads(requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).text)
-        self.assertEqual(3, len(data["stats"])) # this should no longer be cached
-    
+        self.assertEqual(3, len(data["stats"]))  # this should no longer be cached
+
     def test_stats_rounding(self):
         self.stats.log_request("GET", "/test", 1.39764125, 2)
         self.stats.log_request("GET", "/test", 999.9764125, 1000)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+
         data = json.loads(response.text)
         self.assertEqual(1, data["stats"][0]["min_response_time"])
         self.assertEqual(1000, data["stats"][0]["max_response_time"])
-    
+
     def test_request_stats_csv(self):
         self.stats.log_request("GET", "/test2", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
@@ -140,7 +140,7 @@ class TestWebUI(LocustTestCase):
         self.stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/failures/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_request_stats_with_errors(self):
         self.stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
@@ -149,7 +149,7 @@ class TestWebUI(LocustTestCase):
 
     def test_reset_stats(self):
         try:
-            raise Exception(u"A cool test exception")
+            raise Exception("A cool test exception")
         except Exception as e:
             tb = sys.exc_info()[2]
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
@@ -164,27 +164,27 @@ class TestWebUI(LocustTestCase):
 
         self.assertEqual({}, self.stats.errors)
         self.assertEqual({}, self.runner.exceptions)
-        
+
         self.assertEqual(0, self.stats.get("/", "GET").num_requests)
         self.assertEqual(0, self.stats.get("/", "GET").num_failures)
         self.assertEqual(0, self.stats.get("/test", "GET").num_requests)
         self.assertEqual(0, self.stats.get("/test", "GET").num_failures)
-    
+
     def test_exceptions(self):
         try:
-            raise Exception(u"A cool test exception")
+            raise Exception("A cool test exception")
         except Exception as e:
             tb = sys.exc_info()[2]
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
-        
+
         response = requests.get("http://127.0.0.1:%i/exceptions" % self.web_port)
         self.assertEqual(200, response.status_code)
         self.assertIn("A cool test exception", response.text)
-        
+
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_exceptions_csv(self):
         try:
             raise Exception("Test exception")
@@ -192,15 +192,15 @@ class TestWebUI(LocustTestCase):
             tb = sys.exc_info()[2]
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
-        
+
         response = requests.get("http://127.0.0.1:%i/exceptions/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+
         reader = csv.reader(StringIO(response.text))
         rows = []
         for row in reader:
             rows.append(row)
-        
+
         self.assertEqual(2, len(rows))
         self.assertEqual("Test exception", rows[1][1])
         self.assertEqual(2, int(rows[1][0]), "Exception count should be 2")
@@ -208,12 +208,14 @@ class TestWebUI(LocustTestCase):
     def test_swarm_host_value_specified(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task(1)
             def my_task(self):
                 pass
+
         self.environment.user_classes = [MyUser]
         response = requests.post(
-            "http://127.0.0.1:%i/swarm" % self.web_port, 
+            "http://127.0.0.1:%i/swarm" % self.web_port,
             data={"user_count": 5, "hatch_rate": 5, "host": "https://localhost"},
         )
         self.assertEqual(200, response.status_code)
@@ -223,43 +225,47 @@ class TestWebUI(LocustTestCase):
     def test_swarm_host_value_not_specified(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task(1)
             def my_task(self):
                 pass
+
         self.environment.user_classes = [MyUser]
-        response = requests.post(
-            "http://127.0.0.1:%i/swarm" % self.web_port, 
-            data={'user_count': 5, 'hatch_rate': 5},
-        )
+        response = requests.post("http://127.0.0.1:%i/swarm" % self.web_port, data={"user_count": 5, "hatch_rate": 5},)
         self.assertEqual(200, response.status_code)
         self.assertEqual(None, response.json()["host"])
         self.assertEqual(self.environment.host, None)
-    
+
     def test_host_value_from_user_class(self):
         class MyUser(User):
             host = "http://example.com"
+
         self.environment.user_classes = [MyUser]
         response = requests.get("http://127.0.0.1:%i/" % self.web_port)
         self.assertEqual(200, response.status_code)
         self.assertIn("http://example.com", response.content.decode("utf-8"))
         self.assertNotIn("setting this will override the host on all User classes", response.content.decode("utf-8"))
-    
+
     def test_host_value_from_multiple_user_classes(self):
         class MyUser(User):
             host = "http://example.com"
+
         class MyUser2(User):
             host = "http://example.com"
+
         self.environment.user_classes = [MyUser, MyUser2]
         response = requests.get("http://127.0.0.1:%i/" % self.web_port)
         self.assertEqual(200, response.status_code)
         self.assertIn("http://example.com", response.content.decode("utf-8"))
         self.assertNotIn("setting this will override the host on all User classes", response.content.decode("utf-8"))
-    
+
     def test_host_value_from_multiple_user_classes_different_hosts(self):
         class MyUser(User):
             host = None
+
         class MyUser2(User):
             host = "http://example.com"
+
         self.environment.user_classes = [MyUser, MyUser2]
         response = requests.get("http://127.0.0.1:%i/" % self.web_port)
         self.assertEqual(200, response.status_code)
@@ -269,14 +275,16 @@ class TestWebUI(LocustTestCase):
     def test_swarm_in_step_load_mode(self):
         class MyUser(User):
             wait_time = constant(1)
+
             @task(1)
             def my_task(self):
                 pass
+
         self.environment.user_classes = [MyUser]
         self.environment.step_load = True
         response = requests.post(
             "http://127.0.0.1:%i/swarm" % self.web_port,
-            data={"user_count":5, "hatch_rate":2, "step_user_count":2, "step_duration": "2m"}
+            data={"user_count": 5, "hatch_rate": 2, "step_user_count": 2, "step_duration": "2m"},
         )
         self.assertEqual(200, response.status_code)
         self.assertIn("Step Load Mode", response.text)
@@ -301,11 +309,14 @@ class TestWebUIAuth(LocustTestCase):
         self.runner.quit()
 
     def test_index_with_basic_auth_enabled_correct_credentials(self):
-        self.assertEqual(200, requests.get("http://127.0.0.1:%i/?ele=phino" % self.web_port, auth=('john', 'doe')).status_code)
+        self.assertEqual(
+            200, requests.get("http://127.0.0.1:%i/?ele=phino" % self.web_port, auth=("john", "doe")).status_code
+        )
 
     def test_index_with_basic_auth_enabled_incorrect_credentials(self):
-        self.assertEqual(401, requests.get("http://127.0.0.1:%i/?ele=phino" % self.web_port,
-                                           auth=('john', 'invalid')).status_code)
+        self.assertEqual(
+            401, requests.get("http://127.0.0.1:%i/?ele=phino" % self.web_port, auth=("john", "invalid")).status_code
+        )
 
     def test_index_with_basic_auth_enabled_blank_credentials(self):
         self.assertEqual(401, requests.get("http://127.0.0.1:%i/?ele=phino" % self.web_port).status_code)
@@ -317,16 +328,13 @@ class TestWebUIWithTLS(LocustTestCase):
         tls_cert, tls_key = create_tls_cert("127.0.0.1")
         self.tls_cert_file = NamedTemporaryFile(delete=False)
         self.tls_key_file = NamedTemporaryFile(delete=False)
-        with open(self.tls_cert_file.name, 'w') as f:
+        with open(self.tls_cert_file.name, "w") as f:
             f.write(tls_cert.decode())
-        with open(self.tls_key_file.name, 'w') as f:
+        with open(self.tls_key_file.name, "w") as f:
             f.write(tls_key.decode())
 
         parser = get_parser(default_config_files=[])
-        options = parser.parse_args([
-            "--tls-cert", self.tls_cert_file.name,
-            "--tls-key", self.tls_key_file.name,
-        ])
+        options = parser.parse_args(["--tls-cert", self.tls_cert_file.name, "--tls-key", self.tls_key_file.name])
         self.runner = Runner(self.environment)
         self.stats = self.runner.stats
         self.web_ui = self.environment.create_web_ui("127.0.0.1", 0, tls_cert=options.tls_cert, tls_key=options.tls_key)
@@ -343,5 +351,6 @@ class TestWebUIWithTLS(LocustTestCase):
     def test_index_with_https(self):
         # Suppress only the single warning from urllib3 needed.
         from urllib3.exceptions import InsecureRequestWarning
+
         requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
         self.assertEqual(200, requests.get("https://127.0.0.1:%i/" % self.web_port, verify=False).status_code)

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -5,11 +5,12 @@ from locust.rpc import zmqrpc, Message
 from locust.test.testcases import LocustTestCase
 from locust.exception import RPCError
 
+
 class ZMQRPC_tests(LocustTestCase):
     def setUp(self):
         super(ZMQRPC_tests, self).setUp()
-        self.server = zmqrpc.Server('127.0.0.1', 0)
-        self.client = zmqrpc.Client('localhost', self.server.port, 'identity')
+        self.server = zmqrpc.Server("127.0.0.1", 0)
+        self.client = zmqrpc.Client("localhost", self.server.port, "identity")
 
     def tearDown(self):
         self.server.close()
@@ -23,34 +24,32 @@ class ZMQRPC_tests(LocustTestCase):
         self.assertEqual(self.client.socket.getsockopt(zmq.TCP_KEEPALIVE_IDLE), 30)
 
     def test_client_send(self):
-        self.client.send(Message('test', 'message', 'identity'))
+        self.client.send(Message("test", "message", "identity"))
         addr, msg = self.server.recv_from_client()
-        self.assertEqual(addr, 'identity')
-        self.assertEqual(msg.type, 'test')
-        self.assertEqual(msg.data, 'message')
+        self.assertEqual(addr, "identity")
+        self.assertEqual(msg.type, "test")
+        self.assertEqual(msg.data, "message")
 
     def test_client_recv(self):
         sleep(0.1)
-        # We have to wait for the client to finish connecting 
+        # We have to wait for the client to finish connecting
         # before sending a msg to it.
-        self.server.send_to_client(Message('test', 'message', 'identity'))
+        self.server.send_to_client(Message("test", "message", "identity"))
         msg = self.client.recv()
-        self.assertEqual(msg.type, 'test')
-        self.assertEqual(msg.data, 'message')
-        self.assertEqual(msg.node_id, 'identity')
+        self.assertEqual(msg.type, "test")
+        self.assertEqual(msg.data, "message")
+        self.assertEqual(msg.node_id, "identity")
 
     def test_client_retry(self):
-        server = zmqrpc.Server('127.0.0.1', 0)
+        server = zmqrpc.Server("127.0.0.1", 0)
         server.socket.close()
         with self.assertRaises(RPCError):
             server.recv_from_client()
 
     def test_rpc_error(self):
-        server = zmqrpc.Server('127.0.0.1', 5557)
+        server = zmqrpc.Server("127.0.0.1", 5557)
         with self.assertRaises(RPCError):
-            server = zmqrpc.Server('127.0.0.1', 5557)
+            server = zmqrpc.Server("127.0.0.1", 5557)
         server.close()
         with self.assertRaises(RPCError):
-            server.send_to_client(Message('test', 'message', 'identity'))
-        
-    
+            server.send_to_client(Message("test", "message", "identity"))

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -9,8 +9,7 @@ from io import BytesIO
 
 import gevent
 import gevent.pywsgi
-from flask import (Flask, Response, make_response, redirect, request,
-                   send_file, stream_with_context)
+from flask import Flask, Response, make_response, redirect, request, send_file, stream_with_context
 
 import locust
 from locust import log
@@ -21,14 +20,17 @@ from locust.test.mock_logging import MockedLoggingHandler
 
 app = Flask(__name__)
 
+
 @app.route("/ultra_fast")
 def ultra_fast():
     return "This is an ultra fast response"
+
 
 @app.route("/fast")
 def fast():
     gevent.sleep(random.choice([0.1, 0.2, 0.3]))
     return "This is a fast response"
+
 
 @app.route("/slow")
 def slow():
@@ -39,35 +41,43 @@ def slow():
         gevent.sleep(random.choice([0.5, 1, 1.5]))
     return "This is a slow response"
 
+
 @app.route("/consistent")
 def consistent():
     gevent.sleep(0.2)
     return "This is a consistent response"
 
+
 @app.route("/request_method", methods=["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH"])
 def request_method():
     return request.method
 
+
 @app.route("/request_header_test")
 def request_header_test():
     return request.headers["X-Header-Test"]
+
 
 @app.route("/post", methods=["POST"])
 @app.route("/put", methods=["PUT"])
 def manipulate():
     return str(request.form.get("arg", ""))
 
+
 @app.route("/get_arg", methods=["GET"])
 def get_arg():
     return request.args.get("arg")
+
 
 @app.route("/fail")
 def failed_request():
     return "This response failed", 500
 
+
 @app.route("/status/204")
 def status_204():
     return "", 204
+
 
 @app.route("/redirect", methods=["GET", "POST"])
 def do_redirect():
@@ -77,43 +87,53 @@ def do_redirect():
     url = request.args.get("url", "/ultra_fast")
     return redirect(url)
 
+
 @app.route("/basic_auth")
 def basic_auth():
-    auth = base64.b64decode(request.headers.get("Authorization", "").replace("Basic ", "")).decode('utf-8')
+    auth = base64.b64decode(request.headers.get("Authorization", "").replace("Basic ", "")).decode("utf-8")
     if auth == "locust:menace":
         return "Authorized"
     resp = make_response("401 Authorization Required", 401)
     resp.headers["WWW-Authenticate"] = 'Basic realm="Locust"'
     return resp
 
+
 @app.route("/no_content_length")
 def no_content_length():
-    r = send_file(BytesIO("This response does not have content-length in the header".encode('utf-8')),
-                  add_etags=False,
-                  mimetype='text/plain')
+    r = send_file(
+        BytesIO("This response does not have content-length in the header".encode("utf-8")),
+        add_etags=False,
+        mimetype="text/plain",
+    )
     r.headers.remove("Content-Length")
     return r
+
 
 @app.errorhandler(404)
 def not_found(error):
     return "Not Found", 404
 
+
 @app.route("/streaming/<int:iterations>")
 def streaming_response(iterations):
     import time
+
     def generate():
         yield "<html><body><h1>streaming response</h1>"
         for i in range(iterations):
             yield "<span>%s</span>\n" % i
             time.sleep(0.01)
         yield "</body></html>"
+
     return Response(stream_with_context(generate()), mimetype="text/html")
+
 
 @app.route("/set_cookie", methods=["POST"])
 def set_cookie():
     response = make_response("ok")
     response.set_cookie(request.args.get("name"), request.args.get("value"))
     return response
+
 
 @app.route("/get_cookie")
 def get_cookie():
@@ -125,17 +145,18 @@ class LocustTestCase(unittest.TestCase):
     Test case class that restores locust.events.EventHook listeners on tearDown, so that it is
     safe to register any custom event handlers within the test.
     """
+
     def setUp(self):
         # Prevent args passed to test runner from being passed to Locust
         del sys.argv[1:]
-        
+
         locust.events = Events()
         self.environment = Environment(events=locust.events, catch_exceptions=False)
         self.runner = self.environment.create_local_runner()
-        
-        # When running the tests in Python 3 we get warnings about unclosed sockets. 
-        # This causes tests that depends on calls to sys.stderr to fail, so we'll 
-        # suppress those warnings. For more info see: 
+
+        # When running the tests in Python 3 we get warnings about unclosed sockets.
+        # This causes tests that depends on calls to sys.stderr to fail, so we'll
+        # suppress those warnings. For more info see:
         # https://github.com/requests/requests/issues/1882
         try:
             warnings.filterwarnings(action="ignore", message="unclosed <socket object", category=ResourceWarning)
@@ -143,7 +164,7 @@ class LocustTestCase(unittest.TestCase):
             # ResourceWarning doesn't exist in Python 2, but since the warning only appears
             # on Python 3 we don't need to mock it. Instead we can happily ignore the exception
             pass
-        
+
         # set up mocked logging handler
         self._logger_class = MockedLoggingHandler()
         self._logger_class.setLevel(logging.INFO)
@@ -152,10 +173,10 @@ class LocustTestCase(unittest.TestCase):
         logging.root.addHandler(self._logger_class)
         logging.root.setLevel(logging.INFO)
         self.mocked_log = MockedLoggingHandler
-        
+
         # set unandled exception flag to False
         log.unhandled_greenlet_exception = False
-                      
+
     def tearDown(self):
         # restore logging class
         logging.root.removeHandler(self._logger_class)
@@ -167,6 +188,7 @@ class WebserverTestCase(LocustTestCase):
     """
     Test case class that sets up an HTTP server which can be used within the tests
     """
+
     def setUp(self):
         super(WebserverTestCase, self).setUp()
         self._web_server = gevent.pywsgi.WSGIServer(("127.0.0.1", 0), app, log=None)

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
+
 @contextmanager
 def temporary_file(content, suffix="_locustfile.py"):
     f = NamedTemporaryFile(suffix=suffix, delete=False)
@@ -37,7 +38,7 @@ def get_free_tcp_port():
 
 def create_tls_cert(hostname):
     """ Generate a TLS cert and private key to serve over https """
-    key = rsa.generate_private_key(public_exponent=2**16+1, key_size=2048, backend=default_backend())
+    key = rsa.generate_private_key(public_exponent=2 ** 16 + 1, key_size=2048, backend=default_backend())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
     now = datetime.utcnow()
     cert = (
@@ -47,7 +48,7 @@ def create_tls_cert(hostname):
         .public_key(key.public_key())
         .serial_number(1000)
         .not_valid_before(now)
-        .not_valid_after(now + timedelta(days=10*365))
+        .not_valid_after(now + timedelta(days=10 * 365))
         .sign(key, hashes.SHA256(), default_backend())
     )
     cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM)

--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -8,34 +8,35 @@ def print_task_ratio(user_classes, total=False, level=0, parent_ratio=1.0):
     d = get_task_ratio_dict(user_classes, total=total, parent_ratio=parent_ratio)
     _print_task_ratio(d)
 
+
 def _print_task_ratio(x, level=0):
     for k, v in x.items():
-        padding = 2*" "*level
-        ratio = v.get('ratio', 1)
-        print(" %-10s %-50s" % (padding + "%-6.1f" % (ratio*100), padding + k))
-        if 'tasks' in v:
-            _print_task_ratio(v['tasks'], level + 1)
+        padding = 2 * " " * level
+        ratio = v.get("ratio", 1)
+        print(" %-10s %-50s" % (padding + "%-6.1f" % (ratio * 100), padding + k))
+        if "tasks" in v:
+            _print_task_ratio(v["tasks"], level + 1)
 
 
 def get_task_ratio_dict(tasks, total=False, parent_ratio=1.0):
     """
     Return a dict containing task execution ratio info
     """
-    if hasattr(tasks[0], 'weight'):
+    if hasattr(tasks[0], "weight"):
         divisor = sum(t.weight for t in tasks)
     else:
         divisor = len(tasks) / parent_ratio
     ratio = {}
     for task in tasks:
         ratio.setdefault(task, 0)
-        ratio[task] += task.weight if hasattr(task, 'weight') else 1
+        ratio[task] += task.weight if hasattr(task, "weight") else 1
 
     # get percentage
     ratio_percent = dict((k, float(v) / divisor) for k, v in ratio.items())
 
     task_dict = {}
     for locust, ratio in ratio_percent.items():
-        d = {"ratio":ratio}
+        d = {"ratio": ratio}
         if inspect.isclass(locust):
             if issubclass(locust, (User, TaskSet)):
                 T = locust.tasks
@@ -43,7 +44,7 @@ def get_task_ratio_dict(tasks, total=False, parent_ratio=1.0):
                 d["tasks"] = get_task_ratio_dict(T, total, ratio)
             else:
                 d["tasks"] = get_task_ratio_dict(T, total)
-        
+
         task_dict[locust.__name__] = d
 
     return task_dict

--- a/locust/user/sequential_taskset.py
+++ b/locust/user/sequential_taskset.py
@@ -4,12 +4,13 @@ from .task import TaskSet, TaskSetMeta
 
 class SequentialTaskSetMeta(TaskSetMeta):
     """
-    Meta class for SequentialTaskSet. It's used to allow SequentialTaskSet classes to specify 
+    Meta class for SequentialTaskSet. It's used to allow SequentialTaskSet classes to specify
     task execution in both a list as the tasks attribute or using the @task decorator
-    
+
     We use the fact that class_dict order is the order of declaration in Python 3.6
     (See https://www.python.org/dev/peps/pep-0520/)
     """
+
     def __new__(mcs, classname, bases, class_dict):
         new_tasks = []
         for base in bases:
@@ -18,17 +19,17 @@ class SequentialTaskSetMeta(TaskSetMeta):
                 new_tasks += base.tasks
         for key, value in class_dict.items():
             if key == "tasks":
-                # we want to insert tasks from the tasks attribute at the point of it's declaration 
+                # we want to insert tasks from the tasks attribute at the point of it's declaration
                 # compared to methods declared with @task
                 if isinstance(value, list):
                     new_tasks.extend(value)
                 else:
                     raise ValueError("On SequentialTaskSet the task attribute can only be set to a list")
-            
+
             if "locust_task_weight" in dir(value):
                 # method decorated with @task
                 new_tasks.append(value)
-        
+
         class_dict["tasks"] = new_tasks
         return type.__new__(mcs, classname, bases, class_dict)
 
@@ -36,21 +37,24 @@ class SequentialTaskSetMeta(TaskSetMeta):
 class SequentialTaskSet(TaskSet, metaclass=SequentialTaskSetMeta):
     """
     Class defining a sequence of tasks that a User will execute.
-    
-    Works like TaskSet, but task weight is ignored, and all tasks are executed in order. Tasks can 
-    either be specified by setting the *tasks* attribute to a list of tasks, or by declaring tasks 
-    as methods using the @task decorator. The order of declaration decides the order of execution. 
-    
-    It's possible to combine a task list in the *tasks* attribute, with some tasks declared using 
+
+    Works like TaskSet, but task weight is ignored, and all tasks are executed in order. Tasks can
+    either be specified by setting the *tasks* attribute to a list of tasks, or by declaring tasks
+    as methods using the @task decorator. The order of declaration decides the order of execution.
+
+    It's possible to combine a task list in the *tasks* attribute, with some tasks declared using
     the @task decorator. The order of declaration is respected also in that case.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._task_index = 0
 
     def get_next_task(self):
         if not self.tasks:
-            raise LocustError("No tasks defined. use the @task decorator or set the tasks property of the SequentialTaskSet")
+            raise LocustError(
+                "No tasks defined. use the @task decorator or set the tasks property of the SequentialTaskSet"
+            )
         task = self.tasks[self._task_index % len(self.tasks)]
         self._task_index += 1
         return task

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -7,8 +7,7 @@ from time import time
 import gevent
 from gevent import GreenletExit
 
-from locust.exception import InterruptTaskSet, RescheduleTask, RescheduleTaskImmediately, \
-     StopUser, MissingWaitTimeError
+from locust.exception import InterruptTaskSet, RescheduleTask, RescheduleTaskImmediately, StopUser, MissingWaitTimeError
 
 
 logger = logging.getLogger(__name__)
@@ -20,24 +19,24 @@ def task(weight=1):
     """
     Used as a convenience decorator to be able to declare tasks for a User or a TaskSet
     inline in the class. Example::
-    
+
         class ForumPage(TaskSet):
             @task(100)
             def read_thread(self):
                 pass
-            
+
             @task(7)
             def create_thread(self):
                 pass
     """
-    
+
     def decorator_func(func):
         func.locust_task_weight = weight
         return func
-    
+
     """
     Check if task was used without parentheses (not called), like this::
-    
+
         @task
         def my_task()
             pass
@@ -75,18 +74,19 @@ def tag(*tags):
     """
 
     def decorator_func(decorated):
-        if hasattr(decorated, 'tasks'):
+        if hasattr(decorated, "tasks"):
             decorated.tasks = list(map(tag(*tags), decorated.tasks))
         else:
-            if 'locust_tag_set' not in decorated.__dict__:
+            if "locust_tag_set" not in decorated.__dict__:
                 decorated.locust_tag_set = set()
             decorated.locust_tag_set |= set(tags)
         return decorated
 
     if len(tags) == 0 or callable(tags[0]):
-        raise ValueError('No tag name was supplied')
+        raise ValueError("No tag name was supplied")
 
     return decorator_func
+
 
 def get_tasks_from_base_classes(bases, class_dict):
     """
@@ -97,12 +97,12 @@ def get_tasks_from_base_classes(bases, class_dict):
     for base in bases:
         if hasattr(base, "tasks") and base.tasks:
             new_tasks += base.tasks
-    
+
     if "tasks" in class_dict and class_dict["tasks"] is not None:
         tasks = class_dict["tasks"]
         if isinstance(tasks, dict):
             tasks = tasks.items()
-        
+
         for task in tasks:
             if isinstance(task, tuple):
                 task, count = task
@@ -110,13 +110,14 @@ def get_tasks_from_base_classes(bases, class_dict):
                     new_tasks.append(task)
             else:
                 new_tasks.append(task)
-    
+
     for item in class_dict.values():
         if "locust_task_weight" in dir(item):
             for i in range(0, item.locust_task_weight):
                 new_tasks.append(item)
-    
+
     return new_tasks
+
 
 def filter_tasks_by_tags(task_holder, tags=None, exclude_tags=None, checked=None):
     """
@@ -134,14 +135,14 @@ def filter_tasks_by_tags(task_holder, tags=None, exclude_tags=None, checked=None
             continue
 
         passing = True
-        if hasattr(task, 'tasks'):
+        if hasattr(task, "tasks"):
             filter_tasks_by_tags(task, tags, exclude_tags, checked)
             passing = len(task.tasks) > 0
         else:
             if tags is not None:
-                passing &= 'locust_tag_set' in dir(task) and len(task.locust_tag_set & tags) > 0
+                passing &= "locust_tag_set" in dir(task) and len(task.locust_tag_set & tags) > 0
             if exclude_tags is not None:
-                passing &= 'locust_tag_set' not in dir(task) or len(task.locust_tag_set & exclude_tags) == 0
+                passing &= "locust_tag_set" not in dir(task) or len(task.locust_tag_set & exclude_tags) == 0
 
         if passing:
             new_tasks.append(task)
@@ -149,12 +150,13 @@ def filter_tasks_by_tags(task_holder, tags=None, exclude_tags=None, checked=None
 
     task_holder.tasks = new_tasks
 
+
 class TaskSetMeta(type):
     """
     Meta class for the main User class. It's used to allow User classes to specify task execution
     ratio using an {task:int} dict, or a [(task0,int), ..., (taskN,int)] list.
     """
-    
+
     def __new__(mcs, classname, bases, class_dict):
         class_dict["tasks"] = get_tasks_from_base_classes(bases, class_dict)
         return type.__new__(mcs, classname, bases, class_dict)
@@ -163,57 +165,57 @@ class TaskSetMeta(type):
 class TaskSet(object, metaclass=TaskSetMeta):
     """
     Class defining a set of tasks that a User will execute.
-    
-    When a TaskSet starts running, it will pick a task from the *tasks* attribute, 
+
+    When a TaskSet starts running, it will pick a task from the *tasks* attribute,
     execute it, and then sleep for the number of seconds returned by its *wait_time*
-    function. If no wait_time method has been declared on the TaskSet, it'll call the 
+    function. If no wait_time method has been declared on the TaskSet, it'll call the
     wait_time function on the User by default. It will then schedule another task
     for execution and so on.
-    
-    TaskSets can be nested, which means that a TaskSet's *tasks* attribute can contain 
+
+    TaskSets can be nested, which means that a TaskSet's *tasks* attribute can contain
     another TaskSet. If the nested TaskSet is scheduled to be executed, it will be
     instantiated and called from the currently executing TaskSet. Execution in the
-    currently running TaskSet will then be handed over to the nested TaskSet which will 
-    continue to run until it throws an InterruptTaskSet exception, which is done when 
-    :py:meth:`TaskSet.interrupt() <locust.TaskSet.interrupt>` is called. (execution 
+    currently running TaskSet will then be handed over to the nested TaskSet which will
+    continue to run until it throws an InterruptTaskSet exception, which is done when
+    :py:meth:`TaskSet.interrupt() <locust.TaskSet.interrupt>` is called. (execution
     will then continue in the first TaskSet).
     """
-    
+
     tasks = []
     """
     Collection of python callables and/or TaskSet classes that the User(s) will run.
 
     If tasks is a list, the task to be performed will be picked randomly.
 
-    If tasks is a *(callable,int)* list of two-tuples, or a {callable:int} dict, 
-    the task to be performed will be picked randomly, but each task will be weighted 
-    according to its corresponding int value. So in the following case, *ThreadPage* will 
+    If tasks is a *(callable,int)* list of two-tuples, or a {callable:int} dict,
+    the task to be performed will be picked randomly, but each task will be weighted
+    according to its corresponding int value. So in the following case, *ThreadPage* will
     be fifteen times more likely to be picked than *write_post*::
 
         class ForumPage(TaskSet):
             tasks = {ThreadPage:15, write_post:1}
     """
-    
+
     min_wait = None
     """
-    Deprecated: Use wait_time instead. 
-    Minimum waiting time between the execution of user tasks. Can be used to override 
-    the min_wait defined in the root User class, which will be used if not set on the 
+    Deprecated: Use wait_time instead.
+    Minimum waiting time between the execution of user tasks. Can be used to override
+    the min_wait defined in the root User class, which will be used if not set on the
     TaskSet.
     """
-    
+
     max_wait = None
     """
-    Deprecated: Use wait_time instead. 
-    Maximum waiting time between the execution of user tasks. Can be used to override 
-    the max_wait defined in the root User class, which will be used if not set on the 
+    Deprecated: Use wait_time instead.
+    Maximum waiting time between the execution of user tasks. Can be used to override
+    the max_wait defined in the root User class, which will be used if not set on the
     TaskSet.
     """
-    
+
     wait_function = None
     """
     Deprecated: Use wait_time instead.
-    Function used to calculate waiting time between the execution of user tasks in milliseconds. 
+    Function used to calculate waiting time between the execution of user tasks in milliseconds.
     Can be used to override the wait_function defined in the root User class, which will be used
     if not set on the TaskSet.
     """
@@ -224,14 +226,14 @@ class TaskSet(object, metaclass=TaskSetMeta):
     def __init__(self, parent):
         self._task_queue = []
         self._time_start = time()
-        
+
         if isinstance(parent, TaskSet):
             self._user = parent.user
         else:
             self._user = parent
 
         self._parent = parent
-        
+
         # if this class doesn't have a min_wait, max_wait or wait_function defined, copy it from Locust
         if not self.min_wait:
             self.min_wait = self.user.min_wait
@@ -239,8 +241,6 @@ class TaskSet(object, metaclass=TaskSetMeta):
             self.max_wait = self.user.max_wait
         if not self.wait_function:
             self.wait_function = self.user.wait_function
-
-
 
     @property
     def user(self):
@@ -257,7 +257,7 @@ class TaskSet(object, metaclass=TaskSetMeta):
         Called when a User starts executing this TaskSet
         """
         pass
-    
+
     def on_stop(self):
         """
         Called when a User stops executing this TaskSet. E.g. when TaskSet.interrupt() is called
@@ -273,12 +273,12 @@ class TaskSet(object, metaclass=TaskSetMeta):
                 raise RescheduleTaskImmediately(e.reschedule).with_traceback(sys.exc_info()[2])
             else:
                 raise RescheduleTask(e.reschedule).with_traceback(sys.exc_info()[2])
-        
-        while (True):
+
+        while True:
             try:
                 if not self._task_queue:
                     self.schedule_task(self.get_next_task())
-                
+
                 try:
                     self._check_stop_condition()
                     self.execute_next_task()
@@ -304,10 +304,10 @@ class TaskSet(object, metaclass=TaskSetMeta):
                     self.wait()
                 else:
                     raise
-    
+
     def execute_next_task(self):
         self.execute_task(self._task_queue.pop(0))
-    
+
     def execute_task(self, task):
         # check if the function is a method bound to the current locust, and if so, don't pass self as first argument
         if hasattr(task, "__self__") and task.__self__ == self:
@@ -319,11 +319,11 @@ class TaskSet(object, metaclass=TaskSetMeta):
         else:
             # task is a function
             task(self)
-    
+
     def schedule_task(self, task_callable, first=False):
         """
         Add a task to the User's task execution queue.
-        
+
         :param task_callable: User task to schedule.
         :param args: Arguments that will be passed to the task callable.
         :param kwargs: Dict of keyword arguments that will be passed to the task callable.
@@ -333,18 +333,18 @@ class TaskSet(object, metaclass=TaskSetMeta):
             self._task_queue.insert(0, task_callable)
         else:
             self._task_queue.append(task_callable)
-    
+
     def get_next_task(self):
         if not self.tasks:
             raise Exception("No tasks defined. use the @task decorator or set the tasks property of the TaskSet")
         return random.choice(self.tasks)
-    
+
     def wait_time(self):
         """
-        Method that returns the time (in seconds) between the execution of tasks. 
-        
+        Method that returns the time (in seconds) between the execution of tasks.
+
         Example::
-        
+
             from locust import TaskSet, between
             class Tasks(TaskSet):
                 wait_time = between(3, 25)
@@ -354,11 +354,11 @@ class TaskSet(object, metaclass=TaskSetMeta):
         elif self.min_wait is not None and self.max_wait is not None:
             return random.randint(self.min_wait, self.max_wait) / 1000.0
         else:
-            raise MissingWaitTimeError("You must define a wait_time method on either the %s or %s class" % (
-                type(self.user).__name__, 
-                type(self).__name__,
-            ))
-    
+            raise MissingWaitTimeError(
+                "You must define a wait_time method on either the %s or %s class"
+                % (type(self.user).__name__, type(self).__name__,)
+            )
+
     def wait(self):
         """
         Make the running user sleep for a duration defined by the Locust.wait_time
@@ -377,20 +377,20 @@ class TaskSet(object, metaclass=TaskSetMeta):
 
     def _sleep(self, seconds):
         gevent.sleep(seconds)
-    
+
     def _check_stop_condition(self):
         if self.user._state == LOCUST_STATE_STOPPING:
             raise StopUser()
-    
+
     def interrupt(self, reschedule=True):
         """
         Interrupt the TaskSet and hand over execution control back to the parent TaskSet.
-        
+
         If *reschedule* is True (default), the parent User will immediately re-schedule,
         and execute, a new task.
         """
         raise InterruptTaskSet(reschedule)
-    
+
     @property
     def client(self):
         """
@@ -404,11 +404,12 @@ class DefaultTaskSet(TaskSet):
     Default root TaskSet that executes tasks in User.tasks.
     It executes tasks declared directly on the Locust with the user instance as the task argument.
     """
+
     def get_next_task(self):
         if not self.user.tasks:
             raise Exception("No tasks defined. use the @task decorator or set the tasks property of the User")
         return random.choice(self.user.tasks)
-    
+
     def execute_task(self, task):
         if hasattr(task, "tasks") and issubclass(task, TaskSet):
             # task is  (nested) TaskSet class
@@ -416,4 +417,3 @@ class DefaultTaskSet(TaskSet):
         else:
             # task is a function
             task(self.user)
-

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -3,15 +3,21 @@ from gevent import GreenletExit, greenlet
 from locust.clients import HttpSession
 from locust.exception import LocustError, StopUser
 from locust.util import deprecation
-from .task import DefaultTaskSet, get_tasks_from_base_classes, \
-     LOCUST_STATE_RUNNING, LOCUST_STATE_WAITING, LOCUST_STATE_STOPPING
+from .task import (
+    DefaultTaskSet,
+    get_tasks_from_base_classes,
+    LOCUST_STATE_RUNNING,
+    LOCUST_STATE_WAITING,
+    LOCUST_STATE_STOPPING,
+)
 
 
 class NoClientWarningRaiser(object):
     """
-    The purpose of this class is to emit a sensible error message for old test scripts that 
+    The purpose of this class is to emit a sensible error message for old test scripts that
     inherit from User, and expects there to be an HTTP client under the client attribute.
     """
+
     def __getattr__(self, _):
         raise LocustError("No client instantiated. Did you intend to inherit from HttpUser?")
 
@@ -21,72 +27,73 @@ class UserMeta(type):
     Meta class for the main User class. It's used to allow User classes to specify task execution
     ratio using an {task:int} dict, or a [(task0,int), ..., (taskN,int)] list.
     """
+
     def __new__(mcs, classname, bases, class_dict):
         # gather any tasks that is declared on the class (or it's bases)
-        tasks = get_tasks_from_base_classes(bases, class_dict)   
+        tasks = get_tasks_from_base_classes(bases, class_dict)
         class_dict["tasks"] = tasks
-        
+
         if not class_dict.get("abstract"):
             # Not a base class
             class_dict["abstract"] = False
-        
+
         deprecation.check_for_deprecated_task_set_attribute(class_dict)
-        
+
         return type.__new__(mcs, classname, bases, class_dict)
 
 
 class User(object, metaclass=UserMeta):
     """
     Represents a "user" which is to be hatched and attack the system that is to be load tested.
-    
+
     The behaviour of this user is defined by its tasks. Tasks can be declared either directly on the
     class by using the :py:func:`@task decorator <locust.task>` on methods, or by setting
     the :py:attr:`tasks attribute <locust.User.tasks>`.
-    
-    This class should usually be subclassed by a class that defines some kind of client. For 
-    example when load testing an HTTP system, you probably want to use the 
+
+    This class should usually be subclassed by a class that defines some kind of client. For
+    example when load testing an HTTP system, you probably want to use the
     :py:class:`HttpUser <locust.HttpUser>` class.
     """
-    
+
     host = None
     """Base hostname to swarm. i.e: http://127.0.0.1:1234"""
-    
+
     min_wait = None
     """Deprecated: Use wait_time instead. Minimum waiting time between the execution of locust tasks"""
-    
+
     max_wait = None
     """Deprecated: Use wait_time instead. Maximum waiting time between the execution of locust tasks"""
-    
+
     wait_time = None
     """
-    Method that returns the time (in seconds) between the execution of locust tasks. 
+    Method that returns the time (in seconds) between the execution of locust tasks.
     Can be overridden for individual TaskSets.
-    
+
     Example::
-    
+
         from locust import User, between
         class MyUser(User):
             wait_time = between(3, 25)
     """
-    
+
     wait_function = None
     """
     .. warning::
-    
+
         DEPRECATED: Use wait_time instead. Note that the new wait_time method should return seconds and not milliseconds.
-    
+
     Method that returns the time between the execution of locust tasks in milliseconds
     """
-    
+
     tasks = []
     """
     Collection of python callables and/or TaskSet classes that the Locust user(s) will run.
 
     If tasks is a list, the task to be performed will be picked randomly.
 
-    If tasks is a *(callable,int)* list of two-tuples, or a {callable:int} dict, 
-    the task to be performed will be picked randomly, but each task will be weighted 
-    according to its corresponding int value. So in the following case, *ThreadPage* will 
+    If tasks is a *(callable,int)* list of two-tuples, or a {callable:int} dict,
+    the task to be performed will be picked randomly, but each task will be weighted
+    according to its corresponding int value. So in the following case, *ThreadPage* will
     be fifteen times more likely to be picked than *write_post*::
 
         class ForumPage(TaskSet):
@@ -95,10 +102,10 @@ class User(object, metaclass=UserMeta):
 
     weight = 10
     """Probability of user class being chosen. The higher the weight, the greater the chance of it being chosen."""
-    
+
     abstract = True
     """If abstract is True, the class is meant to be subclassed, and locust will not spawn users of this class during a test."""
-    
+
     environment = None
     """A reference to the :py:attr:`environment <locust.Environment>` in which this locust is running"""
 
@@ -110,31 +117,31 @@ class User(object, metaclass=UserMeta):
     def __init__(self, environment):
         super(User, self).__init__()
         self.environment = environment
-    
+
     def on_start(self):
         """
         Called when a User starts running.
         """
         pass
-    
+
     def on_stop(self):
         """
         Called when a User stops running (is killed)
         """
         pass
-    
+
     def run(self):
         self._state = LOCUST_STATE_RUNNING
         self._taskset_instance = DefaultTaskSet(self)
         try:
             # run the TaskSet on_start method, if it has one
             self.on_start()
-            
+
             self._taskset_instance.run()
         except (GreenletExit, StopUser) as e:
             # run the on_stop method, if it has one
             self.on_stop()
-    
+
     def wait(self):
         """
         Make the running user sleep for a duration defined by the User.wait_time
@@ -150,11 +157,12 @@ class User(object, metaclass=UserMeta):
     def start(self, gevent_group):
         """
         Start a greenlet that runs this User instance.
-        
+
         :param gevent_group: Group instance where the greenlet will be spawned.
         :type gevent_group: gevent.pool.Group
         :returns: The spawned greenlet.
         """
+
         def run_user(user):
             """
             Main function for User greenlet. It's important that this function takes the user
@@ -162,13 +170,14 @@ class User(object, metaclass=UserMeta):
             User instance.
             """
             user.run()
+
         self._greenlet = gevent_group.spawn(run_user, self)
         return self._greenlet
-    
+
     def stop(self, gevent_group, force=False):
         """
         Stop the user greenlet that exists in the gevent_group.
-        
+
         :param gevent_group: Group instance where the greenlet will be spawned.
         :type gevent_group: gevent.pool.Group
         :param force: If False (the default) the stopping is done gracefully by setting the state to LOCUST_STATE_STOPPING
@@ -191,32 +200,34 @@ class User(object, metaclass=UserMeta):
 class HttpUser(User):
     """
     Represents an HTTP "user" which is to be hatched and attack the system that is to be load tested.
-    
+
     The behaviour of this user is defined by its tasks. Tasks can be declared either directly on the
     class by using the :py:func:`@task decorator <locust.task>` on methods, or by setting
     the :py:attr:`tasks attribute <locust.User.tasks>`.
-    
-    This class creates a *client* attribute on instantiation which is an HTTP client with support 
+
+    This class creates a *client* attribute on instantiation which is an HTTP client with support
     for keeping a user session between requests.
     """
-    
+
     abstract = True
     """If abstract is True, the class is meant to be subclassed, and users will not choose this locust during a test"""
-    
+
     client = None
     """
-    Instance of HttpSession that is created upon instantiation of Locust. 
+    Instance of HttpSession that is created upon instantiation of Locust.
     The client supports cookies, and therefore keeps the session between HTTP requests.
     """
-    
+
     def __init__(self, *args, **kwargs):
         super(HttpUser, self).__init__(*args, **kwargs)
         if self.host is None:
-            raise LocustError("You must specify the base host. Either in the host attribute in the User class, or on the command line using the --host option.")
+            raise LocustError(
+                "You must specify the base host. Either in the host attribute in the User class, or on the command line using the --host option."
+            )
 
         session = HttpSession(
-            base_url=self.host, 
-            request_success=self.environment.events.request_success, 
+            base_url=self.host,
+            request_success=self.environment.events.request_success,
             request_failure=self.environment.events.request_failure,
         )
         session.trust_env = False

--- a/locust/user/wait_time.py
+++ b/locust/user/wait_time.py
@@ -5,9 +5,9 @@ from time import time
 def between(min_wait, max_wait):
     """
     Returns a function that will return a random number between min_wait and max_wait.
-    
+
     Example::
-    
+
         class MyUser(User):
             # wait between 3.0 and 10.5 seconds after each task
             wait_time = between(3.0, 10.5)
@@ -18,9 +18,9 @@ def between(min_wait, max_wait):
 def constant(wait_time):
     """
     Returns a function that just returns the number specified by the wait_time argument
-    
+
     Example::
-    
+
         class MyUser(User):
             wait_time = constant(3)
     """
@@ -29,24 +29,25 @@ def constant(wait_time):
 
 def constant_pacing(wait_time):
     """
-    Returns a function that will track the run time of the tasks, and for each time it's 
-    called it will return a wait time that will try to make the total time between task 
-    execution equal to the time specified by the wait_time argument. 
-    
-    In the following example the task will always be executed once every second, no matter 
+    Returns a function that will track the run time of the tasks, and for each time it's
+    called it will return a wait time that will try to make the total time between task
+    execution equal to the time specified by the wait_time argument.
+
+    In the following example the task will always be executed once every second, no matter
     the task execution time::
-    
+
         class MyUser(User):
             wait_time = constant_pacing(1)
             @task
             def my_task(self):
                 time.sleep(random.random())
-    
-    If a task execution exceeds the specified wait_time, the wait will be 0 before starting 
+
+    If a task execution exceeds the specified wait_time, the wait will be 0 before starting
     the next task.
     """
+
     def wait_time_func(self):
-        if not hasattr(self,"_cp_last_run"):
+        if not hasattr(self, "_cp_last_run"):
             self._cp_last_wait_time = wait_time
             self._cp_last_run = time()
             return wait_time
@@ -55,4 +56,5 @@ def constant_pacing(wait_time):
             self._cp_last_wait_time = max(0, wait_time - run_time)
             self._cp_last_run = time()
             return self._cp_last_wait_time
+
     return wait_time_func

--- a/locust/util/cache.py
+++ b/locust/util/cache.py
@@ -7,29 +7,31 @@ from time import time
 def memoize(timeout, dynamic_timeout=False):
     """
     Memoization decorator with support for timeout.
-    
-    If dynamic_timeout is set, the cache timeout is doubled if the cached function 
+
+    If dynamic_timeout is set, the cache timeout is doubled if the cached function
     takes longer time to run than the timeout time
     """
-    cache = {"timeout":timeout}
+    cache = {"timeout": timeout}
+
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             start = time()
-            if (not "time" in cache) or (start - cache["time"] > cache["timeout"]):
+            if ("time" not in cache) or (start - cache["time"] > cache["timeout"]):
                 # cache miss
                 cache["result"] = func(*args, **kwargs)
                 cache["time"] = time()
                 if dynamic_timeout and cache["time"] - start > cache["timeout"]:
                     cache["timeout"] *= 2
             return cache["result"]
-        
+
         def clear_cache():
             if "time" in cache:
                 del cache["time"]
             if "result" in cache:
                 del cache["result"]
-        
+
         wrapper.clear_cache = clear_cache
         return wrapper
+
     return decorator

--- a/locust/util/deprecation.py
+++ b/locust/util/deprecation.py
@@ -2,16 +2,20 @@ import warnings
 
 
 # Show deprecation warnings
-warnings.filterwarnings('always', category=DeprecationWarning, module="locust")
+warnings.filterwarnings("always", category=DeprecationWarning, module="locust")
 
 
 def check_for_deprecated_task_set_attribute(class_dict):
     from locust.user.task import TaskSet
+
     if "task_set" in class_dict:
         task_set = class_dict["task_set"]
         if issubclass(task_set, TaskSet) and not hasattr(task_set, "locust_task_weight"):
-            warnings.warn("Usage of User.task_set is deprecated since version 1.0. Set the tasks attribute instead "
-                          "(tasks = [%s])" % task_set.__name__, DeprecationWarning)
+            warnings.warn(
+                "Usage of User.task_set is deprecated since version 1.0. Set the tasks attribute instead "
+                "(tasks = [%s])" % task_set.__name__,
+                DeprecationWarning,
+            )
 
 
 def deprecated_locust_meta_class(deprecation_message):
@@ -21,22 +25,32 @@ def deprecated_locust_meta_class(deprecation_message):
                 return super().__new__(mcs, classname, bases, class_dict)
             else:
                 raise ImportError(deprecation_message)
+
     return MetaClass
 
-class DeprecatedLocustClass(metaclass=deprecated_locust_meta_class(
-    "The Locust class has been renamed to User in version 1.0. "
-    "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
-)):
+
+class DeprecatedLocustClass(
+    metaclass=deprecated_locust_meta_class(
+        "The Locust class has been renamed to User in version 1.0. "
+        "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
+    )
+):
     pass
 
-class DeprecatedHttpLocustClass(metaclass=deprecated_locust_meta_class(
-    "The HttpLocust class has been renamed to HttpUser in version 1.0. "
-    "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
-)):
+
+class DeprecatedHttpLocustClass(
+    metaclass=deprecated_locust_meta_class(
+        "The HttpLocust class has been renamed to HttpUser in version 1.0. "
+        "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
+    )
+):
     pass
 
-class DeprecatedFastHttpLocustClass(metaclass=deprecated_locust_meta_class(
-    "The FastHttpLocust class has been renamed to FastHttpUser in version 1.0. "
-    "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
-)):
+
+class DeprecatedFastHttpLocustClass(
+    metaclass=deprecated_locust_meta_class(
+        "The FastHttpLocust class has been renamed to FastHttpUser in version 1.0. "
+        "For more info see: https://docs.locust.io/en/latest/changelog.html#changelog-1-0"
+    )
+):
     pass

--- a/locust/util/exception_handler.py
+++ b/locust/util/exception_handler.py
@@ -3,8 +3,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def retry(delays=(1, 3, 5),
-          exception=Exception):
+
+def retry(delays=(1, 3, 5), exception=Exception):
     def decorator(function):
         def wrapper(*args, **kwargs):
             cnt = 0
@@ -13,12 +13,14 @@ def retry(delays=(1, 3, 5),
                     return function(*args, **kwargs)
                 except exception as e:
                     if delay is None:
-                        logger.info("Retry failed after %d times." % ( cnt ) )
+                        logger.info("Retry failed after %d times." % (cnt))
                         raise
                     else:
                         cnt += 1
-                        logger.info("Exception found on retry %d: -- retry after %ds" % ( cnt, delay ) )
+                        logger.info("Exception found on retry %d: -- retry after %ds" % (cnt, delay))
                         logger.exception(e)
                         time.sleep(delay)
+
         return wrapper
+
     return decorator

--- a/locust/util/timespan.py
+++ b/locust/util/timespan.py
@@ -1,6 +1,7 @@
 import re
 from datetime import timedelta
 
+
 def parse_timespan(time_str):
     """
     Parse a string representing a time span and return the number of seconds.
@@ -8,18 +9,17 @@ def parse_timespan(time_str):
     """
     if not time_str:
         raise ValueError("Invalid time span format")
-    
-    if re.match(r'^\d+$', time_str):
+
+    if re.match(r"^\d+$", time_str):
         # if an int is specified we assume they want seconds
         return int(time_str)
-    
-    timespan_regex = re.compile(r'((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+
+    timespan_regex = re.compile(r"((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?")
     parts = timespan_regex.match(time_str)
     if not parts:
         raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
     parts = parts.groupdict()
-    time_params = {name:int(value) for name, value in parts.items() if value}
+    time_params = {name: int(value) for name, value in parts.items() if value}
     if not time_params:
         raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
     return int(timedelta(**time_params).total_seconds())
-            

--- a/locust/web.py
+++ b/locust/web.py
@@ -32,35 +32,35 @@ DEFAULT_CACHE_TIME = 2.0
 
 class WebUI:
     """
-    Sets up and runs a Flask web app that can start and stop load tests using the 
-    :attr:`environment.runner <locust.env.Environment.runner>` as well as show the load test statistics 
+    Sets up and runs a Flask web app that can start and stop load tests using the
+    :attr:`environment.runner <locust.env.Environment.runner>` as well as show the load test statistics
     in :attr:`environment.stats <locust.env.Environment.stats>`
     """
-    
+
     app = None
     """
     Reference to the :class:`flask.Flask` app. Can be used to add additional web routes and customize
     the Flask app in other various ways. Example::
-    
+
         from flask import request
-        
+
         @web_ui.app.route("/my_custom_route")
         def my_custom_route():
             return "your IP is: %s" % request.remote_addr
     """
-    
+
     greenlet = None
     """
     Greenlet of the running web server
     """
-    
+
     server = None
     """Reference to the :class:`pyqsgi.WSGIServer` instance"""
-    
+
     def __init__(self, environment, host, port, auth_credentials=None, tls_cert=None, tls_key=None):
         """
         Create WebUI instance and start running the web server in a separate greenlet (self.greenlet)
-        
+
         Arguments:
         environment: Reference to the curren Locust Environment
         host: Host/interface that the web server should accept connections to
@@ -85,7 +85,7 @@ class WebUI:
         self.greenlet = None
 
         if auth_credentials is not None:
-            credentials = auth_credentials.split(':')
+            credentials = auth_credentials.split(":")
             if len(credentials) == 2:
                 self.app.config["BASIC_AUTH_USERNAME"] = credentials[0]
                 self.app.config["BASIC_AUTH_PASSWORD"] = credentials[1]
@@ -93,20 +93,22 @@ class WebUI:
                 self.auth = BasicAuth()
                 self.auth.init_app(self.app)
             else:
-                raise AuthCredentialsError("Invalid auth_credentials. It should be a string in the following format: 'user.pass'")
+                raise AuthCredentialsError(
+                    "Invalid auth_credentials. It should be a string in the following format: 'user.pass'"
+                )
 
-        @app.route('/')
+        @app.route("/")
         @self.auth_required_if_enabled
         def index():
             if not environment.runner:
                 return make_response("Error: Locust Environment does not have any runner", 500)
-            
+
             is_distributed = isinstance(environment.runner, MasterRunner)
             if is_distributed:
                 worker_count = environment.runner.worker_count
             else:
                 worker_count = 0
-            
+
             override_host_warning = False
             if environment.host:
                 host = environment.host
@@ -121,9 +123,10 @@ class WebUI:
                     host = None
             else:
                 host = None
-            
+
             options = environment.parsed_options
-            return render_template("index.html",
+            return render_template(
+                "index.html",
                 state=environment.runner.state,
                 is_distributed=is_distributed,
                 user_count=environment.runner.user_count,
@@ -137,38 +140,40 @@ class WebUI:
                 worker_count=worker_count,
                 is_step_load=environment.step_load,
             )
-        
-        @app.route('/swarm', methods=["POST"])
+
+        @app.route("/swarm", methods=["POST"])
         @self.auth_required_if_enabled
         def swarm():
             assert request.method == "POST"
             user_count = int(request.form["user_count"])
             hatch_rate = float(request.form["hatch_rate"])
-            if (request.form.get("host")):
+            if request.form.get("host"):
                 environment.host = str(request.form["host"])
-        
+
             if environment.step_load:
                 step_user_count = int(request.form["step_user_count"])
                 step_duration = parse_timespan(str(request.form["step_duration"]))
                 environment.runner.start_stepload(user_count, hatch_rate, step_user_count, step_duration)
-                return jsonify({'success': True, 'message': 'Swarming started in Step Load Mode', 'host': environment.host})
-            
+                return jsonify(
+                    {"success": True, "message": "Swarming started in Step Load Mode", "host": environment.host}
+                )
+
             environment.runner.start(user_count, hatch_rate)
-            return jsonify({'success': True, 'message': 'Swarming started', 'host': environment.host})
-        
-        @app.route('/stop')
+            return jsonify({"success": True, "message": "Swarming started", "host": environment.host})
+
+        @app.route("/stop")
         @self.auth_required_if_enabled
         def stop():
             environment.runner.stop()
-            return jsonify({'success':True, 'message': 'Test stopped'})
-        
+            return jsonify({"success": True, "message": "Test stopped"})
+
         @app.route("/stats/reset")
         @self.auth_required_if_enabled
         def reset_stats():
             environment.runner.stats.reset_all()
             environment.runner.exceptions = {}
             return "ok"
-            
+
         @app.route("/stats/requests/csv")
         @self.auth_required_if_enabled
         def request_stats_csv():
@@ -181,7 +186,7 @@ class WebUI:
             response.headers["Content-type"] = "text/csv"
             response.headers["Content-disposition"] = disposition
             return response
-        
+
         @app.route("/stats/failures/csv")
         @self.auth_required_if_enabled
         def failures_stats_csv():
@@ -194,30 +199,32 @@ class WebUI:
             response.headers["Content-type"] = "text/csv"
             response.headers["Content-disposition"] = disposition
             return response
-        
-        @app.route('/stats/requests')
+
+        @app.route("/stats/requests")
         @self.auth_required_if_enabled
         @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
         def request_stats():
             stats = []
-        
+
             for s in chain(sort_stats(self.environment.runner.stats.entries), [environment.runner.stats.total]):
-                stats.append({
-                    "method": s.method,
-                    "name": s.name,
-                    "safe_name": escape(s.name, quote=False),
-                    "num_requests": s.num_requests,
-                    "num_failures": s.num_failures,
-                    "avg_response_time": s.avg_response_time,
-                    "min_response_time": 0 if s.min_response_time is None else proper_round(s.min_response_time),
-                    "max_response_time": proper_round(s.max_response_time),
-                    "current_rps": s.current_rps,
-                    "current_fail_per_sec": s.current_fail_per_sec,
-                    "median_response_time": s.median_response_time,
-                    "ninetieth_response_time": s.get_response_time_percentile(0.9),
-                    "avg_content_length": s.avg_content_length,
-                })
-            
+                stats.append(
+                    {
+                        "method": s.method,
+                        "name": s.name,
+                        "safe_name": escape(s.name, quote=False),
+                        "num_requests": s.num_requests,
+                        "num_failures": s.num_failures,
+                        "avg_response_time": s.avg_response_time,
+                        "min_response_time": 0 if s.min_response_time is None else proper_round(s.min_response_time),
+                        "max_response_time": proper_round(s.max_response_time),
+                        "current_rps": s.current_rps,
+                        "current_fail_per_sec": s.current_fail_per_sec,
+                        "median_response_time": s.median_response_time,
+                        "ninetieth_response_time": s.get_response_time_percentile(0.9),
+                        "avg_content_length": s.avg_content_length,
+                    }
+                )
+
             errors = []
             for e in environment.runner.errors.values():
                 err_dict = e.to_dict()
@@ -230,40 +237,54 @@ class WebUI:
             report = {"stats": stats[:500], "errors": errors[:500]}
             if len(stats) > 500:
                 report["stats"] += [stats[-1]]
-        
+
             if stats:
-                report["total_rps"] = stats[len(stats)-1]["current_rps"]
+                report["total_rps"] = stats[len(stats) - 1]["current_rps"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
-                report["current_response_time_percentile_95"] = environment.runner.stats.total.get_current_response_time_percentile(0.95)
-                report["current_response_time_percentile_50"] = environment.runner.stats.total.get_current_response_time_percentile(0.5)
-            
+                report[
+                    "current_response_time_percentile_95"
+                ] = environment.runner.stats.total.get_current_response_time_percentile(0.95)
+                report[
+                    "current_response_time_percentile_50"
+                ] = environment.runner.stats.total.get_current_response_time_percentile(0.5)
+
             is_distributed = isinstance(environment.runner, MasterRunner)
             if is_distributed:
                 workers = []
                 for worker in environment.runner.clients.values():
-                    workers.append({"id":worker.id, "state":worker.state, "user_count": worker.user_count, "cpu_usage":worker.cpu_usage})
-        
+                    workers.append(
+                        {
+                            "id": worker.id,
+                            "state": worker.state,
+                            "user_count": worker.user_count,
+                            "cpu_usage": worker.cpu_usage,
+                        }
+                    )
+
                 report["workers"] = workers
-            
+
             report["state"] = environment.runner.state
             report["user_count"] = environment.runner.user_count
-        
+
             return jsonify(report)
-        
+
         @app.route("/exceptions")
         @self.auth_required_if_enabled
         def exceptions():
-            return jsonify({
-                'exceptions': [
-                    {
-                        "count": row["count"],
-                        "msg": row["msg"],
-                        "traceback": row["traceback"],
-                        "nodes" : ", ".join(row["nodes"])
-                    } for row in environment.runner.exceptions.values()
-                ]
-            })
-        
+            return jsonify(
+                {
+                    "exceptions": [
+                        {
+                            "count": row["count"],
+                            "msg": row["msg"],
+                            "traceback": row["traceback"],
+                            "nodes": ", ".join(row["nodes"]),
+                        }
+                        for row in environment.runner.exceptions.values()
+                    ]
+                }
+            )
+
         @app.route("/exceptions/csv")
         @self.auth_required_if_enabled
         def exceptions_csv():
@@ -280,18 +301,20 @@ class WebUI:
             response.headers["Content-type"] = "text/csv"
             response.headers["Content-disposition"] = disposition
             return response
-        
+
         # start the web server
         self.greenlet = gevent.spawn(self.start)
         self.greenlet.link_exception(greenlet_exception_handler)
 
     def start(self):
         if self.tls_cert and self.tls_key:
-            self.server = pywsgi.WSGIServer((self.host, self.port), self.app, log=None, keyfile=self.tls_key, certfile=self.tls_cert)
+            self.server = pywsgi.WSGIServer(
+                (self.host, self.port), self.app, log=None, keyfile=self.tls_key, certfile=self.tls_cert
+            )
         else:
             self.server = pywsgi.WSGIServer((self.host, self.port), self.app, log=None)
         self.server.serve_forever()
-    
+
     def stop(self):
         """
         Stop the running web server
@@ -300,14 +323,15 @@ class WebUI:
 
     def auth_required_if_enabled(self, view_func):
         """
-        Decorator that can be used on custom route methods that will turn on Basic Auth 
+        Decorator that can be used on custom route methods that will turn on Basic Auth
         authentication if the ``--web-auth`` flag is used. Example::
-        
+
             @web_ui.app.route("/my_custom_route")
             @web_ui.auth_required_if_enabled
             def my_custom_route():
                 return "custom response"
         """
+
         @wraps(view_func)
         def wrapper(*args, **kwargs):
             if self.app.config["BASIC_AUTH_ENABLED"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target-version = ["py36", "py37", "py38"]

--- a/setup.py
+++ b/setup.py
@@ -9,30 +9,25 @@ from setuptools import find_packages, setup
 ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 
 # parse version from locust/__init__.py
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_version_re = re.compile(r"__version__\s+=\s+(.*)")
 _init_file = os.path.join(ROOT_PATH, "locust", "__init__.py")
-with open(_init_file, 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+with open(_init_file, "rb") as f:
+    version = str(ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1)))
 
 setup(
-    name='locust',
+    name="locust",
     version=version,
     install_requires=[
         "gevent>=1.5.0",
-        "flask>=1.1.2", 
-        "requests>=2.9.1", 
-        "msgpack>=0.6.2", 
-        "pyzmq>=16.0.2", 
+        "flask>=1.1.2",
+        "requests>=2.9.1",
+        "msgpack>=0.6.2",
+        "pyzmq>=16.0.2",
         "geventhttpclient>=1.4.4",
         "ConfigArgParse>=1.0",
         "psutil>=5.6.7",
-        "Flask-BasicAuth>=0.2.0"
+        "Flask-BasicAuth>=0.2.0",
     ],
     test_suite="locust.test",
-    tests_require=[
-        'cryptography',
-        'mock',
-        'pyquery',
-    ], 
+    tests_require=["cryptography", "mock", "pyquery"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ deps =
     mock
     pyquery
     cryptography
+    black
 commands =
     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     coverage run -m unittest discover []
+    black --check .


### PR DESCRIPTION
Fixes #1489 (kinda)

* Black is very popular, so many will be familiar with it.
* It is good at minimizing diffs
* It is very opinionated (the only config I've added is the line length), so there should be minimal discussion about how to configure it
* IMO it strikes a good balance between keeping the code nicely formatted (and PEP8 compliant) without making it unnecessarily long. 

Here's a comparison of various formatters https://medium.com/3yourmind/auto-formatters-for-python-8925065f9505

As the next step, we could (should) increase the number of rules covered by flake8 (probably switching to ignoring the few rules that we dont like instead of enabling a few favourite ones. something like --ignore E501,W503,E701,E731,E741,E712,E402,F401).

