### PR TITLE
Add feature locust launcher useful for run/debug on IDEs like PyCharm

### DIFF
--- a/locust.py
+++ b/locust.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+from locust.main import main
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())


### PR DESCRIPTION
Add feature locust launcher useful for run/debug on IDEs like PyCharm
Borrowed from the virtualenv installed package used for execute locust in the command-line

This will help to setup locust in an IDE like the following image
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/404966/101840401-0688a280-3b12-11eb-88c3-c3936cff3335.png">

Using this script to run locust in the IDE will fix import errors related to the usage of others scripts like `main.py`, `__init__.py` and `__main__.py`

It's only an utility file to easy the develop of locust. An entry in the documentation will be needed if this PR become merged. I could include it as part of this PR. 
This PR is related to the issue #613 