### PR TITLE
More easily extend web UI

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -47,6 +47,24 @@ to the Flask app instance and use that to set up a new route::
 
 You should now be able to start locust and browse to http://127.0.0.1:8089/added_page
 
+
+
+Extending Web UI
+================
+
+As an alternative to adding simple web routes, you can use `Flask Blueprints 
+<https://flask.palletsprojects.com/en/1.1.x/blueprints/>`_ and `templates 
+<https://flask.palletsprojects.com/en/1.1.x/tutorial/templates/>`_ to not only add routes but also extend 
+the web UI to allow you to show custom data along side the built-in Locust stats. This is more advanced 
+as it involves also writing and including HTML and Javascript files to be served by routes but can 
+greatly enhance the utility and customizability of the web UI.
+
+A working example of extending the web UI, complete with HTML and Javascript example files, can be found 
+in the `examples directory <https://github.com/locustio/locust/tree/master/examples>`_ of the Locust 
+source code.
+
+
+
 Run a background greenlet
 =========================
 

--- a/examples/extend_web_ui/extend.py
+++ b/examples/extend_web_ui/extend.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+
+"""
+This is an example of a locustfile that uses Locust's built in event and web
+UI extension hooks to track the sum of the content-length header in all
+successful HTTP responses and display them in the web UI.
+"""
+
+import os
+from time import time
+from html import escape
+from locust import HttpUser, TaskSet, task, web, between, events
+from flask import Blueprint, render_template, jsonify, make_response
+
+
+class MyTaskSet(TaskSet):
+    @task(2)
+    def index(l):
+        l.client.get("/")
+
+    @task(1)
+    def stats(l):
+        l.client.get("/stats/requests")
+
+
+class WebsiteUser(HttpUser):
+    host = "http://127.0.0.1:8089"
+    wait_time = between(2, 5)
+    tasks = [MyTaskSet]
+
+
+stats = {}
+path = os.path.dirname(os.path.abspath(__file__))
+extend = Blueprint(
+    "extend",
+    "extend_web_ui",
+    static_folder=f"{path}/static/",
+    static_url_path="/extend/static/",
+    template_folder=f"{path}/templates/",
+)
+
+
+@events.init.add_listener
+def locust_init(environment, **kwargs):
+    """
+    We need somewhere to store the stats.
+
+    On the master node stats will contain the aggregated sum of all content-lengths,
+    while on the worker nodes this will be the sum of the content-lengths since the
+    last stats report was sent to the master
+    """
+    if environment.web_ui:
+        # this code is only run on the master node (the web_ui instance doesn't exist on workers)
+        @extend.route("/content-length")
+        def total_content_length():
+            """
+            Add a route to the Locust web app where we can see the total content-length for each
+            endpoint Locust users are hitting. This is also used by the Content Length tab in the
+            extended web UI to show the stats. See `updateContentLengthStats()` and
+            `renderContentLengthTable()` in extend.js.
+            """
+            report = {"stats": []}
+            if stats:
+                stats_tmp = []
+
+                for name, inner_stats in stats.items():
+                    content_length = inner_stats["content-length"]
+
+                    stats_tmp.append(
+                        {"name": name, "safe_name": escape(name, quote=False), "content_length": content_length}
+                    )
+
+                    # Truncate the total number of stats and errors displayed since a large number of rows will cause the app
+                    # to render extremely slowly.
+                    report = {"stats": stats_tmp[:500]}
+                return jsonify(report)
+            return jsonify(stats)
+
+        @extend.route("/extend")
+        def extend_web_ui():
+            """
+            Add route to access the extended web UI with our new tab.
+            """
+            # ensure the template_args are up to date before using them
+            environment.web_ui.update_template_args()
+            return render_template("extend.html", **environment.web_ui.template_args)
+
+        @extend.route("/content-length/csv")
+        def request_content_length_csv():
+            """
+            Add route to enable downloading of content-length stats as CSV
+            """
+            response = make_response(content_length_csv())
+            file_name = "content_length{0}.csv".format(time())
+            disposition = "attachment;filename={0}".format(file_name)
+            response.headers["Content-type"] = "text/csv"
+            response.headers["Content-disposition"] = disposition
+            return response
+
+        def content_length_csv():
+            """Returns the content-length stats as CSV."""
+            rows = [
+                ",".join(
+                    [
+                        '"Name"',
+                        '"Total content-length"',
+                    ]
+                )
+            ]
+
+            if stats:
+                for url, inner_stats in stats.items():
+                    rows.append(
+                        '"%s",%.2f'
+                        % (
+                            url,
+                            inner_stats["content-length"],
+                        )
+                    )
+            return "\n".join(rows)
+
+        # register our new routes and extended UI with the Locust web UI
+        environment.web_ui.app.register_blueprint(extend)
+
+
+@events.request_success.add_listener
+def on_request_success(request_type, name, response_time, response_length):
+    """
+    Event handler that get triggered on every successful request
+    """
+    stats.setdefault(name, {"content-length": 0})
+    stats[name]["content-length"] += response_length
+
+
+@events.reset_stats.add_listener
+def on_reset_stats():
+    """
+    Event handler that get triggered on click of web UI Reset Stats button
+    """
+    global stats
+    stats = {}

