### PR TITLE
Fix Test by use report file as bytes

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -417,17 +417,15 @@ def main():
     # install SIGTERM handler
     def sig_term_handler():
         logger.info("Got SIGTERM signal")
-        shutdown()
 
     gevent.signal_handler(signal.SIGTERM, sig_term_handler)
 
     try:
         logger.info("Starting Locust %s" % version)
         main_greenlet.join()
+    finally:
         if options.html_file:
             html_report = get_html_report(environment, show_download_link=False)
-            with open(options.html_file, "w+") as file:
-                file.write(html_report)
-        shutdown()
-    except KeyboardInterrupt:
+            with open(options.html_file, "wb+") as file:
+                file.write(html_report.encode("utf-8"))
         shutdown()

--- a/locust/main.py
+++ b/locust/main.py
@@ -426,6 +426,6 @@ def main():
     finally:
         if options.html_file:
             html_report = get_html_report(environment, show_download_link=False)
-            with open(options.html_file, "wb+") as file:
-                file.write(html_report.encode("utf-8"))
+            with open(options.html_file, "w", encoding="utf-8") as file:
+                file.write(html_report)
         shutdown()


### PR DESCRIPTION
The update of Echarts contains ascii characters that provoke errors when saving the html file with the concatenated content containing those ascii characters.
To solve this I have changed the file to handle bytes

Results of the changes:
-----------------------------
I have been working with this thing of tests failing a little bit and this are my results
```log
  py36: commands succeeded
ERROR:   py37: commands failed
  py38: commands succeeded
  py39: commands succeeded
```
Only py37 tests are failling but it's due to that it's not installing the python dependencies with errors like this:
```logs

FAILED (errors=14)
ERROR: InvocationError for command /Users/axel/git-workspace/locust/.tox/py37/bin/coverage run -m unittest discover (exited with code 1)

======================================================================
ERROR: locust.test.test_runners (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: locust.test.test_runners
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/Users/axel/git-workspace/locust/locust/test/test_runners.py", line 11, in <module>
    from locust.main import create_environment
  File "/Users/axel/git-workspace/locust/locust/main.py", line 15, in <module>
    from .argument_parser import parse_locustfile_option, parse_options
  File "/Users/axel/git-workspace/locust/locust/argument_parser.py", line 6, in <module>
    import configargparse
ModuleNotFoundError: No module named 'configargparse'


======================================================================
ERROR: locust.test.test_sequential_taskset (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: locust.test.test_sequential_taskset
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/Users/axel/git-workspace/locust/locust/test/test_sequential_taskset.py", line 4, in <module>
    from .testcases import LocustTestCase
  File "/Users/axel/git-workspace/locust/locust/test/testcases.py", line 17, in <module>
    from locust.env import Environment
  File "/Users/axel/git-workspace/locust/locust/env.py", line 5, in <module>
    from .web import WebUI
  File "/Users/axel/git-workspace/locust/locust/web.py", line 15, in <module>
    from flask_basicauth import BasicAuth
ModuleNotFoundError: No module named 'flask_basicauth'
```

py36, py38 and py39 logs are good, like:

