### PR TITLE
Feature chart sync

### DIFF
--- a/locust/static/chart.js
+++ b/locust/static/chart.js
@@ -47,7 +47,9 @@
                                 var param = params[i];
                                 str += '<br><span style="color:' + param.color + ';">' + param.seriesName + ': ' + param.data.value + '</span>';
                             }
-                            str += '<br><span style="color:#a3b3ac;">Users: ' + param.data.users + '</span>';
+                            if(param.data.users != undefined){
+                                str += '<br><span style="color:#a3b3ac;">Users: ' + param.data.users + '</span>';
+                            }
                             return str;
                         } else {
                             return "No data";

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -178,7 +178,34 @@ $("#workers .stats_label").click(function(event) {
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
-charts.push(rpsChart, responseTimeChart, usersChart)
+charts.push(rpsChart, responseTimeChart, usersChart);
+
+if(stats_history["time"].length > 0){
+    rpsChart.chart.setOption({
+        xAxis: {data: stats_history["time"]},
+        series: [
+            {data: stats_history["current_rps"]},
+            {data: stats_history["current_fail_per_sec"]},
+        ]
+    });
+
+    responseTimeChart.chart.setOption({
+        xAxis: {data: stats_history["time"]},
+        series: [
+            {data: stats_history["response_time_percentile_50"]},
+            {data: stats_history["response_time_percentile_95"]},
+        ]
+    });
+
+    usersChart.chart.setOption({
+        xAxis: {
+            data: stats_history["time"]
+        },
+        series: [
+            {data: stats_history["user_count"]},
+        ]
+    });
+}
 
 function updateStats() {
     $.get('./stats/requests', function (report) {

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,15 +784,16 @@ def stats_history(runner):
         stats = runner.stats
         if not stats.total.use_response_times_cache:
             break
-        r = {
-            "time": datetime.datetime.now().strftime("%H:%M:%S"),
-            "current_rps": stats.total.current_rps or 0,
-            "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-            "response_time_percentile_95": stats.total.get_current_response_time_percentile(0.95) or 0,
-            "response_time_percentile_50": stats.total.get_current_response_time_percentile(0.5) or 0,
-            "user_count": runner.user_count or 0,
-        }
-        stats.history.append(r)
+        if runner.state != 'stopped':
+            r = {
+                "time": datetime.datetime.now().strftime("%H:%M:%S"),
+                "current_rps": stats.total.current_rps or 0,
+                "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
+                "response_time_percentile_95": stats.total.get_current_response_time_percentile(0.95) or 0,
+                "response_time_percentile_50": stats.total.get_current_response_time_percentile(0.5) or 0,
+                "user_count": runner.user_count or 0,
+            }
+            stats.history.append(r)
         gevent.sleep(HISTORY_STATS_INTERVAL_SEC)
 
 

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -304,22 +304,7 @@
         ]]>
     </script>
     <script type="text/javascript">
-        var stats_history = {
-            "time": [],
-            "user_count": [],
-            "current_rps": [],
-            "current_fail_per_sec": [],
-            "response_time_percentile_50": [],
-            "response_time_percentile_95": [],
-        };
-        {% for r in history %}
-            stats_history["time"].push("{{ r.time }}");
-            stats_history["user_count"].push({{ r.user_count }});
-            stats_history["current_rps"].push({{ r.current_rps }});
-            stats_history["current_fail_per_sec"].push({{ r.current_fail_per_sec }});
-            stats_history["response_time_percentile_50"].push({{ r.response_time_percentile_50 }});
-            stats_history["response_time_percentile_95"].push({{ r.response_time_percentile_95 }});
-        {% endfor %}
+        {% include 'stats_data.html' %}
     </script>
     <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>
     <script type="text/javascript" src="./static/locust.js?v={{ version }}"></script>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -152,7 +152,6 @@
             </div>
             <div id="charts" style="display:none;">
                 <div class="charts-container"></div>
-                <p class="note">Note: There is no persistence of these charts, if you refresh this page, new charts will be created.</p>
             </div>
             <div style="display:none;">
                 <table id="errors" class="stats">
@@ -303,6 +302,24 @@
         </tr>
         <% alternate = !alternate; %>
         ]]>
+    </script>
+    <script type="text/javascript">
+        var stats_history = {
+            "time": [],
+            "user_count": [],
+            "current_rps": [],
+            "current_fail_per_sec": [],
+            "response_time_percentile_50": [],
+            "response_time_percentile_95": [],
+        };
+        {% for r in history %}
+            stats_history["time"].push("{{ r.time }}");
+            stats_history["user_count"].push({{ r.user_count }});
+            stats_history["current_rps"].push({{ r.current_rps }});
+            stats_history["current_fail_per_sec"].push({{ r.current_fail_per_sec }});
+            stats_history["response_time_percentile_50"].push({{ r.response_time_percentile_50 }});
+            stats_history["response_time_percentile_95"].push({{ r.response_time_percentile_95 }});
+        {% endfor %}
     </script>
     <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>
     <script type="text/javascript" src="./static/locust.js?v={{ version }}"></script>

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -188,51 +188,37 @@
     </script>
 
     <script>
-
+        {% include 'stats_data.html' %}
         var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
         var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
         var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
-        rpsChart.chart.setOption({
-            xAxis: {
-                data: [ {% for r in history %}"{{ r.time }}", {% endfor %} ],
-            },
-            series: [
-                {
-                    data: [ {% for r in history %}{{ r.current_rps }}, {% endfor %} ]
-                },
-                {
-                    data: [ {% for r in history %}{{ r.current_fail_per_sec }}, {% endfor %} ]
-                },
-            ]
-        });
+        if(stats_history["time"].length > 0){
+            rpsChart.chart.setOption({
+                xAxis: {data: stats_history["time"]},
+                series: [
+                    {data: stats_history["current_rps"]},
+                    {data: stats_history["current_fail_per_sec"]},
+                ]
+            });
 
-        responseTimeChart.chart.setOption({
-            xAxis: {
-                data: [ {% for r in history %}"{{ r.time }}", {% endfor %} ],
-            },
-            series: [
-                {
-                    data: [ {% for r in history %}{{ r.response_time_percentile_50 }}, {% endfor %} ]
-                },
-                {
-                    data: [ {% for r in history %}{{ r.response_time_percentile_95 }}, {% endfor %} ]
-                },
-            ]
-        });
+            responseTimeChart.chart.setOption({
+                xAxis: {data: stats_history["time"]},
+                series: [
+                    {data: stats_history["response_time_percentile_50"]},
+                    {data: stats_history["response_time_percentile_95"]},
+                ]
+            });
 
-        usersChart.chart.setOption({
-            xAxis: {
-                data: [ {% for r in history %}"{{ r.time }}", {% endfor %} ],
-            },
-            series: [
-                {
-                    data: [ {% for r in history %}{{ r.user_count }}, {% endfor %} ]
+            usersChart.chart.setOption({
+                xAxis: {
+                    data: stats_history["time"]
                 },
-            ]
-        });
-
-
+                series: [
+                    {data: stats_history["user_count"]},
+                ]
+            });
+        }
     </script>
 </body>
 </html>

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -1,0 +1,17 @@
+var stats_history = {
+    "time": [],
+    "user_count": [],
+    "current_rps": [],
+    "current_fail_per_sec": [],
+    "response_time_percentile_50": [],
+    "response_time_percentile_95": [],
+};
+{% for r in history %}
+    var user_count = {{ r.user_count }};
+    stats_history["time"].push("{{ r.time }}");
+    stats_history["user_count"].push({"value": user_count});
+    stats_history["current_rps"].push({"value": {{ r.current_rps }}, "users": user_count});
+    stats_history["current_fail_per_sec"].push({"value": {{ r.current_fail_per_sec }}, "users": user_count});
+    stats_history["response_time_percentile_50"].push({"value": {{ r.response_time_percentile_50 }}, "users": user_count});
+    stats_history["response_time_percentile_95"].push({"value": {{ r.response_time_percentile_95 }}, "users": user_count});
+{% endfor %}

--- a/locust/web.py
+++ b/locust/web.py
@@ -390,12 +390,15 @@ class WebUI:
         else:
             worker_count = 0
 
+        stats = self.environment.runner.stats
+
         self.template_args = {
             "state": self.environment.runner.state,
             "is_distributed": is_distributed,
             "user_count": self.environment.runner.user_count,
             "version": version,
             "host": host,
+            "history": stats.history,
             "override_host_warning": override_host_warning,
             "num_users": options and options.num_users,
             "spawn_rate": options and options.spawn_rate,


### PR DESCRIPTION
This PR improves the charts of the index and the report page with the following changes:
- Prevent to continue reporting stats to the history of stats when the runner is stopped
- Usage of shared template to build stats_history data to reload to charts data in the index.html and report.html templates
- Fix Report Charts tooltips user count values

Fixes #1677