--- a/examples/extend_web_ui/static/extend.js
+++ b/examples/extend_web_ui/static/extend.js
@@ -1,0 +1,54 @@
+var contentLengthStats;
+var contentLengthCharts = {};
+
+// Used for sorting
+var contentLengthDesc = false;
+var contentLengthSortAttribute = "name";
+
+// Trigger sorting of stats when a table label is clicked
+$("#content-length .stats_label").click(function (event) {
+    event.preventDefault();
+    contentLengthSortAttribute = $(this).attr("data-sortkey");
+    contentLengthDesc = !contentLengthDesc;
+    renderContentLengthTable(window.content_length_report);
+});
+
+// Render and sort Content Length table
+function renderContentLengthTable(content_length_report) {
+    $('#content-length tbody').empty();
+
+    window.alternate = false;
+    $('#content-length tbody').jqoteapp($('#content-length-template'), (content_length_report.stats).sort(sortBy(contentLengthSortAttribute, contentLengthDesc)));
+}
+
+// Get and repeatedly update Content Length stats and table
+function updateContentLengthStats() {
+    $.get('./content-length', function (content_length_report) {
+        window.content_length_report = content_length_report
+        $('#content-length tbody').empty();
+
+        if (JSON.stringify(content_length_report) !== JSON.stringify({})) {
+            renderContentLengthTable(content_length_report);
+
+            // Make a separate chart for each URL
+            for (let index = 0; index < content_length_report.stats.length; index++) {
+                const url_stats = content_length_report.stats[index];
+
+                // If a chart already exists, just add the new value
+                if (contentLengthCharts.hasOwnProperty(url_stats.safe_name)) {
+                    contentLengthCharts[url_stats.safe_name].addValue([url_stats.content_length]);
+                } else {
+                    // If a chart doesn't already exist, create the chart first then add the value
+                    contentLengthCharts[url_stats.safe_name] = new LocustLineChart($(".content-length-chart-container"), `Content Length for ${url_stats.safe_name}`, ["content-length"], "bytes");
+                    // Add newly created chart to Locust web UI's array of charts
+                    charts.push(contentLengthCharts[url_stats.safe_name])
+                    contentLengthCharts[url_stats.safe_name].addValue([url_stats.content_length]);
+                }
+            }
+        }
+        // Schedule a repeat of updating stats in 2 seconds
+        setTimeout(updateContentLengthStats, 2000);
+    });
+}
+
+updateContentLengthStats();

