### PR TITLE
Download full history - see issue 1468

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -287,17 +287,17 @@ def setup_parser_arguments(parser):
     
     stats_group = parser.add_argument_group("Request statistics options")
     stats_group.add_argument(
-        '--csv',
+        '--csv',  # Name repeated in 'parse_options'
         dest="csv_prefix",
         help="Store current request stats to files in CSV format. Setting this option will generate three files: [CSV_PREFIX]_stats.csv, [CSV_PREFIX]_stats_history.csv and [CSV_PREFIX]_failures.csv",
         env_var="LOCUST_CSV",
     )
     stats_group.add_argument(
-        '--csv-full-history',
+        '--csv-full-history',  # Name repeated in 'parse_options'
         action='store_true',
         default=False,
         dest='stats_history_enabled',
-        help="Store each stats entry in CSV format to _stats_history.csv file",
+        help="Store each stats entry in CSV format to _stats_history.csv file. You must also specify the '--csv' argument to enable this.",
         env_var="LOCUST_CSV_FULL_HISTORY",
     )    
     stats_group.add_argument(
@@ -419,4 +419,8 @@ def get_parser(default_config_files=DEFAULT_CONFIG_FILES):
 
 
 def parse_options(args=None):
-    return get_parser().parse_args(args=args)
+    parser = get_parser()
+    parsed_opts = parser.parse_args(args=args)
+    if parsed_opts.stats_history_enabled and (parsed_opts.csv_prefix is None):
+        parser.error("'--csv-full-history' requires '--csv'.")
+    return parsed_opts

--- a/locust/main.py
+++ b/locust/main.py
@@ -16,7 +16,7 @@ from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
 from .log import setup_logging, greenlet_exception_logger
 from .stats import (print_error_report, print_percentile_stats, print_stats,
-                    stats_printer, stats_writer, write_csv_files)
+                    stats_printer, stats_writer, write_csv_files, write_stats_history_csv_header)
 from .user import User
 from .user.inspectuser import get_task_ratio_dict, print_task_ratio
 from .util.timespan import parse_timespan
@@ -297,9 +297,9 @@ def main():
         stats_printer_greenlet.link_exception(greenlet_exception_handler)
 
     if options.csv_prefix:
+        write_stats_history_csv_header(options.csv_prefix) # Write file now to ensure full-history-file exists for download
         gevent.spawn(stats_writer, environment, options.csv_prefix, full_history=options.stats_history_enabled).link_exception(greenlet_exception_handler)
 
-    
     def shutdown():
         """
         Shut down locust by firing quitting event, printing/writing stats and exiting

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -745,8 +745,7 @@ def stats_printer(stats):
 
 def stats_writer(environment, base_filepath, full_history=False):
     """Writes the csv files for the locust run."""
-    with open(base_filepath + '_stats_history.csv', 'w') as f:
-        f.write(stats_history_csv_header())
+    write_stats_history_csv_header(base_filepath)
     while True:
         write_csv_files(environment, base_filepath, full_history)
         gevent.sleep(CSV_STATS_INTERVAL_SEC)
@@ -759,7 +758,7 @@ def write_csv_files(environment, base_filepath, full_history=False):
         requests_csv(environment.stats, csv_writer)
 
     with open(base_filepath + '_stats_history.csv', 'a') as f:
-        f.write(stats_history_csv(environment, full_history) + "\n")
+        f.write(stats_history_csv_rows(environment, full_history) + "\n")
 
     with open(base_filepath + '_failures.csv', 'w') as f:
         csv_writer = csv.writer(f)
@@ -809,10 +808,11 @@ def requests_csv(stats, csv_writer):
 
         csv_writer.writerow(stats_row + percentile_row)
 
-def stats_history_csv_header():
+
+def write_stats_history_csv_header(base_filepath):
     """Headers for the stats history CSV"""
 
-    return ",".join((
+    header = ",".join((
         "Timestamp",
         "User Count",
         "Type",
@@ -829,7 +829,10 @@ def stats_history_csv_header():
         "Total Average Content Size",
     )) + '\n'
 
-def stats_history_csv(environment, all_entries=False):
+    with open(base_filepath + '_stats_history.csv', 'w') as f:
+        f.write(header)
+
+def stats_history_csv_rows(environment, all_entries=False):
     """
     Return a string of CSV rows with the *current* stats. By default only includes the 
     Aggregated stats entry, but if all_entries is set to True, a row for each entry will 
