### PR TITLE
URLs with non default (param=value) query strings doesn't work with FastHttpUser

### DIFF
--- a/locust/test/test_client.py
+++ b/locust/test/test_client.py
@@ -196,3 +196,8 @@ class TestHttpSession(WebserverTestCase):
             pass
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
+
+    def test_querystring_different_format(self):
+        s = self.get_client()
+        response = s.get("/querystring?this/is/a/non-standard/querystring")
+        self.assertEqual("this/is/a/non-standard/querystring", response.text)

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -173,6 +173,11 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
 
+    def test_querystring_different_format(self):
+        s = self.get_client()
+        response = s.get("/querystring?this/is/a/non-standard/querystring")
+        self.assertEqual("this/is/a/non-standard/querystring", response.text)
+
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def test_request_stats_content_length(self):

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -139,6 +139,7 @@ def set_cookie():
 def get_cookie():
     return make_response(request.cookies.get(request.args.get("name"), ""))
 
+
 @app.route("/querystring")
 def get_querystring():
     return request.query_string

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -139,6 +139,10 @@ def set_cookie():
 def get_cookie():
     return make_response(request.cookies.get(request.args.get("name"), ""))
 
+@app.route("/querystring")
+def get_querystring():
+    return request.query_string
+
 
 class LocustTestCase(unittest.TestCase):
     """

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "requests>=2.9.1",
         "msgpack>=0.6.2",
         "pyzmq>=16.0.2",
-        "geventhttpclient>=1.4.4",
+        "geventhttpclient>=1.4.5",
         "ConfigArgParse>=1.0",
         "psutil>=5.6.7",
         "Flask-BasicAuth>=0.2.0",


### PR DESCRIPTION
Currently it's not possible to make a request - using the FastHttpUser client - to URLs such as:

`http://example.com/get-file?path/to/file`

The fix needs to be implemented in the geventhttpclient lib, and I've made a PR for that here:
https://github.com/gwik/geventhttpclient/pull/134

This PR has a (currently failing) test for this. Once the above PR is merged, and a new geventhttpclient version released, we should bump the required geventhttpclient version, and merge this PR.