--- a/examples/extend_web_ui/templates/extend.html
+++ b/examples/extend_web_ui/templates/extend.html
@@ -1,0 +1,48 @@
+{% extends "index.html" %}
+
+{% block extended_tabs %}
+<li><a href="#" class="content-length-tab-link">Content Length</a></li>
+{% endblock extended_tabs %}
+
+{% block extended_panes %}
+<div style="display:none;">
+    <table id="content-length" class="stats">
+        <thead>
+            <tr>
+                <th class="stats_label" href="#" data-sortkey="name">Name</th>
+                <th class="stats_label numeric" href="#" data-sortkey="content_length" title="Total content length">Total content length</th>
+            </tr>
+        </thead>
+        <tbody>
+        </tbody>
+    </table>
+    <div id="content-length-container">
+        <div class="content-length-chart-container"></div>
+        <p class="note">Note: There is no persistence of these charts, if you refresh this page, new charts will be created.</p>
+    </div>
+    <p></p>
+    <a href="./content-length/csv">Download content length statistics CSV</a><br>
+</div>
+{% endblock extended_panes %}
+
+{% block extended_script %}
+<script type="text/javascript" src="./extend/static/extend.js"></script>
+<script type="text/x-jqote-template" id="content-length-template">
+    <![CDATA[
+    <tr class="<%=(alternate ? "dark" : "")%> <%=(this.is_aggregated ? "total" : "")%>">
+        <td class="name" title="<%= this.name %>"><%= this.safe_name %></td>
+        <td class="numeric"><%= this.content_length %></td>
+    </tr>
+    <% alternate = !alternate; %>
+    ]]>
+</script>
+<script type="text/x-jqote-template" id="content-length-template">
+    <![CDATA[
+    <tr class="<%=(alternate ? "dark" : "")%> <%=(this.is_aggregated ? "total" : "")%>">
+        <td class="name" title="<%= this.name %>"><%= this.safe_name %></td>
+        <td class="numeric"><%= this.content_length %></td>
+    </tr>
+    <% alternate = !alternate; %>
+    ]]>
+</script>
+{% endblock extended_script %}

