### PR TITLE
Fix automatic distributed test shutdown

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -608,7 +608,7 @@ class MasterRunner(DistributedRunner):
                     logger.info("Worker %s failed to send heartbeat, setting state to missing." % str(client.id))
                     client.state = STATE_MISSING
                     client.user_count = 0
-                    if self.worker_count - len(self.clients.missing) <= 0:
+                    if self.worker_count <= 0:
                         logger.info("The last worker went missing, stopping test.")
                         self.stop()
                         self.check_stopped()


### PR DESCRIPTION
This PR fixes #1707 by not subtracting missing workers from the active workers list (which excludes missing workers already).

Also adds another log message when workers are coming back (including currently active users - which required an event data extension).

The existing test `test_runners::test_last_worker_missing_stops_test` was also checking for the wrong state (missed to check for "stopping" in addition to "stopped", since the created clients cannot react to a stop event in the test.