### PR TITLE
Add 2 things to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 .coverage
 .tox/
 docs/env-options.rst
+.editorconfig
+__pycache__


### PR DESCRIPTION
Since it looks like we're gonna [keep the messy formatting](https://github.com/locustio/locust/pull/1494) then I think we need to ignore `.editorconfig` 🙂

Also adding `__pycache__` as it shows these directories in a colour as if they would be committed by git (at least in Atom) and this is a little confusing:

![Screen Shot 2020-08-03 at 17 17 46](https://user-images.githubusercontent.com/8859277/89198268-47453d80-d5ad-11ea-8106-1866aef600a1.png)
