### PR TITLE
Make zero wait time the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ Locust is an easy to use, scriptable and scalable performance testing tool. You 
 If you want your users to loop, perform some conditional behaviour or do some calculations, you just use the regular programming constructs provided by Python. Locust runs every user inside its own greenlet (a lightweight process/coroutine). This enables you to write your tests like normal (blocking) Python code instead of having to use callbacks or some other mechanism. Because your scenarios are “just python” you can use your regular IDE, and version control your tests as regular code (as opposed to some other tools that use XML or binary formats)
 
 ```python
-from locust import HttpUser, task, between
+from locust import HttpUser, task
 
 class QuickstartUser(HttpUser):
-    wait_time = between(1, 2)
-
     def on_start(self):
         self.client.post("/login", json={"username":"foo", "password":"bar"})
 

--- a/docs/increase-performance.rst
+++ b/docs/increase-performance.rst
@@ -27,12 +27,10 @@ How to use FastHttpUser
 
 Subclass FastHttpUser instead of HttpUser::
 
-    from locust import task, between
+    from locust import task
     from locust.contrib.fasthttp import FastHttpUser
     
-    class MyUser(FastHttpUser):
-        wait_time = between(2, 5)
-        
+    class MyUser(FastHttpUser):        
         @task
         def index(self):
             response = self.client.get("/")

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,11 +9,9 @@ A Locust performance test is specified in a plain python file:
 .. code-block:: python
 
     import time
-    from locust import HttpUser, task, between
+    from locust import HttpUser, task
 
     class QuickstartUser(HttpUser):
-        wait_time = between(1, 2)
-
         @task
         def index_page(self):
             self.client.get("/hello")
@@ -34,7 +32,7 @@ A Locust performance test is specified in a plain python file:
 .. code-block:: python
 
     import time
-    from locust import HttpUser, task, between
+    from locust import HttpUser, task
 
 A locust file is just a normal Python module, it can import code from other files or packages.
 
@@ -43,13 +41,6 @@ A locust file is just a normal Python module, it can import code from other file
     class QuickstartUser(HttpUser):
 
 The behaviour of a simulated user is represented by a class in your locust file. When you start a test run, Locust will create an instance of the class for each concurrent user.
-
-.. code-block:: python
-
-    wait_time = between(1, 2)
-
-The class defines a ``wait_time`` that will make the simulated users wait between 1 and 2 seconds after each task (see below)
-is executed. For more info see :ref:`wait-time`.
 
 .. code-block:: python
 

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -18,8 +18,8 @@ a User class may define.
 wait_time attribute
 -------------------
 
-A User's :py:attr:`wait_time <locust.User.wait_time>` method is used to determine
-for how long a simulated user should wait between executing tasks.
+A User's :py:attr:`wait_time <locust.User.wait_time>` method is an optional feature used to make 
+a simulated user wait a specified time between task executions.
 
 There are three built in wait time functions: 
 
@@ -142,11 +142,9 @@ The easiest way to add a task for a User is by using the :py:meth:`task <locust.
 
 .. code-block:: python
 
-    from locust import User, task, constant
+    from locust import User, task
 
     class MyUser(User):
-        wait_time = constant(1)
-        
         @task
         def my_task(self):
             print("User instance (%r) executing my_task" % self)
@@ -156,11 +154,9 @@ the following example *task2* will have twice the chance of being picked as *tas
 
 .. code-block:: python
     
-    from locust import User, task, between
+    from locust import User, task
     
     class MyUser(User):
-        wait_time = between(5, 15)
-        
         @task(3)
         def task1(self):
             pass
@@ -192,7 +188,6 @@ Here is an example of a User task declared as a normal python function:
     
     class MyUser(User):
         tasks = [my_task]
-        wait_time = constant(1)
 
 
 If the tasks attribute is specified as a list, each time a task is to be performed, it will be randomly 

--- a/examples/add_command_line_argument.py
+++ b/examples/add_command_line_argument.py
@@ -18,7 +18,6 @@ class WebsiteUser(HttpUser):
     """
 
     host = "http://127.0.0.1:8089"
-    wait_time = between(2, 5)
 
     @task
     def my_task(self):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -25,5 +25,4 @@ class WebsiteUser(HttpUser):
     """
 
     host = "http://127.0.0.1:8089"
-    wait_time = between(2, 5)
     tasks = [UserTasks]

--- a/examples/dynamice_user_credentials.py
+++ b/examples/dynamice_user_credentials.py
@@ -1,6 +1,6 @@
 # locustfile.py
 
