### PR TITLE
Fix typo of redirect_response_codes

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -221,14 +221,14 @@ class FastHttpSession(object):
                 headers['Accept'] = "application/json"
 
         if not allow_redirects:
-            old_redirect_response_codes = self.client.redirect_resonse_codes
-            self.client.redirect_resonse_codes = []
+            old_redirect_response_codes = self.client.redirect_response_codes
+            self.client.redirect_response_codes = []
         
         # send request, and catch any exceptions
         response = self._send_request_safe_mode(method, url, payload=data, headers=headers, **kwargs)
 
         if not allow_redirects:
-            self.client.redirect_resonse_codes = old_redirect_response_codes
+            self.client.redirect_response_codes = old_redirect_response_codes
 
         # get the length of the content, but if the argument stream is set to True, we take
         # the size from the content-length header, in order to not trigger fetching of the body


### PR DESCRIPTION
This looks like it could be a bug, but I don't see where `redirect_resonse_codes` or `redirect_response_codes` is mentioned anywhere else.

Update: it comes from https://github.com/locustio/geventhttpclient

PR https://github.com/locustio/geventhttpclient/pull/3 would be needed first to make this pass. And I guess that would be a backward-compatibility break for https://github.com/locustio/geventhttpclient