```logs
py36 inst-nodeps: /Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip
py36 installed: appdirs==1.4.4,black==20.8b1,certifi==2020.12.5,cffi==1.14.4,chardet==4.0.0,click==7.1.2,codecov==2.1.11,ConfigArgParse==1.2.3,coverage==5.3.1,cryptography==3.3.1,cssselect==1.1.0,dataclasses==0.8,flake8==3.8.4,Flask==1.1.2,Flask-BasicAuth==0.2.0,gevent==21.1.1,geventhttpclient==1.4.4,greenlet==1.0.0,idna==2.10,importlib-metadata==3.4.0,itsdangerous==1.1.0,Jinja2==2.11.2,locust @ file:///Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip,lxml==4.6.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,msgpack==1.0.2,mypy-extensions==0.4.3,pathspec==0.8.1,psutil==5.8.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,pyquery==1.4.3,pyzmq==21.0.1,regex==2020.11.13,requests==2.25.1,six==1.15.0,toml==0.10.2,typed-ast==1.4.2,typing-extensions==3.7.4.3,urllib3==1.26.2,Werkzeug==1.0.1,zipp==3.4.0,zope.event==4.5.0,zope.interface==5.2.0
py36 run-test-pre: PYTHONHASHSEED='3083370141'
py36 run-test: commands[0] | flake8 . --count --show-source --statistics
0
py36 run-test: commands[1] | coverage run -m unittest discover
...................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 323 tests in 95.483s

OK
py36 run-test: commands[2] | black --check .
All done! ✨ 🍰 ✨
77 files would be left unchanged.

py38 create: /Users/axel/git-workspace/locust/.tox/py38
py38 installdeps: codecov, flake8, mock, pyquery, cryptography, black
py38 inst: /Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip
py38 installed: appdirs==1.4.4,black==20.8b1,certifi==2020.12.5,cffi==1.14.4,chardet==4.0.0,click==7.1.2,codecov==2.1.11,ConfigArgParse==1.2.3,coverage==5.3.1,cryptography==3.3.1,cssselect==1.1.0,flake8==3.8.4,Flask==1.1.2,Flask-BasicAuth==0.2.0,gevent==21.1.1,geventhttpclient==1.4.4,greenlet==1.0.0,idna==2.10,itsdangerous==1.1.0,Jinja2==2.11.2,locust @ file:///Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip,lxml==4.6.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,msgpack==1.0.2,mypy-extensions==0.4.3,pathspec==0.8.1,psutil==5.8.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,pyquery==1.4.3,pyzmq==21.0.1,regex==2020.11.13,requests==2.25.1,six==1.15.0,toml==0.10.2,typed-ast==1.4.2,typing-extensions==3.7.4.3,urllib3==1.26.2,Werkzeug==1.0.1,zope.event==4.5.0,zope.interface==5.2.0
py38 run-test-pre: PYTHONHASHSEED='3083370141'
py38 run-test: commands[0] | flake8 . --count --show-source --statistics
0
py38 run-test: commands[1] | coverage run -m unittest discover
...................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 323 tests in 95.786s

OK
py38 run-test: commands[2] | black --check .
All done! ✨ 🍰 ✨
77 files would be left unchanged.
py39 recreate: /Users/axel/git-workspace/locust/.tox/py39
py39 installdeps: codecov, flake8, mock, pyquery, cryptography, black
py39 inst: /Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip
py39 installed: appdirs==1.4.4,black==20.8b1,certifi==2020.12.5,cffi==1.14.4,chardet==4.0.0,click==7.1.2,codecov==2.1.11,ConfigArgParse==1.2.3,coverage==5.3.1,cryptography==3.3.1,cssselect==1.1.0,flake8==3.8.4,Flask==1.1.2,Flask-BasicAuth==0.2.0,gevent==21.1.1,geventhttpclient==1.4.4,greenlet==1.0.0,idna==2.10,itsdangerous==1.1.0,Jinja2==2.11.2,locust @ file:///Users/axel/git-workspace/locust/.tox/.tmp/package/1/locust-1.4.1.zip,lxml==4.6.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,msgpack==1.0.2,mypy-extensions==0.4.3,pathspec==0.8.1,psutil==5.8.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,pyquery==1.4.3,pyzmq==21.0.1,regex==2020.11.13,requests==2.25.1,six==1.15.0,toml==0.10.2,typed-ast==1.4.2,typing-extensions==3.7.4.3,urllib3==1.26.2,Werkzeug==1.0.1,zope.event==4.5.0,zope.interface==5.2.0
py39 run-test-pre: PYTHONHASHSEED='3083370141'
py39 run-test: commands[0] | flake8 . --count --show-source --statistics
0
py39 run-test: commands[1] | coverage run -m unittest discover
...................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 323 tests in 95.664s

OK
py39 run-test: commands[2] | black --check .
All done! ✨ 🍰 ✨
77 files would be left unchanged.
```