@@ -867,6 +870,13 @@ def stats_history_csv(environment, all_entries=False):
         ))
 
     return "\n".join(rows)
+
+
+def load_requests_csv(base_filepath):
+    """Return content of ..._stats_history.csv file."""
+    with open(base_filepath + '_stats_history.csv') as f:
+        return f.read()
+
 
 def failures_csv(stats, csv_writer):
     """"Return the contents of the 'failures' tab as a CSV."""

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -757,7 +757,7 @@ def write_csv_files(environment, base_filepath, full_history=False):
         csv_writer = csv.writer(f)
         requests_csv(environment.stats, csv_writer)
 
-    with open(base_filepath + '_stats_history.csv', 'a') as f:
+    with open(stats_history_file_name(base_filepath), 'a') as f:
         f.write(stats_history_csv_rows(environment, full_history) + "\n")
 
     with open(base_filepath + '_failures.csv', 'w') as f:
@@ -829,7 +829,7 @@ def write_stats_history_csv_header(base_filepath):
         "Total Average Content Size",
     )) + '\n'
 
-    with open(base_filepath + '_stats_history.csv', 'w') as f:
+    with open(stats_history_file_name(base_filepath), 'w') as f:
         f.write(header)
 
 def stats_history_csv_rows(environment, all_entries=False):
@@ -872,10 +872,8 @@ def stats_history_csv_rows(environment, all_entries=False):
     return "\n".join(rows)
 
 
-def load_requests_csv(base_filepath):
-    """Return content of ..._stats_history.csv file."""
-    with open(base_filepath + '_stats_history.csv') as f:
-        return f.read()
+def stats_history_file_name(base_filepath):
+    return base_filepath + '_stats_history.csv'
 
 
 def failures_csv(stats, csv_writer):

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -169,6 +169,9 @@
                 <div style="display:none;">
                     <div style="margin-top:20px;">
                         <a href="./stats/requests/csv">Download request statistics CSV</a><br>
+                        {% if stats_history_enabled %}
+                        <a href="./stats/requests_full_history/csv">Download full request statistics history CSV</a><br>
+                        {% endif %}
                         <a href="./stats/failures/csv">Download failures CSV</a><br>
                         <a href="./exceptions/csv">Download exceptions CSV</a>
                     </div>

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -149,3 +149,11 @@ class TestArgumentParser(LocustTestCase):
         stdout = out.read()
         self.assertIn("Custom boolean flag", stdout)
         self.assertIn("Custom string arg", stdout)
+
+    def test_csv_full_history_requires_csv(self):
+        with mock.patch("sys.stderr", new=StringIO()):
+            with self.assertRaises(SystemExit):
+                parse_options(args=[
+                    "-f", "locustfile.py",
+                    "--csv-full-history",
+                ])

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -24,7 +24,19 @@ from .testcases import LocustTestCase
 from .util import create_tls_cert
 
 
-class TestWebUI(LocustTestCase):
+class _HeaderCheckMixin():
+    def _check_csv_headers(self, headers, exp_fn_prefix):
+        # Check common headers for csv file download request
+        self.assertIn('Content-Type', headers)
+        content_type = headers['Content-Type']
+        self.assertIn('text/csv', content_type)
+
+        self.assertIn('Content-disposition', headers)
+        disposition = headers['Content-disposition']  # e.g.: 'attachment; filename=requests_full_history_1597586811.5084946.csv'
+        self.assertIn(exp_fn_prefix, disposition)
+
+
+class TestWebUI(LocustTestCase, _HeaderCheckMixin):
     def setUp(self):
         super(TestWebUI, self).setUp()
 