--- a/locust/event.py
+++ b/locust/event.py
@@ -165,6 +165,11 @@ class Events:
     is only fired on the master node and not on each worker node.
     """
 
+    reset_stats = EventHook
+    """
+    Fired when the Reset Stats button is clicked in the web UI.
+    """
+
     def __init__(self):
         for name, value in vars(type(self)).items():
             if value == EventHook:

--- a/locust/main.py
+++ b/locust/main.py
@@ -302,15 +302,14 @@ def main():
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)
+        else:
+            main_greenlet = web_ui.greenlet
     else:
         web_ui = None
 
     # Fire locust init event which can be used by end-users' code to run setup code that
-    # need access to the Environment, Runner or WebUI. Fire init event before starting
-    # web server to avoid race conditions with adding Flask routes.
+    # need access to the Environment, Runner or WebUI.
     environment.events.init.fire(environment=environment, runner=runner, web_ui=web_ui)
-    if web_ui:
-        main_greenlet = web_ui.web_server_greenlet()
 
     if options.headless:
         # headless mode

--- a/locust/main.py
+++ b/locust/main.py
@@ -302,14 +302,15 @@ def main():
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)
-        else:
-            main_greenlet = web_ui.greenlet
     else:
         web_ui = None
 
     # Fire locust init event which can be used by end-users' code to run setup code that
-    # need access to the Environment, Runner or WebUI
+    # need access to the Environment, Runner or WebUI. Fire init event before starting
+    # web server to avoid race conditions with adding Flask routes.
     environment.events.init.fire(environment=environment, runner=runner, web_ui=web_ui)
+    if web_ui:
+        main_greenlet = web_ui.web_server_greenlet()
 
     if options.headless:
         # headless mode

--- a/locust/static/chart.js
+++ b/locust/static/chart.js
@@ -34,7 +34,7 @@
                 tooltip: {
                     trigger: 'axis',
                     formatter: function (params) {
-                        if (!!params && params.length > 0 && !!params[0].value) {
+                        if (!!params && params.length > 0 && params.some(param => !!param.value)) {
                             var str = params[0].name;
                             for (var i=0; i<params.length; i++) {
                                 var param = params[i];

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -1,5 +1,5 @@
-$(window).ready(function() {
-    if($("#user_count").length > 0) {
+$(window).ready(function () {
+    if ($("#user_count").length > 0) {
         $("#user_count").focus().select();
     }
 });
@@ -11,43 +11,47 @@ function appearStopped() {
     $(".user_count").hide();
 }
 
-$("#box_stop a.stop-button").click(function(event) {
+$("#box_stop a.stop-button").click(function (event) {
     event.preventDefault();
     $.get($(this).attr("href"));
     $("body").attr("class", "stopped");
     appearStopped()
 });
 
-$("#box_stop a.reset-button").click(function(event) {
+$("#box_stop a.reset-button").click(function (event) {
     event.preventDefault();
     $.get($(this).attr("href"));
 });
 
-$("#new_test").click(function(event) {
+$("#new_test").click(function (event) {
     event.preventDefault();
     $("#start").show();
     $("#user_count").focus().select();
 });
 
-$(".edit_test").click(function(event) {
+$(".edit_test").click(function (event) {
     event.preventDefault();
     $("#edit").show();
     $("#new_user_count").focus().select();
 });
 
-$(".close_link").click(function(event) {
+$(".close_link").click(function (event) {
     event.preventDefault();
     $(this).parent().parent().hide();
 });
 
-$("ul.tabs").tabs("div.panes > div").on("onClick", function(event) {
-    if (event.target == $(".chart-tab-link")[0]) {
-        // trigger resizing of charts
-        rpsChart.resize();
-        responseTimeChart.resize();
-        usersChart.resize();
-    }
+$("ul.tabs").tabs("div.panes > div").on("onClick", function (event) {
+    // trigger resizing of charts
+    resizeCharts();
 });
+
+var charts = []
+function resizeCharts() {
+    for (let index = 0; index < charts.length; index++) {
+        const chart = charts[index];
+        chart.resize();
+    }
+}
 
 var stats_tpl = $('#stats-template');
 var errors_tpl = $('#errors-template');
@@ -59,7 +63,7 @@ function setHostName(hostname) {
     $('#host_url').text(hostname);
 }
 
-$('#swarm_form').submit(function(event) {
+$('#swarm_form').submit(function (event) {
     event.preventDefault();
     $("body").attr("class", "spawning");
     $("#start").fadeOut();
@@ -69,7 +73,7 @@ $('#swarm_form').submit(function(event) {
     $("a.edit_test").fadeIn();
     $(".user_count").fadeIn();
     $.post($(this).attr("action"), $(this).serialize(),
-        function(response) {
+        function (response) {
             if (response.success) {
                 setHostName(response.host);
             }
@@ -77,10 +81,10 @@ $('#swarm_form').submit(function(event) {
     );
 });
 
-$('#edit_form').submit(function(event) {
+$('#edit_form').submit(function (event) {
     event.preventDefault();
     $.post($(this).attr("action"), $(this).serialize(),
-        function(response) {
+        function (response) {
             if (response.success) {
                 $("body").attr("class", "spawning");
                 $("#edit").fadeOut();
@@ -90,18 +94,18 @@ $('#edit_form').submit(function(event) {
     );
 });
 
-var sortBy = function(field, reverse, primer){
+var sortBy = function (field, reverse, primer) {
     reverse = (reverse) ? -1 : 1;
-    return function(a,b){
+    return function (a, b) {
         a = a[field];
         b = b[field];
-       if (typeof(primer) != 'undefined'){
-           a = primer(a);
-           b = primer(b);
-       }
-       if (a<b) return reverse * -1;
-       if (a>b) return reverse * 1;
-       return 0;
+        if (typeof (primer) != 'undefined') {
+            a = primer(a);
+            b = primer(b);
+        }
+        if (a < b) return reverse * -1;
+        if (a > b) return reverse * 1;
+        return 0;
     }
 }
 
@@ -127,8 +131,8 @@ function renderTable(report) {
     window.alternate = false;
     $('#errors tbody').jqoteapp(errors_tpl, (report.errors).sort(sortBy(sortAttribute, desc)));
 
-    $("#total_rps").html(Math.round(report.total_rps*100)/100);
-    $("#fail_ratio").html(Math.round(report.fail_ratio*100));
+    $("#total_rps").html(Math.round(report.total_rps * 100) / 100);
+    $("#fail_ratio").html(Math.round(report.fail_ratio * 100));
     $("#status_text").html(report.state);
     $("#userCount").html(report.user_count);
 }
@@ -144,14 +148,14 @@ function renderWorkerTable(report) {
 }
 
 
-$("#stats .stats_label").click(function(event) {
+$("#stats .stats_label").click(function (event) {
     event.preventDefault();
     sortAttribute = $(this).attr("data-sortkey");
     desc = !desc;
     renderTable(window.report);
 });
 
-$("#workers .stats_label").click(function(event) {
+$("#workers .stats_label").click(function (event) {
     event.preventDefault();
     WorkerSortAttribute = $(this).attr("data-sortkey");
     WorkerDesc = !WorkerDesc;
@@ -162,6 +166,7 @@ $("#workers .stats_label").click(function(event) {
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
+charts.push(rpsChart, responseTimeChart, usersChart)
 
 function updateStats() {
     $.get('./stats/requests', function (report) {
@@ -170,9 +175,9 @@ function updateStats() {
         renderTable(report);
         renderWorkerTable(report);
 
-        if (report.state !== "stopped"){
+        if (report.state !== "stopped") {
             // get total stats row
-            var total = report.stats[report.stats.length-1];
+            var total = report.stats[report.stats.length - 1];
             // update charts
             rpsChart.addValue([total.current_rps, total.current_fail_per_sec]);
             responseTimeChart.addValue([report.current_response_time_percentile_50, report.current_response_time_percentile_95]);

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -1,5 +1,5 @@
-$(window).ready(function () {
-    if ($("#user_count").length > 0) {
+$(window).ready(function() {
+    if($("#user_count").length > 0) {
         $("#user_count").focus().select();
     }
 });
@@ -11,31 +11,31 @@ function appearStopped() {
     $(".user_count").hide();
 }
 
-$("#box_stop a.stop-button").click(function (event) {
+$("#box_stop a.stop-button").click(function(event) {
     event.preventDefault();
     $.get($(this).attr("href"));
     $("body").attr("class", "stopped");
     appearStopped()
 });
 
-$("#box_stop a.reset-button").click(function (event) {
+$("#box_stop a.reset-button").click(function(event) {
     event.preventDefault();
     $.get($(this).attr("href"));
 });
 
-$("#new_test").click(function (event) {
+$("#new_test").click(function(event) {
     event.preventDefault();
     $("#start").show();
     $("#user_count").focus().select();
 });
 
-$(".edit_test").click(function (event) {
+$(".edit_test").click(function(event) {
     event.preventDefault();
     $("#edit").show();
     $("#new_user_count").focus().select();
 });
 
-$(".close_link").click(function (event) {
+$(".close_link").click(function(event) {
     event.preventDefault();
     $(this).parent().parent().hide();
 });
@@ -63,7 +63,7 @@ function setHostName(hostname) {
     $('#host_url').text(hostname);
 }
 
-$('#swarm_form').submit(function (event) {
+$('#swarm_form').submit(function(event) {
     event.preventDefault();
     $("body").attr("class", "spawning");
     $("#start").fadeOut();
@@ -73,7 +73,7 @@ $('#swarm_form').submit(function (event) {
     $("a.edit_test").fadeIn();
     $(".user_count").fadeIn();
     $.post($(this).attr("action"), $(this).serialize(),
-        function (response) {
+        function(response) {
             if (response.success) {
                 setHostName(response.host);
             }
@@ -81,10 +81,10 @@ $('#swarm_form').submit(function (event) {
     );
 });
 
-$('#edit_form').submit(function (event) {
+$('#edit_form').submit(function(event) {
     event.preventDefault();
     $.post($(this).attr("action"), $(this).serialize(),
-        function (response) {
+        function(response) {
             if (response.success) {
                 $("body").attr("class", "spawning");
                 $("#edit").fadeOut();
@@ -94,18 +94,18 @@ $('#edit_form').submit(function (event) {
     );
 });
 
-var sortBy = function (field, reverse, primer) {
+var sortBy = function(field, reverse, primer){
     reverse = (reverse) ? -1 : 1;
-    return function (a, b) {
+    return function(a,b){
         a = a[field];
         b = b[field];
-        if (typeof (primer) != 'undefined') {
-            a = primer(a);
-            b = primer(b);
-        }
-        if (a < b) return reverse * -1;
-        if (a > b) return reverse * 1;
-        return 0;
+       if (typeof(primer) != 'undefined'){
+           a = primer(a);
+           b = primer(b);
+       }
+       if (a<b) return reverse * -1;
+       if (a>b) return reverse * 1;
+       return 0;
     }
 }
 
@@ -131,8 +131,8 @@ function renderTable(report) {
     window.alternate = false;
     $('#errors tbody').jqoteapp(errors_tpl, (report.errors).sort(sortBy(sortAttribute, desc)));
 
-    $("#total_rps").html(Math.round(report.total_rps * 100) / 100);
-    $("#fail_ratio").html(Math.round(report.fail_ratio * 100));
+    $("#total_rps").html(Math.round(report.total_rps*100)/100);
+    $("#fail_ratio").html(Math.round(report.fail_ratio*100));
     $("#status_text").html(report.state);
     $("#userCount").html(report.user_count);
 }
@@ -148,14 +148,14 @@ function renderWorkerTable(report) {
 }
 
 
-$("#stats .stats_label").click(function (event) {
+$("#stats .stats_label").click(function(event) {
     event.preventDefault();
     sortAttribute = $(this).attr("data-sortkey");
     desc = !desc;
     renderTable(window.report);
 });
 
-$("#workers .stats_label").click(function (event) {
+$("#workers .stats_label").click(function(event) {
     event.preventDefault();
     WorkerSortAttribute = $(this).attr("data-sortkey");
     WorkerDesc = !WorkerDesc;
@@ -175,9 +175,9 @@ function updateStats() {
         renderTable(report);
         renderWorkerTable(report);
 
-        if (report.state !== "stopped") {
+        if (report.state !== "stopped"){
             // get total stats row
-            var total = report.stats[report.stats.length - 1];
+            var total = report.stats[report.stats.length-1];
             // update charts
             rpsChart.addValue([total.current_rps, total.current_fail_per_sec]);
             responseTimeChart.addValue([report.current_response_time_percentile_50, report.current_response_time_percentile_95]);

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -270,6 +270,7 @@ a:hover {
     border-radius: 3px;
     border: 2px solid #11251c;
     border-spacing: 0;
+    margin-bottom: 30px;
 }
 .status thead {
     background: #11251c;
@@ -357,14 +358,14 @@ a:hover {
 #charts {
     width: 100%;
 }
-#charts .chart {
+.chart {
     height: 350px;
     margin-bottom: 30px;
     box-sizing: border-box;
     border: 1px solid #11271e;
     border-radius: 3px;
 }
-#charts .note {
+.note {
     color: #b3c3bc;
     margin-bottom: 30px;
     border-radius: 3px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -135,6 +135,8 @@
                     {% if is_distributed %}
                     <li><a href="#">Workers</a></li>
                     {% endif %}
+                    {% block extended_tabs %}
+                    {% endblock extended_tabs %}
                 </ul>
             </nav>
             <div class="panes container">
@@ -197,6 +199,7 @@
                         <a href="./stats/report" target="_blank">Download Report</a><br>
                     </div>
                 </div>
+                {% if is_distributed %}
                 <div style="display:none;">
                     <table id="workers">
                         <thead>
@@ -211,6 +214,9 @@
                         </tbody>
                     </table>
                 </div>
+                {% endif %}
+                {% block extended_panes %}
+                {% endblock extended_panes %}
             </div>
         </div>
 
@@ -314,5 +320,7 @@
     </script>
     <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>
     <script type="text/javascript" src="./static/locust.js?v={{ version }}"></script>
+    {% block extended_script %}
+    {% endblock extended_script %}
 </body>
 </html>

--- a/locust/web.py
+++ b/locust/web.py
@@ -186,6 +186,7 @@ class WebUI:
         @app.route("/stats/reset")
         @self.auth_required_if_enabled
         def reset_stats():
+            environment.events.reset_stats.fire()
             environment.runner.stats.reset_all()
             environment.runner.exceptions = {}
             return "ok"

--- a/locust/web.py
+++ b/locust/web.py
@@ -371,9 +371,10 @@ class WebUI:
 
             return _download_csv_response(data.getvalue(), "exceptions")
 
-        # start the web server
+    def web_server_greenlet(self):
         self.greenlet = gevent.spawn(self.start)
         self.greenlet.link_exception(greenlet_exception_handler)
+        return self.greenlet
 
     def start(self):
         if self.tls_cert and self.tls_key:

--- a/locust/web.py
+++ b/locust/web.py
@@ -108,7 +108,8 @@ class WebUI:
                 raise AuthCredentialsError(
                     "Invalid auth_credentials. It should be a string in the following format: 'user.pass'"
                 )
-        self.update_template_args()
+        if environment.runner:
+            self.update_template_args()
 
         @app.route("/")
         @self.auth_required_if_enabled
@@ -371,10 +372,8 @@ class WebUI:
 
             return _download_csv_response(data.getvalue(), "exceptions")
 
-    def web_server_greenlet(self):
         self.greenlet = gevent.spawn(self.start)
         self.greenlet.link_exception(greenlet_exception_handler)
-        return self.greenlet
 
     def start(self):
         if self.tls_cert and self.tls_key:

--- a/locust/web.py
+++ b/locust/web.py
@@ -62,6 +62,10 @@ class WebUI:
     server = None
     """Reference to the :class:`pyqsgi.WSGIServer` instance"""
 
+    template_args: dict = None
+    """Arguments used to render index.html for the web UI. Must be used with custom templates
+    extending index.html."""
+
     def __init__(
         self, environment, host, port, auth_credentials=None, tls_cert=None, tls_key=None, stats_csv_writer=None
     ):
@@ -104,52 +108,15 @@ class WebUI:
                 raise AuthCredentialsError(
                     "Invalid auth_credentials. It should be a string in the following format: 'user.pass'"
                 )
+        self.update_template_args()
 
         @app.route("/")
         @self.auth_required_if_enabled
         def index():
             if not environment.runner:
                 return make_response("Error: Locust Environment does not have any runner", 500)
-
-            is_distributed = isinstance(environment.runner, MasterRunner)
-            if is_distributed:
-                worker_count = environment.runner.worker_count
-            else:
-                worker_count = 0
-
-            override_host_warning = False
-            if environment.host:
-                host = environment.host
-            elif environment.runner.user_classes:
-                all_hosts = set([l.host for l in environment.runner.user_classes])
-                if len(all_hosts) == 1:
-                    host = list(all_hosts)[0]
-                else:
-                    # since we have multiple User classes with different host attributes, we'll
-                    # inform that specifying host will override the host for all User classes
-                    override_host_warning = True
-                    host = None
-            else:
-                host = None
-
-            options = environment.parsed_options
-            return render_template(
-                "index.html",
-                state=environment.runner.state,
-                is_distributed=is_distributed,
-                user_count=environment.runner.user_count,
-                version=version,
-                host=host,
-                override_host_warning=override_host_warning,
-                num_users=options and options.num_users,
-                spawn_rate=options and options.spawn_rate,
-                step_users=options and options.step_users,
-                step_time=options and options.step_time,
-                worker_count=worker_count,
-                is_step_load=environment.step_load,
-                is_shape=environment.shape_class,
-                stats_history_enabled=options and options.stats_history_enabled,
-            )
+            self.update_template_args()
+            return render_template("index.html", **self.template_args)
 
         @app.route("/swarm", methods=["POST"])
         @self.auth_required_if_enabled
@@ -445,3 +412,44 @@ class WebUI:
                 return view_func(*args, **kwargs)
 
         return wrapper
+
+    def update_template_args(self):
+        override_host_warning = False
+        if self.environment.host:
+            host = self.environment.host
+        elif self.environment.runner.user_classes:
+            all_hosts = set([l.host for l in self.environment.runner.user_classes])
+            if len(all_hosts) == 1:
+                host = list(all_hosts)[0]
+            else:
+                # since we have multiple User classes with different host attributes, we'll
+                # inform that specifying host will override the host for all User classes
+                override_host_warning = True
+                host = None
+        else:
+            host = None
+
+        options = self.environment.parsed_options
+
+        is_distributed = isinstance(self.environment.runner, MasterRunner)
+        if is_distributed:
+            worker_count = self.environment.runner.worker_count
+        else:
+            worker_count = 0
+
+        self.template_args = {
+            "state": self.environment.runner.state,
+            "is_distributed": is_distributed,
+            "user_count": self.environment.runner.user_count,
+            "version": version,
+            "host": host,
+            "override_host_warning": override_host_warning,
+            "num_users": options and options.num_users,
+            "spawn_rate": options and options.spawn_rate,
+            "step_users": options and options.step_users,
+            "step_time": options and options.step_time,
+            "worker_count": worker_count,
+            "is_step_load": self.environment.step_load,
+            "is_shape": self.environment.shape_class,
+            "stats_history_enabled": options and options.stats_history_enabled,
+        }


### PR DESCRIPTION
Addresses #1530. Includes the following additions and changes:

* `index.html` is extendable with blocks for tabs, panes, and scripts
* Args required to properly render `index.html` are retrievable via `web_ui.update_template_args()`
* Event for web UI's Reset Stats button to aid in custom data resetting
* Make some UI classes and functions more generic and more easily reusable for extended UI