### PR TITLE
Update documentation for schedule_task parameters in TaskSet (task.py)

### DIFF
--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -326,8 +326,6 @@ class TaskSet(object, metaclass=TaskSetMeta):
         Add a task to the User's task execution queue.
 
         :param task_callable: User task to schedule.
-        :param args: Arguments that will be passed to the task callable.
-        :param kwargs: Dict of keyword arguments that will be passed to the task callable.
         :param first: Optional keyword argument. If True, the task will be put first in the queue.
         """
         if first:


### PR DESCRIPTION
The parameters "args" and "kwargs" were removed in commit 82c2d6a68f946bdd303642dff6a89e0d5c2bf298. However they still show in the latest documentation https://docs.locust.io/en/latest/api.html?highlight=schedule_task#locust.TaskSet.schedule_task