### PR TITLE
Ensure runner.quit finishes even when users are broken

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -4,6 +4,7 @@ import random
 import socket
 import sys
 import traceback
+from typing import Type, List
 import warnings
 from uuid import uuid4
 from time import time
@@ -132,7 +133,7 @@ class Runner:
             return True
         return False
 
-    def weight_users(self, amount):
+    def weight_users(self, amount) -> List[Type[User]]:
         """
         Distributes the amount of users for each WebLocust-class according to it's weight
         returns a list "bucket" with the weighted users

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -219,12 +219,18 @@ class Runner:
         bucket = self.weight_users(user_count)
         user_count = len(bucket)
         to_stop = []
-        for g in self.user_greenlets:
-            for l in bucket:
-                user = g.args[0]
-                if isinstance(user, l):
+        for user_greenlet in self.user_greenlets:
+            try:
+                user = user_greenlet.args[0]
+            except IndexError:
+                logger.error(
+                    "While stopping users, we encountered a user that didnt have proper args %s", user_greenlet
+                )
+                continue
+            for user_class in bucket:
+                if isinstance(user, user_class):
                     to_stop.append(user)
-                    bucket.remove(l)
+                    bucket.remove(user_class)
                     break
 
         if not to_stop:


### PR DESCRIPTION
Workaround for #1726

This should change it from throwing an exception (and thus failing to stop), to instead logging an error message and then moving on (havent been able to test it 100% though). May give us some more info for a proper fix as well.

[2021-03-11 12:54:24,150] lafp-mac-JG5J.int.svenskaspel.se/INFO/locust.main: Shutting down (exit code 0), bye.
[2021-03-11 12:54:24,150] lafp-mac-JG5J.int.svenskaspel.se/INFO/locust.main: Cleaning up runner...
[2021-03-11 12:54:24,150] lafp-mac-JG5J.int.svenskaspel.se/ERROR/locust.runners: Found a user that didnt have proper args <Greenlet "Greenlet-0" at 0x112c863b0: run_user(<player_settings.WebUser object at 0x112b1f650>)>