### PR TITLE
Make hatch-rate parameter deprecated instead of killing it right away.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ For full details of the Locust changelog, please see https://github.com/locustio
 1.2
 ===
 
-* Rename hatch rate to spawn rate (this may be a breaking change in some cases!)
+* Rename hatch rate to spawn rate (the --hatch-rate parameter is only deprecated, but the hatch_complete event has been renamed spawning_complete)
 * Ability to generate any custom load shape with LoadTestShape class
 * Allow ramping down of users
 * Ability to use save custom percentiles

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -146,7 +146,8 @@ def setup_parser_arguments(parser):
     parser.add_argument(
         '--hatch-rate',
         env_var="LOCUST_HATCH_RATE",
-        action='store_true',
+        type=float,
+        default=0,
         help=configargparse.SUPPRESS,
     )
     parser.add_argument(

--- a/locust/main.py
+++ b/locust/main.py
@@ -142,8 +142,8 @@ def main():
         sys.exit(1)
 
     if options.hatch_rate:
-        sys.stderr.write("The --hatch-rate parameter has been renamed --spawn-rate\n")
-        sys.exit(1)
+        sys.stderr.write("[DEPRECATED] The --hatch-rate parameter has been renamed --spawn-rate\n")
+        options.spawn_rate = options.hatch_rate
  
 
     # setup logging


### PR DESCRIPTION
The renamed events are still incompatible, but that should impact much fewer users.

Should we still call it 2.0? I guess we should.

ping @lhupfeldt 