### PR TITLE
Allow ramping down of users

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -195,7 +195,7 @@ class Runner(object):
         if not to_stop:
             return
 
-        if stop_rate == None or user_count == stop_rate:
+        if stop_rate == None or stop_rate >= user_count:
             sleep_time = 0
             logger.info("Stopping %i users immediately" % (user_count))
         else:

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -56,7 +56,7 @@
                 <a href="#" class="close_link">Close</a>
             </div>
             <div class="padder">
-                <h2>Start new Locust run</h2>
+                <h2>Start new load test</h2>
                 <form action="./swarm" method="POST" id="swarm_form">
                     <label for="user_count">Number of total users to simulate</label>
                     <input type="text" name="user_count" id="user_count" class="val" value="{{ num_users or "" }}"/><br>
@@ -86,11 +86,11 @@
                 <a href="#" class="close_link">Close</a>
             </div>
             <div class="padder">
-                <h2>Change the locust count</h2>
+                <h2>Edit running load test</h2>
                 <form action="./swarm" method="POST" id="edit_form">
                     <label for="new_user_count">Number of users to simulate</label>
                     <input type="text" name="user_count" id="new_user_count" class="val"  value="{{ num_users or "" }}"/><br>
-                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
+                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned or stopped per second)</span></label>
                     <input type="text" name="hatch_rate" id="new_hatch_rate" class="val"  value="{{ hatch_rate or "" }}"/><br>
                     {% if is_step_load %}
                     <label for="step_user_count">Number of users to increase by step</label>

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -351,18 +351,18 @@ class TestLocustRunner(LocustTestCase):
 
         # Start load test, wait for users to start, then trigger ramp down
         runner.start(10, 10, wait=False)
-        gevent.sleep(1)
-        runner.start(2, 2, wait=False)
+        sleep(1)
+        runner.start(2, 4, wait=False)
 
         # Wait a moment and then ensure the user count has started to drop but
         # not immediately to user_count
         sleep(1)
         user_count = len(runner.user_greenlets)
-        self.assertTrue(user_count > 2, "User count has decreased too quickly: %i" % user_count)
+        self.assertTrue(user_count > 5, "User count has decreased too quickly: %i" % user_count)
         self.assertTrue(user_count < 10, "User count has not decreased at all: %i" % user_count)
-
+        
         # Wait and ensure load test users eventually dropped to desired count
-        sleep(5)
+        sleep(2)
         user_count = len(runner.user_greenlets)
         self.assertTrue(user_count == 2, "User count has not decreased correctly to 2, it is : %i" % user_count)
 
@@ -1308,15 +1308,17 @@ class TestStopTimeout(LocustTestCase):
 
         # Start load test, wait for users to start, then trigger ramp down
         runner.start(10, 10, wait=False)
-        gevent.sleep(1)
-        runner.start(2, 2, wait=False)
+        sleep(1)
+        runner.start(2, 4, wait=False)
 
-        sleep(2)
+        # Wait a moment and then ensure the user count has started to drop but
+        # not immediately to user_count
+        sleep(1)
         user_count = len(runner.user_greenlets)
-        self.assertTrue(user_count > 2, "User count has decreased too quickly: %i" % user_count)
+        self.assertTrue(user_count > 5, "User count has decreased too quickly: %i" % user_count)
         self.assertTrue(user_count < 10, "User count has not decreased at all: %i" % user_count)
         
         # Wait and ensure load test users eventually dropped to desired count
-        sleep(5)
+        sleep(2)
         user_count = len(runner.user_greenlets)
         self.assertTrue(user_count == 2, "User count has not decreased correctly to 2, it is : %i" % user_count)


### PR DESCRIPTION
Resolves: https://github.com/locustio/locust/issues/1488

- Merge `stop_user_instances()` into `stop_users()`
- Allow `stop_rate` to be passed to `stop_users()`
- Negative or positive value for `stop_rate` does the same thing
- Copy same ramping behaviour from `spawn_users()`, it seems robust
- If no `stop_rate` passed to `stop_users()` then don't "ramp down", just stop all without sleeping
- Add one extra debug log message when running test is edited with new `user_count`/`hatch_rate` values
- Add test runner to ensure ramping down works

This is my first proper PR for this project so any and all feedback welcome 🙂

I have still yet to update any documentation...