### PR TITLE
add LoadTestShape to __all__ in order to fix warning "'LoadTestShape'…

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -26,6 +26,7 @@ __all__ = (
     "constant",
     "constant_pacing",
     "events",
+    "LoadTestShape",
 )
 
 # Used for raising a DeprecationWarning if old Locust/HttpLocust is used


### PR DESCRIPTION
add LoadTestShape to __all__ in order to fix warning "'LoadTestShape' is not declared in __all__" raised by pycharm code->inspect