### PR TITLE
SequentialTaskSet improvements

### DIFF
--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -388,39 +388,32 @@ within a nested TaskSet, locust will execute that task even if the TaskSet isn't
 SequentialTaskSet class
 =======================
 
-:py:class:`SequentialTaskSet <locust.SequentialTaskSet>` is a TaskSet but its 
-tasks will be executed in the order that they are declared. Weights are ignored for tasks on a 
-SequentialTaskSet class. It is possible to nest SequentialTaskSets within a TaskSet and vice versa.
+:py:class:`SequentialTaskSet <locust.SequentialTaskSet>` is a TaskSet whose tasks will be executed 
+in the order that they are declared. It is possible to nest SequentialTaskSets 
+within a TaskSet and vice versa.
+
+For example, the following code will request URLs /1-/4 in order, and then repeat.
 
 .. code-block:: python
     
     def function_task(taskset):
-        pass
+        taskset.client.get("/3")
     
     class SequenceOfTasks(SequentialTaskSet):
         @task
         def first_task(self):
-            pass
+            self.client.get("/1")
+            self.client.get("/2")
         
+        # you can still use the tasks property to specify a list of tasks
         tasks = [function_task]
         
         @task
-        def second_task(self):
-            pass
+        def last_task(self):
+            self.client.get("/4")
 
-        @task
-        def third_task(self):
-            pass
-
-In the above example, the tasks are executed in the order of declaration: 
-
-1. ``first_task``
-2. ``function_task``
-3. ``second_task``
-4. ``third_task``
-
-and then it will start over at ``first_task`` again.
-
+Note that you dont need SequentialTaskSets to just do some requests in order. It is often easier to 
+just do a whole user flow in a single task.
 
 .. _on-start-on-stop:
 

--- a/examples/browse_docs_sequence_test.py
+++ b/examples/browse_docs_sequence_test.py
@@ -17,6 +17,8 @@ class BrowseDocumentationSequence(SequentialTaskSet):
         pq = PyQuery(r.content)
         link_elements = pq(".toctree-wrapper a.internal")
         self.toc_urls = [l.attrib["href"] for l in link_elements]
+        # it is fine to do multiple requests in a single task, you dont need SequentialTaskSet for that
+        self.client.get("/favicon.ico")
 
     @task
     def load_page(self, url=None):

--- a/locust/user/sequential_taskset.py
+++ b/locust/user/sequential_taskset.py
@@ -1,3 +1,4 @@
+import logging
 from locust.exception import LocustError
 from .task import TaskSet, TaskSetMeta
 
@@ -28,7 +29,8 @@ class SequentialTaskSetMeta(TaskSetMeta):
 
             if "locust_task_weight" in dir(value):
                 # method decorated with @task
-                new_tasks.append(value)
+                for _ in range(value.locust_task_weight):
+                    new_tasks.append(value)
 
         class_dict["tasks"] = new_tasks
         return type.__new__(mcs, classname, bases, class_dict)

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -110,14 +110,14 @@ def get_tasks_from_base_classes(bases, class_dict):
         for task in tasks:
             if isinstance(task, tuple):
                 task, count = task
-                for i in range(count):
+                for _ in range(count):
                     new_tasks.append(task)
             else:
                 new_tasks.append(task)
 
     for item in class_dict.values():
         if "locust_task_weight" in dir(item):
-            for i in range(0, item.locust_task_weight):
+            for i in range(item.locust_task_weight):
                 new_tasks.append(item)
 
     return new_tasks


### PR DESCRIPTION
Clarify documentation to indicate you can do multiple requests in a task without a SequentialTask.

Support task weights (repetitions) instead of silently ignoring them.