### PR TITLE
Fix 100% cpu usage when running in docker/non-tty terminal

### DIFF
--- a/locust/input_events.py
+++ b/locust/input_events.py
@@ -94,7 +94,7 @@ def input_listener(key_to_func_map):
         try:
             while True:
                 input = poller.poll()
-                if input is not None:
+                if input:
                     for key in key_to_func_map:
                         if input == key:
                             key_to_func_map[key]()

--- a/locust/input_events.py
+++ b/locust/input_events.py
@@ -24,12 +24,12 @@ class InitError(Exception):
 
 class UnixKeyPoller:
     def __init__(self):
-        if sys.stdout.isatty():
+        if sys.stdin.isatty():
             self.stdin = sys.stdin.fileno()
             self.tattr = termios.tcgetattr(self.stdin)
             tty.setcbreak(self.stdin, termios.TCSANOW)
         else:
-            raise InitError("Failed to get terminal attributes during keypoller init. Keyboard input disabled")
+            raise InitError("Terminal was not a tty. Keyboard input disabled")
 
     def cleanup(self):
         termios.tcsetattr(self.stdin, termios.TCSANOW, self.tattr)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import pty
 import signal
 import subprocess
 import textwrap
@@ -297,7 +298,19 @@ class LoadTestShape(LoadTestShape):
             proc.terminate()
 
     def test_input(self):
-        with mock_locustfile() as mocked:
+        LOCUSTFILE_CONTENT = textwrap.dedent("""
+        from locust import User, TaskSet, task, between
+        
+        class UserSubclass(User):
+            wait_time = between(0.2, 0.8)
+            @task
+            def t(self):
+                print("Test task is running")
+        """)
+        with mock_locustfile(content=LOCUSTFILE_CONTENT) as mocked:
+            stdin_m, stdin_s = pty.openpty()
+            stdin = os.fdopen(stdin_m, "wb", 0)
+
             proc = subprocess.Popen(
                 " ".join(
                     [
@@ -312,20 +325,26 @@ class LoadTestShape(LoadTestShape):
                     ]
                 ),
                 stderr=STDOUT,
-                stdin=PIPE,
+                stdin=stdin_s,
                 stdout=PIPE,
                 shell=True,
             )
-
             gevent.sleep(1)
-            proc.stdin.write(b"w")
-            proc.stdin.write(b"W")
-            proc.stdin.write(b"s")
-            proc.stdin.write(b"S")
+            
+            stdin.write(b"w")
+            gevent.sleep(0.1)
+            stdin.write(b"W")
+            gevent.sleep(0.1)
+            stdin.write(b"s")
+            gevent.sleep(0.1)
+            stdin.write(b"S")
+
             gevent.sleep(1)
 
             output = proc.communicate()[0].decode("utf-8")
+            stdin.close()
             self.assertIn("Spawning 1 users at the rate 100 users/s", output)
             self.assertIn("Spawning 10 users at the rate 100 users/s", output)
             self.assertIn("1 Users have been stopped", output)
             self.assertIn("10 Users have been stopped", output)
+            self.assertIn("Test task is running", output)


### PR DESCRIPTION
Raise and catch an exception when failing to get terminal attributes.