-from locust import HttpUser, TaskSet, task, between
+from locust import HttpUser, TaskSet, task
 
 USER_CREDENTIALS = [
     ("user1", "password"),
@@ -23,4 +23,3 @@ class UserBehaviour(TaskSet):
 
 class User(HttpUser):
     tasks = [UserBehaviour]
-    wait_time = between(5, 60)

--- a/examples/events.py
+++ b/examples/events.py
@@ -5,7 +5,7 @@ This is an example of a locustfile that uses Locust's built in event hooks to
 track the sum of the content-length header in all successful HTTP responses
 """
 
-from locust import HttpUser, TaskSet, task, web, between
+from locust import HttpUser, TaskSet, task, web
 from locust import events
 
 
@@ -21,7 +21,6 @@ class MyTaskSet(TaskSet):
 
 class WebsiteUser(HttpUser):
     host = "http://127.0.0.1:8089"
-    wait_time = between(2, 5)
     tasks = [MyTaskSet]
 
 

--- a/examples/fast_http_locust.py
+++ b/examples/fast_http_locust.py
@@ -1,4 +1,4 @@
-from locust import HttpUser, TaskSet, task, between
+from locust import task
 from locust.contrib.fasthttp import FastHttpUser
 
 
@@ -9,7 +9,6 @@ class WebsiteUser(FastHttpUser):
     """
 
     host = "http://127.0.0.1:8089"
-    wait_time = between(2, 5)
     # some things you can configure on FastHttpUser
     # connection_timeout = 60.0
     # insecure = True

--- a/examples/locustfile.py
+++ b/examples/locustfile.py
@@ -1,10 +1,8 @@
 import time
-from locust import HttpUser, task, between
+from locust import HttpUser, task
 
 
 class QuickstartUser(HttpUser):
-    wait_time = between(1, 2)
-
     @task
     def index_page(self):
         self.client.get("/hello")

--- a/examples/multiple_hosts.py
+++ b/examples/multiple_hosts.py
@@ -1,6 +1,6 @@
 import os
 
-from locust import HttpUser, TaskSet, task, between
+from locust import HttpUser, TaskSet, task
 from locust.clients import HttpSession
 
 
@@ -29,5 +29,4 @@ class WebsiteUser(MultipleHostsUser):
     """
 
     host = "http://127.0.0.1:8089"
-    wait_time = between(2, 5)
     tasks = [UserTasks]

--- a/examples/use_as_lib.py
+++ b/examples/use_as_lib.py
@@ -1,5 +1,5 @@
 import gevent
-from locust import HttpUser, task, between
+from locust import HttpUser, task
 from locust.env import Environment
 from locust.stats import stats_printer, stats_history
 from locust.log import setup_logging
@@ -8,7 +8,6 @@ setup_logging("INFO", None)
 
 
 class User(HttpUser):
-    wait_time = between(1, 3)
     host = "https://docs.locust.io"
 
     @task

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -138,8 +138,6 @@ class TestTaskSet(LocustTestCase):
         state = [0]
 
         class MyUser(User):
-            wait_time = constant(0)
-
             @task
             def t1(self):
                 pass
@@ -427,7 +425,6 @@ class TestTaskSet(LocustTestCase):
                 raise StopUser()
 
         class MyUser(User):
-            wait_time = constant(0)
             host = ""
             tasks = [MyTaskSet]
 
@@ -517,7 +514,6 @@ class TestLocustClass(LocustTestCase):
 
     def test_locust_graceful_stop(self):
         class TestUser(User):
-            wait_time = constant(0)
             test_state = 0
 
             @task
@@ -545,7 +541,6 @@ class TestLocustClass(LocustTestCase):
 
     def test_locust_forced_stop(self):
         class TestUser(User):
-            wait_time = constant(0)
             test_state = 0
 
             @task

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -7,7 +7,7 @@ from gevent.queue import Queue
 import greenlet
 
 import locust
-from locust import runners, between, constant, LoadTestShape
+from locust import runners, constant, LoadTestShape
 from locust.main import create_environment
 from locust.user import User, TaskSet, task
 from locust.env import Environment
@@ -306,8 +306,6 @@ class TestLocustRunner(LocustTestCase):
 
     def test_reset_stats(self):
         class MyUser(User):
-            wait_time = constant(0)
-
             @task
             class task_set(TaskSet):
                 @task
@@ -331,8 +329,6 @@ class TestLocustRunner(LocustTestCase):
 
     def test_no_reset_stats(self):
         class MyUser(User):
-            wait_time = constant(0)
-
             @task
             class task_set(TaskSet):
                 @task
@@ -362,7 +358,6 @@ class TestLocustRunner(LocustTestCase):
 
     def test_users_can_call_runner_quit_without_deadlocking(self):
         class BaseUser(User):
-            wait_time = constant(0)
             stop_triggered = False
 
             @task
@@ -387,7 +382,6 @@ class TestLocustRunner(LocustTestCase):
 
     def test_runner_quit_can_run_on_stop_for_multiple_users_concurrently(self):
         class BaseUser(User):
-            wait_time = constant(0)
             stop_count = 0
 
             @task
@@ -500,8 +494,6 @@ class TestMasterWorkerRunners(LocustTestCase):
         """
 
         class TestUser(User):
-            wait_time = constant(0)
-
             @task
             def my_task(self):
                 pass
@@ -557,8 +549,6 @@ class TestMasterWorkerRunners(LocustTestCase):
         """
 
         class TestUser(User):
-            wait_time = constant(0)
-
             @task
             def my_task(self):
                 pass
@@ -1056,8 +1046,6 @@ class TestMasterRunner(LocustTestCase):
 
     def test_custom_shape_scale_up(self):
         class MyUser(User):
-            wait_time = constant(0)
-
             @task
             def my_task(self):
                 pass
@@ -1110,8 +1098,6 @@ class TestMasterRunner(LocustTestCase):
 
     def test_custom_shape_scale_down(self):
         class MyUser(User):
-            wait_time = constant(0)
-
             @task
             def my_task(self):
                 pass
@@ -1254,7 +1240,6 @@ class TestWorkerRunner(LocustTestCase):
     def test_worker_stop_timeout(self):
         class MyTestUser(User):
             _test_state = 0
-            wait_time = constant(0)
 
             @task
             def the_task(self):
@@ -1304,7 +1289,6 @@ class TestWorkerRunner(LocustTestCase):
     def test_worker_without_stop_timeout(self):
         class MyTestUser(User):
             _test_state = 0
-            wait_time = constant(0)
 
             @task
             def the_task(self):
@@ -1411,7 +1395,6 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = constant(0)
 
         environment = Environment(user_classes=[MyTestUser])
         runner = environment.create_local_runner()
@@ -1461,7 +1444,6 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = constant(0)
 
         environment = create_environment([MyTestUser], mocked_options())
         environment.stop_timeout = short_time
@@ -1483,7 +1465,7 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = between(1, 1)
+            wait_time = constant(1)
 
         environment = Environment(user_classes=[MyTestUser], stop_timeout=short_time)
         runner = environment.create_local_runner()
@@ -1513,7 +1495,6 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = constant(0)
 
         environment = create_environment([MyTestUser], mocked_options())
         environment.stop_timeout = short_time
@@ -1574,7 +1555,6 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = constant(0)
 
         environment = create_environment([MyTestUser], mocked_options())
         runner = environment.create_local_runner()
@@ -1664,7 +1644,6 @@ class TestStopTimeout(LocustTestCase):
 
         class MyTestUser(User):
             tasks = [MyTaskSet]
-            wait_time = constant(0)
 
         environment = Environment(user_classes=[MyTestUser], stop_timeout=2)
         runner = environment.create_local_runner()

--- a/locust/test/test_sequential_taskset.py
+++ b/locust/test/test_sequential_taskset.py
@@ -10,7 +10,6 @@ class TestTaskSet(LocustTestCase):
 
         class MyUser(User):
             host = "127.0.0.1"
-            wait_time = constant(0)
 
         self.locust = MyUser(self.environment)
 

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -43,9 +43,9 @@ class TestWaitTime(LocustTestCase):
         self.assertEqual(13, MyUser(self.environment).wait_time())
         self.assertEqual(13, TaskSet1(MyUser(self.environment)).wait_time())
 
-    def test_constant_zero(self):
+    def test_default_wait_time(self):
         class MyUser(User):
-            wait_time = constant(0)
+            pass  # default is wait_time = constant(0)
 
         class TaskSet1(TaskSet):
             pass
@@ -77,12 +77,3 @@ class TestWaitTime(LocustTestCase):
             time.sleep(random.random() * 0.1)
             _ = ts2.wait_time()
             _ = ts2.wait_time()
-
-    def test_missing_wait_time(self):
-        class MyUser(User):
-            pass
-
-        class TS(TaskSet):
-            pass
-
-        self.assertRaises(MissingWaitTimeError, lambda: TS(MyUser(self.environment)).wait_time())

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,3 +1,4 @@
+from locust.user.wait_time import constant
 from typing import Any, Callable, List, TypeVar, Union
 from gevent import GreenletExit, greenlet
 from gevent.pool import Group
@@ -56,7 +57,7 @@ class User(object, metaclass=UserMeta):
     max_wait = None
     """Deprecated: Use wait_time instead. Maximum waiting time between the execution of locust tasks"""
 
-    wait_time = None
+    wait_time = constant(0)
     """
     Method that returns the time (in seconds) between the execution of locust tasks.
     Can be overridden for individual TaskSets.


### PR DESCRIPTION
Make wait_time = constant(0) the default instead of forcing our users to specify it on every user class. 

This makes a big difference in readability of small User classes and reduces the cognitive overhead for locust beginners. Fixes #1308