### PR TITLE
updated double wave load shape docs to reflect peak times

### DIFF
--- a/examples/custom_shape/double_wave.py
+++ b/examples/custom_shape/double_wave.py
@@ -17,7 +17,8 @@ class WebsiteUser(HttpUser):
 class DoubleWave(LoadTestShape):
     """
     A shape to immitate some specific user behaviour. In this example, midday
-    and evening meal times.
+    and evening meal times. First peak of users appear at time_limit/3 and
+    second peak appears at 2*time_limit/3
 
     Settings:
         min_users -- minimum users


### PR DESCRIPTION
Currently it might not be directly clear where the peaks are for double wave load shape class. Adding for clarification.