### PR TITLE
Grey out UI input fields when LoadTestShape is in use

### DIFF
--- a/locust/shape.py
+++ b/locust/shape.py
@@ -31,6 +31,5 @@ class LoadTestShape(object):
         If `None` is returned then the running load test will be stopped.
 
         """
-        run_time = self.get_run_time()
 
         return None

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -188,6 +188,14 @@ a:hover {
     font-size: 24px;
     padding-left: 10px;
 }
+.start input.val_disabled, .edit input.val_disabled {
+    border: none;
+    background: #cccccc;
+    height: 52px;
+    width: 328px;
+    font-size: 24px;
+    padding-left: 10px;
+}
 .start button,
 .edit button {
     margin-top: 20px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -58,10 +58,19 @@
             <div class="padder">
                 <h2>Start new load test</h2>
                 <form action="./swarm" method="POST" id="swarm_form">
+                    {% if is_shape %}
+                    <label for="user_count">Number of total users to simulate</label>
+                    <input type="text" name="user_count" id="user_count" class="val_disabled" value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
+                    <input type="hidden" name="user_count" id="user_count" value="0"/><br>
+                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
+                    <input type="text" name="hatch_rate" id="hatch_rate" class="val_disabled" value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
+                    <input type="hidden" name="hatch_rate" id="hatch_rate" value="0"/><br>
+                    {% else %}
                     <label for="user_count">Number of total users to simulate</label>
                     <input type="text" name="user_count" id="user_count" class="val" value="{{ num_users or "" }}"/><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
                     <input type="text" name="hatch_rate" id="hatch_rate" class="val" value="{{ hatch_rate or "" }}"/><br>
+                    {% endif %}
                     <label for="host">
                         Host <span style="color:#8a8a8a;">(e.g. http://www.example.com)</span>
                         {% if override_host_warning %}
@@ -88,17 +97,28 @@
             <div class="padder">
                 <h2>Edit running load test</h2>
                 <form action="./swarm" method="POST" id="edit_form">
+                    {% if is_shape %}
+                    <label for="new_user_count">Number of users to simulate</label>
+                    <input type="text" name="user_count" id="new_user_count" class="val_disabled"  value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
+                    <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned or stopped per second)</span></label>
+                    <input type="text" name="hatch_rate" id="new_hatch_rate" class="val_disabled"  value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
+                    {% else %}
                     <label for="new_user_count">Number of users to simulate</label>
                     <input type="text" name="user_count" id="new_user_count" class="val"  value="{{ num_users or "" }}"/><br>
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned or stopped per second)</span></label>
                     <input type="text" name="hatch_rate" id="new_hatch_rate" class="val"  value="{{ hatch_rate or "" }}"/><br>
+                    {% endif %}
                     {% if is_step_load %}
                     <label for="step_user_count">Number of users to increase by step</label>
                     <input type="text" name="step_user_count" id="step_user_count" class="val"  value="{{ step_users or "" }}"/><br>
                     <label for="step_duration">Step duration <span style="color:#8a8a8a;">(300s, 20m, 3h, 1h30m, etc.)</span></label>
                     <input type="text" name="step_duration" id="step_duration" class="val"  value="{{ step_time or "" }}"/><br>
                     {% endif %}
+                    {% if is_shape %}
+                    <button type="submit" disabled>Start swarming</button>
+                    {% else %}
                     <button type="submit">Start swarming</button>
+                    {% endif %}
                 </form>
                 <div style="clear:right;"></div>
             </div>


### PR DESCRIPTION
- Grey out input fields for starting and editing users and hatch rate when `LoadTestShape` is in use
- Add CSS style for above
- Remove unused `run_time = self.get_run_time()` from `shape.py`