@@ -131,11 +143,12 @@ class TestWebUI(LocustTestCase):
         data = json.loads(response.text)
         self.assertEqual(1, data["stats"][0]["min_response_time"])
         self.assertEqual(1000, data["stats"][0]["max_response_time"])
-    
+
     def test_request_stats_csv(self):
         self.stats.log_request("GET", "/test2", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
+        self._check_csv_headers(response.headers, 'requests')
 
     def test_request_stats_full_history_csv_not_present(self):
         self.stats.log_request("GET", "/test2", 120, 5612)
@@ -146,6 +159,7 @@ class TestWebUI(LocustTestCase):
         self.stats.log_error("GET", "/", Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/failures/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
+        self._check_csv_headers(response.headers, 'failures')
     
     def test_request_stats_with_errors(self):
         self.stats.log_error("GET", "/", Exception("Error1337"))
@@ -201,7 +215,8 @@ class TestWebUI(LocustTestCase):
         
         response = requests.get("http://127.0.0.1:%i/exceptions/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+        self._check_csv_headers(response.headers, 'exceptions')
+
         reader = csv.reader(StringIO(response.text))
         rows = []
         for row in reader:
@@ -353,7 +368,7 @@ class TestWebUIWithTLS(LocustTestCase):
         self.assertEqual(200, requests.get("https://127.0.0.1:%i/" % self.web_port, verify=False).status_code)
 
 
-class TestWebUIFullHistory(LocustTestCase):
+class TestWebUIFullHistory(LocustTestCase, _HeaderCheckMixin):
     STATS_BASE_NAME = "web_test"
     STATS_FILENAME = "{}_stats.csv".format(STATS_BASE_NAME)
     STATS_HISTORY_FILENAME = "{}_stats_history.csv".format(STATS_BASE_NAME)
@@ -366,10 +381,9 @@ class TestWebUIFullHistory(LocustTestCase):
         parser = get_parser(default_config_files=[])
         self.environment.parsed_options = parser.parse_args(["--csv", self.STATS_BASE_NAME, "--csv-full-history"])
         self.stats = self.environment.stats
+        self.stats.CSV_STATS_INTERVAL_SEC = 0.02
 
         self.web_ui = self.environment.create_web_ui("127.0.0.1", 0)
-        # Write files now to ensure full-history exists for download - normally done in main
-        locust.stats.write_csv_files(self.environment, self.STATS_BASE_NAME, full_history=True)
         self.web_ui.app.view_functions["request_stats"].clear_cache()
         gevent.sleep(0.01)
         self.web_port = self.web_ui.server.server_port
@@ -390,6 +404,26 @@ class TestWebUIFullHistory(LocustTestCase):
         self.remove_file_if_exists(self.STATS_FAILURES_FILENAME)
 
     def test_request_stats_full_history_csv(self):
+        self.stats.log_request("GET", "/test", 1.39764125, 2)
+        self.stats.log_request("GET", "/test", 999.9764125, 1000)
         self.stats.log_request("GET", "/test2", 120, 5612)
+
+        # Call these two methods instead of the 'stats_writer' so that we avoid gevent wait loop
+        locust.stats.write_stats_history_csv_header(self.STATS_BASE_NAME)
+        locust.stats.write_csv_files(self.environment, self.STATS_BASE_NAME, full_history=True)
+
         response = requests.get("http://127.0.0.1:%i/stats/requests_full_history/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
+        self._check_csv_headers(response.headers, 'requests_full_history')
+        self.assertIn('Content-Length', response.headers)
+
+        reader = csv.reader(StringIO(response.text))
+        rows = [r for r in reader]
+
+        self.assertEqual(4, len(rows))
+        self.assertEqual("Timestamp", rows[0][0])
+        self.assertEqual("GET", rows[1][2])
+        self.assertEqual("/test", rows[1][3])
+        self.assertEqual("/test2", rows[2][3])
+        self.assertEqual("", rows[3][2])
+        self.assertEqual("Aggregated", rows[3][3])


### PR DESCRIPTION
Adds another download link to the UI when --csv-full-history was specified

See: https://github.com/locustio/locust/issues/1468

Does not implement the suggested 'download-all'