### PR TITLE
Run time relative to start when using LoadTestShape

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -1,7 +1,7 @@
 from .event import Events
 from .exception import RunnerAlreadyExistsError
 from .stats import RequestStats
-from .runners import LocalRunner, MasterRunner, WorkerRunner
+from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
 from .web import WebUI
 from .user.task import filter_tasks_by_tags
 from .shape import LoadTestShape
@@ -29,7 +29,7 @@ class Environment:
     stats = None
     """Reference to RequestStats instance"""
 
-    runner = None
+    runner: Runner = None
     """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
 
     web_ui = None

--- a/locust/main.py
+++ b/locust/main.py
@@ -193,10 +193,9 @@ def main():
     environment = create_environment(user_classes, options, events=locust.events, shape_class=shape_class)
 
     if shape_class and (options.num_users or options.spawn_rate or options.step_load):
-        logger.error(
-            "The specified locustfile contains a shape class but a conflicting argument was specified: users, spawn-rate or step-load"
+        logger.warning(
+            "The specified locustfile contains a shape class but a conflicting argument was specified: users, spawn-rate or step-load. Ignoring arguments"
         )
-        sys.exit(1)
 
     if options.show_task_ratio:
         print("\n Task ratio per User class")

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 import warnings
 from uuid import uuid4
-from time import time, monotonic
+from time import time
 
 import gevent
 import greenlet
@@ -352,7 +352,7 @@ class Runner(object):
         self.update_state(STATE_INIT)
         self.shape_greenlet = self.greenlet.spawn(self.shape_worker)
         self.shape_greenlet.link_exception(greenlet_exception_handler)
-        self.environment.shape_class.start_time = monotonic()
+        self.environment.shape_class.reset_time()
 
     def shape_worker(self):
         logger.info("Shape worker starting")

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 import warnings
 from uuid import uuid4
-from time import time
+from time import time, monotonic
 
 import gevent
 import greenlet
@@ -352,6 +352,7 @@ class Runner(object):
         self.update_state(STATE_INIT)
         self.shape_greenlet = self.greenlet.spawn(self.shape_worker)
         self.shape_greenlet.link_exception(greenlet_exception_handler)
+        self.environment.shape_class.start_time = monotonic()
 
     def shape_worker(self):
         logger.info("Shape worker starting")

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -7,7 +7,8 @@ class LoadTestShape(object):
     during a load test.
     """
 
-    start_time = time.monotonic()
+    def __init__(self):
+        self.start_time = time.monotonic()
 
     def reset_time(self):
         """


### PR DESCRIPTION
Adresses #1557

The start time of a test with a shape should now be reset every time a new test is being run. Not from the time of locust init.