### PR TITLE
Updated request event with context 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Migrate code style to Black
 7c0fcc213d3988f6e7c6ffef63b24afe00e5fbd9
+2e7a8b5697a98d1d314d6fc3ef0589f81f09d7fe

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,7 @@ User class
 ============
 
 .. autoclass:: locust.User
-    :members: wait_time, tasks, weight, abstract, on_start, on_stop, wait
+    :members: wait_time, tasks, weight, abstract, on_start, on_stop, wait, context
 
 HttpUser class
 ================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,8 @@ For full details of the Locust changelog, please see https://github.com/locustio
 1.5.0
 =====
 
-* Add new event called request. Is called on every request successful or not. request_success and request_failure are still available but can be considered deprecated
-* Add parameter to the request event. Can be used to forward information when calling a request, things like user information, tags etc
+* Add new event called request. Is called on every request successful or not. request_success and request_failure are still available but are deprecated
+* Add parameter context to the request event. Can be used to forward information when calling a request, things like user information, tags etc
 
 1.4.4
 =====

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog Highlights
 
 For full details of the Locust changelog, please see https://github.com/locustio/locust/blob/master/CHANGELOG.md
 
+1.5.0
+=====
+
+* Add new event called request. Is called on every request successful or not. request_success and request_failure are still available but can be considered deprecated
+* Add parameter to the request event. Can be used to forward information when calling a request, things like user information, tags etc
+
 1.4.4
 =====
 

--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -15,9 +15,10 @@ Here's an example on how to set up an event listener::
 
     from locust import events
     
-    @events.request_success.add_listener
-    def my_success_handler(request_type, name, response_time, response_length, **kw):
-        print("Successfully made a request to: %s" % name)
+    @events.request.add_listener
+    def my_request_handler(request_type, name, response_time, response_length, context, exception, **kw):
+        if not exception:
+            print("Successfully made a request to: %s" % name)
 
 
 .. note::

--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -17,8 +17,10 @@ Here's an example on how to set up an event listener::
     
     @events.request.add_listener
     def my_request_handler(request_type, name, response_time, response_length, context, exception, **kw):
-        if not exception:
-            print("Successfully made a request to: %s" % name)
+        if exception:
+            print(f"Request to {name} failed with exception {exception}")
+        else:
+            print(f"Successfully made a request to: {name})
 
 
 .. note::

--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -29,10 +29,44 @@ Here's an example on how to set up an event listener::
     (the \**kw in the code above), to prevent your code from breaking if new arguments are
     added in a future version.
 
+
+Request context
+==================
+
+By using the context parameter in the request method information you can attach data that will be forwarded by the 
+request event. This should be a dictionary and can be set directly when calling request() or on a class level 
+by overwriting the User.context() method. 
+
+Context from request method::
+
+    class MyUser(HttpUser):
+        @task
+        def t(self):
+            self.client.post("/login", json={"username": "foo"}, context={"username": "foo"})
+
+        @events.request.add_listener
+        def on_request(context, **kwargs):
+            print(context["username"])
+    
+Context from User class::
+
+    class MyUser(HttpUser):
+        def context(self):
+            return {"username": self.username}
+
+        @task
+        def t(self):
+            self.username = "foo"
+            self.client.post("/login", json={"username": self.username})
+
+        @events.request.add_listener
+        def on_request(self, context, **kwargs):
+            print(context["username"])
+
+
 .. seealso::
 
     To see all available events, please see :ref:`events`.
-
 
 
 Adding Web Routes

--- a/docs/testing-other-systems.rst
+++ b/docs/testing-other-systems.rst
@@ -6,8 +6,7 @@ Testing other systems using custom clients
 
 Locust was built with HTTP as its main target. However, it can easily be extended to load test 
 any request/response based system, by writing a custom client that triggers 
-:py:attr:`request_success <locust.event.Events.request_success>` and 
-:py:attr:`request_failure <locust.event.Events.request_failure>` events.
+:py:attr:`request <locust.event.Events.request>`
 
 .. note::
 
@@ -32,7 +31,7 @@ using ``abstract = True`` which means that Locust will not try to create simulat
 
 The ``XmlRpcClient`` is a wrapper around the standard 
 library's :py:class:`xmlrpc.client.ServerProxy`. It basically just proxies the function calls, but with the
-important addition of firing :py:attr:`locust.event.Events.request_success` and :py:attr:`locust.event.Events.request_failure` 
+important addition of firing :py:attr:`locust.event.Events.request`
 events, which will record all calls in Locust's statistics.
 
 Here's an implementation of an XML-RPC server that would work as a server for the code above:

--- a/docs/testing-other-systems.rst
+++ b/docs/testing-other-systems.rst
@@ -32,7 +32,7 @@ using ``abstract = True`` which means that Locust will not try to create simulat
 The ``XmlRpcClient`` is a wrapper around the standard 
 library's :py:class:`xmlrpc.client.ServerProxy`. It basically just proxies the function calls, but with the
 important addition of firing :py:attr:`locust.event.Events.request`
-events, which will record all calls in Locust's statistics.
+event, which will record all calls in Locust's statistics.
 
 Here's an implementation of an XML-RPC server that would work as a server for the code above:
 

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -18,20 +18,23 @@ class XmlRpcClient(ServerProxy):
 
         def wrapper(*args, **kwargs):
             start_time = time.time()
+            exc = None
             try:
                 result = func(*args, **kwargs)
             except Fault as e:
-                total_time = int((time.time() - start_time) * 1000)
-                self._locust_environment.events.request_failure.fire(
-                    request_type="xmlrpc", name=name, response_time=total_time, exception=e
-                )
-            else:
-                total_time = int((time.time() - start_time) * 1000)
-                self._locust_environment.events.request_success.fire(
-                    request_type="xmlrpc", name=name, response_time=total_time, response_length=0
-                )
-                # In this example, I've hardcoded response_length=0. If we would want the response length to be
-                # reported correctly in the statistics, we would probably need to hook in at a lower level
+                exc = e
+
+            total_time = int((time.time() - start_time) * 1000)
+            self._locust_environment.events.request.fire(
+                request_type="xmlrpc",
+                name=name,
+                response_time=total_time,
+                response_length=0,
+                context={},
+                exception=exc,
+            )
+            # In this example, I've hardcoded response_length=0. If we would want the response length to be
+            # reported correctly in the statistics, we would probably need to hook in at a lower level
 
         return wrapper
 

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -8,7 +8,7 @@ class XmlRpcClient(ServerProxy):
     """
     Simple, sample XML RPC client implementation that wraps xmlrpclib.ServerProxy and
     fires locust events on request, so that all requests
-    gets tracked in locust's statistics.
+    get tracked in locust's statistics.
     """
 
     _locust_environment = None

--- a/examples/events.py
+++ b/examples/events.py
@@ -50,7 +50,7 @@ def locust_init(environment, **kwargs):
 @events.request.add_listener
 def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
     """
-    Event handler that get triggered on every successful request
+    Event handler that get triggered on every request.
     """
     stats["content-length"] += response_length
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -47,8 +47,8 @@ def locust_init(environment, **kwargs):
             return "Total content-length received: %i" % stats["content-length"]
 
 
-@events.request_success.add_listener
-def on_request_success(request_type, name, response_time, response_length):
+@events.request.add_listener
+def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
     """
     Event handler that get triggered on every successful request
     """

--- a/examples/extend_web_ui/extend.py
+++ b/examples/extend_web_ui/extend.py
@@ -123,8 +123,8 @@ def locust_init(environment, **kwargs):
         environment.web_ui.app.register_blueprint(extend)
 
 
-@events.request_success.add_listener
-def on_request_success(request_type, name, response_time, response_length):
+@events.request.add_listener
+def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
     """
     Event handler that get triggered on every successful request
     """

--- a/examples/extend_web_ui/extend.py
+++ b/examples/extend_web_ui/extend.py
@@ -126,7 +126,7 @@ def locust_init(environment, **kwargs):
 @events.request.add_listener
 def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
     """
-    Event handler that get triggered on every successful request
+    Event handler that get triggered on every request
     """
     stats.setdefault(name, {"content-length": 0})
     stats[name]["content-length"] += response_length

--- a/examples/manual_stats_reporting.py
+++ b/examples/manual_stats_reporting.py
@@ -30,7 +30,7 @@ def _manual_report(name):
     try:
         yield
     except Exception as e:
-        events.request_failure.fire(
+        events.request.fire(
             request_type="manual",
             name=name,
             response_time=(time() - start_time) * 1000,
@@ -39,11 +39,12 @@ def _manual_report(name):
         )
         raise
     else:
-        events.request_success.fire(
+        events.request.fire(
             request_type="manual",
             name=name,
             response_time=(time() - start_time) * 1000,
             response_length=0,
+            exception=None,
         )
 
 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -109,7 +109,7 @@ class HttpSession(requests.Session):
         response = self._send_request_safe_mode(method, url, **kwargs)
 
         if self.user:
-            context.update(self.user.context())
+            context = {**context, **self.user.context()}
 
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -129,10 +129,7 @@ class HttpSession(requests.Session):
 
         if catch_response:
             response.locust_request_meta = request_meta
-            return ResponseContextManager(
-                response,
-                request_event=self.request_event,
-            )
+            return ResponseContextManager(response, request_event=self.request_event)
         else:
             if name:
                 # Since we use the Exception message when grouping failures, in order to not get
@@ -198,14 +195,13 @@ class ResponseContextManager(LocustResponse):
         return self
 
     def __exit__(self, exc, value, traceback):
+        # if the user has already manually marked this response as failure or success
+        # we can ignore the default behaviour of letting the response code determine the outcome
         if self._manual_result is not None:
             if self._manual_result is True:
                 self._report_request()
             elif isinstance(self._manual_result, Exception):
                 self._report_request(self._manual_result)
-
-            # if the user has already manually marked this response as failure or success
-            # we can ignore the default behaviour of letting the response code determine the outcome
             return exc is None
 
         if exc:

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -226,8 +226,8 @@ class ResponseContextManager(LocustResponse):
             name=self.locust_request_meta["name"],
             response_time=self.locust_request_meta["response_time"],
             response_length=self.locust_request_meta["content_size"],
-            exception=exc,
             context=self.locust_request_meta["context"],
+            exception=exc,
         )
 
     def success(self):

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -108,6 +108,9 @@ class HttpSession(requests.Session):
 
         response = self._send_request_safe_mode(method, url, **kwargs)
 
+        if self.user and self.user.context():
+            context.update(self.user.context())
+
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {
             "request_type": method,
@@ -115,7 +118,6 @@ class HttpSession(requests.Session):
             "response_time": (time.monotonic() - start_time) * 1000,
             "name": name or (response.history and response.history[0] or response).request.path_url,
             "context": context,
-            "user": self.user,
             "exception": None,
         }
 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -65,7 +65,7 @@ class HttpSession(requests.Session):
             self.auth = HTTPBasicAuth(parsed_url.username, parsed_url.password)
 
     def _build_url(self, path):
-        """ prepend url with hostname unless it's already an absolute URL """
+        """prepend url with hostname unless it's already an absolute URL"""
         if absolute_http_url_regexp.match(path):
             return path
         else:

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -108,7 +108,7 @@ class HttpSession(requests.Session):
 
         response = self._send_request_safe_mode(method, url, **kwargs)
 
-        if self.user and self.user.context():
+        if self.user:
             context.update(self.user.context())
 
         # store meta data that is used when reporting the request to locust's statistics

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -163,7 +163,7 @@ class FastHttpSession:
 
         start_time = default_timer()
 
-        if self.user and self.user.context():
+        if self.user:
             context.update(self.user.context())
 
         # store meta data that is used when reporting the request to locust's statistics
@@ -416,7 +416,7 @@ class ResponseContextManager(FastResponse):
         self.__dict__ = response.__dict__
         self._cached_content = response.content
         # store reference to locust Environment
-        self.environment = environment
+        self._environment = environment
         self._request_meta = request_meta
 
     def __enter__(self):
@@ -450,7 +450,7 @@ class ResponseContextManager(FastResponse):
         return True
 
     def _report_request(self):
-        self.environment.events.request.fire(**self._request_meta)
+        self._environment.events.request.fire(**self._request_meta)
 
     def success(self):
         """

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -435,7 +435,7 @@ class ResponseContextManager(FastResponse):
             if self._manual_result is True:
                 self._report_request()
             elif isinstance(self._manual_result, Exception):
-                self._report_request(exc=self._manual_result)
+                self._report_request(self._manual_result)
 
             return exc is None
 
@@ -459,8 +459,8 @@ class ResponseContextManager(FastResponse):
             name=self.locust_request_meta["name"],
             response_time=self.locust_request_meta["response_time"],
             response_length=self.locust_request_meta["content_size"],
-            exception=exc,
             context=self.locust_request_meta["context"],
+            exception=exc,
         )
 
     def success(self):

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -429,14 +429,14 @@ class ResponseContextManager(FastResponse):
         return self
 
     def __exit__(self, exc, value, traceback):
+        # if the user has already manually marked this response as failure or success
+        # we can ignore the default behaviour of letting the response code determine the outcome
         if self._manual_result is not None:
             if self._manual_result is True:
                 self._report_request()
             elif isinstance(self._manual_result, Exception):
                 self._report_request(exc=self._manual_result)
 
-            # if the user has already manually marked this response as failure or success
-            # we can ignore the default behaviour of letting the response code determine the outcome
             return exc is None
 
         if exc:

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -312,6 +312,7 @@ class FastHttpUser(User):
             max_redirects=self.max_redirects,
             max_retries=self.max_retries,
             insecure=self.insecure,
+            user=self,
         )
 
 

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -164,7 +164,7 @@ class FastHttpSession:
         start_time = default_timer()
 
         if self.user:
-            context.update(self.user.context())
+            context = {**context, **self.user.context()}
 
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -163,6 +163,9 @@ class FastHttpSession:
 
         start_time = default_timer()
 
+        if self.user and self.user.context():
+            context.update(self.user.context())
+
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {
             "request_type": method,

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -94,7 +94,7 @@ class FastHttpSession:
             self.auth_header = _construct_basic_auth_str(parsed_url.username, parsed_url.password)
 
     def _build_url(self, path):
-        """ prepend url with hostname unless it's already an absolute URL """
+        """prepend url with hostname unless it's already an absolute URL"""
         if absolute_http_url_regexp.match(path):
             return path
         else:

--- a/locust/event.py
+++ b/locust/event.py
@@ -48,6 +48,20 @@ class EventHook:
 
 
 class Events:
+    request: EventHook
+    """
+    Fired when a request in completed, successful or unsuccessful. This event is typically used to report requests when writing custom clients for locust.
+
+    Event arguments:
+
+    :param request_type: Request type method used
+    :param name: Path to the URL that was called (or override name if it was used in the call to the client)
+    :param response_time: Time in milliseconds until exception was thrown
+    :param response_length: Content-length of the response
+    :param exception: Exception instance that was thrown. None if no exception
+    :param context: Dict with context values specified when performing request
+    """
+
     request_success: EventHook
     """
     Fired when a request is completed successfully. This event is typically used to report requests

--- a/locust/event.py
+++ b/locust/event.py
@@ -74,8 +74,8 @@ class Events:
 
     request_success: DeprecatedEventHook
     """
-    Fired when a request is completed successfully. This event is typically used to report requests
-    when writing custom clients for locust.
+    DEPRECATED. Fired when a request is completed successfully. This event is typically used to report requests
+    when writing custom clients for locust. 
 
     Event arguments:
 
@@ -87,7 +87,7 @@ class Events:
 
     request_failure: DeprecatedEventHook
     """
-    Fired when a request fails. This event is typically used to report failed requests when writing
+    DEPRECATED. Fired when a request fails. This event is typically used to report failed requests when writing
     custom clients for locust.
 
     Event arguments:

--- a/locust/event.py
+++ b/locust/event.py
@@ -75,7 +75,7 @@ class Events:
     request_success: DeprecatedEventHook
     """
     DEPRECATED. Fired when a request is completed successfully. This event is typically used to report requests
-    when writing custom clients for locust. 
+    when writing custom clients for locust.
 
     Event arguments:
 

--- a/locust/event.py
+++ b/locust/event.py
@@ -39,7 +39,7 @@ class EventHook:
             try:
                 handler(**kwargs)
             except (StopUser, RescheduleTask, RescheduleTaskImmediately, InterruptTaskSet):
-                # These exceptions could be thrown by, for example, a request_failure handler,
+                # These exceptions could be thrown by, for example, a request handler,
                 # in which case they are entirely appropriate and should not be caught
                 raise
             except Exception:
@@ -204,12 +204,9 @@ class Events:
             if value == EventHook:
                 setattr(self, name, value())
 
-        setattr(
-            self, "request_success", DeprecatedEventHook("request_success event deprecated. Use the request event.")
-        )
-        setattr(
-            self, "request_failure", DeprecatedEventHook("request_failure event deprecated. Use the request event.")
-        )
+        self.request_success = DeprecatedEventHook("request_success event deprecated. Use the request event.")
+
+        self.request_failure = DeprecatedEventHook("request_failure event deprecated. Use the request event.")
 
         def fire_deprecated_request_handlers(
             request_type, name, response_time, response_length, exception, context, **kwargs

--- a/locust/event.py
+++ b/locust/event.py
@@ -211,7 +211,9 @@ class Events:
             self, "request_failure", DeprecatedEventHook("request_failure event deprecated. Use the request event.")
         )
 
-        def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
+        def fire_deprecated_request_handlers(
+            request_type, name, response_time, response_length, exception, context, **kwargs
+        ):
             if exception:
                 self.request_failure.fire(
                     request_type=request_type,
@@ -228,4 +230,4 @@ class Events:
                     response_length=response_length,
                 )
 
-        self.request.add_listener(on_request)
+        self.request.add_listener(fire_deprecated_request_handlers)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -71,15 +71,19 @@ class Runner:
         self.target_user_count = None
 
         # set up event listeners for recording requests
-        def on_request_success(request_type, name, response_time, response_length, **kwargs):
+        def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
             self.stats.log_request(request_type, name, response_time, response_length)
+            if exception:
+                self.stats.log_error(request_type, name, exception)
+                # Fire fail event. To be removed in future versions.
+                self.environment.events.request_failure.fire(
+                    request_type, name, response_time, response_length, exception
+                )
+            else:
+                # Fire success event.To be removed in future versions.
+                self.environment.events.request_success.fire(request_type, name, response_time, response_length)
 
-        def on_request_failure(request_type, name, response_time, response_length, exception, **kwargs):
-            self.stats.log_request(request_type, name, response_time, response_length)
-            self.stats.log_error(request_type, name, exception)
-
-        self.environment.events.request_success.add_listener(on_request_success)
-        self.environment.events.request_failure.add_listener(on_request_failure)
+        self.environment.events.request.add_listener(on_request)
         self.connection_broken = False
 
         # register listener that resets stats when spawning is complete

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -75,13 +75,6 @@ class Runner:
             self.stats.log_request(request_type, name, response_time, response_length)
             if exception:
                 self.stats.log_error(request_type, name, exception)
-                # Fire fail event. To be removed in future versions.
-                self.environment.events.request_failure.fire(
-                    request_type, name, response_time, response_length, exception
-                )
-            else:
-                # Fire success event.To be removed in future versions.
-                self.environment.events.request_success.fire(request_type, name, response_time, response_length)
 
         self.environment.events.request.add_listener(on_request)
         self.connection_broken = False

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -442,12 +442,9 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.assertEqual(1, self.num_failures)
         self.assertEqual(1, self.num_success)
         self.assertIn("ultra fast", str(response.content))
-        print(self.num_failures)
 
         with self.locust.client.get("/ultra_fast", catch_response=True) as response:
             raise ResponseError("Not working")
-
-        print(self.num_failures)
 
         self.assertEqual(2, self.num_failures)
         self.assertEqual(1, self.num_success)

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -520,7 +520,7 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.assertEqual(0, self.num_success)
         self.assertEqual(1, self.num_failures)
 
-    def test_status_specific_request_event(self):
+    def test_deprecated_request_events(self):
         status = {"success_amount": 0, "failure_amount": 0}
 
         def on_success(**kw):

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -520,6 +520,25 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.assertEqual(0, self.num_success)
         self.assertEqual(1, self.num_failures)
 
+    def test_status_specific_request_event(self):
+        status = {"success_amount": 0, "failure_amount": 0}
+
+        def on_success(**kw):
+            status["success_amount"] += 1
+
+        def on_failure(**kw):
+            status["failure_amount"] += 1
+
+        self.environment.events.request_success.add_listener(on_success)
+        self.environment.events.request_failure.add_listener(on_failure)
+        with self.locust.client.get("/ultra_fast", catch_response=True) as response:
+            pass
+        with self.locust.client.get("/wrong_url", catch_response=True) as response:
+            pass
+
+        self.assertEqual(1, status["success_amount"])
+        self.assertEqual(1, status["failure_amount"])
+
 
 class TestFastHttpSsl(LocustTestCase):
     def setUp(self):

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -384,7 +384,7 @@ class TestFastHttpUserClass(WebserverTestCase):
         self.assertFalse("location" in resp.headers)
 
     def test_slow_redirect(self):
-        s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port)
+        s = FastHttpSession(self.environment, "http://127.0.0.1:%i" % self.port, user=None)
         url = "/redirect?url=/redirect&delay=0.5"
         r = s.get(url)
         stats = self.runner.stats.get(url, method="GET")
@@ -565,7 +565,7 @@ class TestFastHttpSsl(LocustTestCase):
         self.web_ui.stop()
 
     def test_ssl_request_insecure(self):
-        s = FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, insecure=True)
+        s = FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, insecure=True, user=None)
         r = s.get("/")
         self.assertEqual(200, r.status_code)
         self.assertIn("<title>Locust</title>", r.content.decode("utf-8"))

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -265,7 +265,7 @@ class TestFastHttpUserClass(WebserverTestCase):
         self.environment.events.request.add_listener(on_request)
         user = MyUser(self.environment)
         user.client.request("get", "/request_method")
-        self.assertDictContainsSubset({"user": user}, kwargs["context"])
+        self.assertDictEqual({"user": user}, kwargs["context"])
 
     def test_get_request(self):
         self.response = ""

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -250,6 +250,23 @@ class TestFastHttpUserClass(WebserverTestCase):
         self.assertTrue(FastHttpUser.abstract)
         self.assertFalse(is_user_class(FastHttpUser))
 
+    def test_class_context(self):
+        class MyUser(FastHttpUser):
+            host = "http://127.0.0.1:%i" % self.port
+
+            def context(self):
+                return {"user": self}
+
+        kwargs = {}
+
+        def on_request(**kw):
+            kwargs.update(kw)
+
+        self.environment.events.request.add_listener(on_request)
+        user = MyUser(self.environment)
+        user.client.request("get", "/request_method")
+        self.assertDictContainsSubset({"user": user}, kwargs["context"])
+
     def test_get_request(self):
         self.response = ""
 

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -423,7 +423,7 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.num_failures = 0
         self.num_success = 0
 
-        def on_failure(request_type, name, response_time, response_length, exception):
+        def on_failure(request_type, name, response_time, response_length, exception, **kwargs):
             self.num_failures += 1
             self.last_failure_exception = exception
 

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -118,7 +118,7 @@ class TestHttpSession(WebserverTestCase):
         self.environment.events.request.add_listener(on_request)
         s.request("get", "/wrong_url", context={"foo": "bar"})
         self.assertIn("/wrong_url", str(kwargs["exception"]))
-        self.assertDictContainsSubset({"foo": "bar"}, kwargs["context"])
+        self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
     def test_context_in_success(self):
         s = self.get_client()
@@ -130,7 +130,7 @@ class TestHttpSession(WebserverTestCase):
 
         self.environment.events.request.add_listener(on_request)
         s.request("get", "/request_method", context={"foo": "bar"})
-        self.assertDictContainsSubset({"foo": "bar"}, kwargs["context"])
+        self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
     def test_deprecated_request_events(self):
         s = self.get_client()
@@ -160,7 +160,7 @@ class TestHttpSession(WebserverTestCase):
         self.environment.events.request.add_listener(on_request)
         s.request("get", "/wrong_url/01", name="replaced_url_name", context={"foo": "bar"})
         self.assertIn("for url: replaced_url_name", str(kwargs["exception"]))
-        self.assertDictContainsSubset({"foo": "bar"}, kwargs["context"])
+        self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
     def test_get_with_params(self):
         s = self.get_client()
@@ -257,4 +257,4 @@ class TestHttpSession(WebserverTestCase):
 
         user = TestUser(self.environment)
         user.client.request("get", "/request_method")
-        self.assertDictContainsSubset({"user": user}, kwargs["context"])
+        self.assertDictEqual({"user": user}, kwargs["context"])

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -130,7 +130,7 @@ class TestHttpSession(WebserverTestCase):
         s.request("get", "/request_method", context={"foo": "bar"})
         self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
-    def test_status_specific_request_event(self):
+    def test_deprecated_request_events(self):
         s = self.get_client()
         status = {"success_amount": 0, "failure_amount": 0}
 

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -14,6 +14,7 @@ class TestHttpSession(WebserverTestCase):
         return HttpSession(
             base_url=base_url,
             request_event=self.environment.events.request,
+            user=None,
         )
 
     def test_get(self):

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -130,6 +130,23 @@ class TestHttpSession(WebserverTestCase):
         s.request("get", "/request_method", context={"foo": "bar"})
         self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
+    def test_status_specific_request_event(self):
+        s = self.get_client()
+        status = {"success_amount": 0, "failure_amount": 0}
+
+        def on_success(**kw):
+            status["success_amount"] += 1
+
+        def on_failure(**kw):
+            status["failure_amount"] += 1
+
+        self.environment.events.request_success.add_listener(on_success)
+        self.environment.events.request_failure.add_listener(on_failure)
+        s.request("get", "/request_method")
+        s.request("get", "/wrong_url")
+        self.assertEqual(1, status["success_amount"])
+        self.assertEqual(1, status["failure_amount"])
+
     def test_error_message_with_name_replacement(self):
         s = self.get_client()
         kwargs = {}

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -724,15 +724,14 @@ class TestCatchResponse(WebserverTestCase):
         self.num_failures = 0
         self.num_success = 0
 
-        def on_failure(request_type, name, response_time, response_length, exception, **kwargs):
-            self.num_failures += 1
-            self.last_failure_exception = exception
+        def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
+            if exception:
+                self.num_failures += 1
+                self.last_failure_exception = exception
+            else:
+                self.num_success += 1
 
-        def on_success(**kwargs):
-            self.num_success += 1
-
-        self.environment.events.request_failure.add_listener(on_failure)
-        self.environment.events.request_success.add_listener(on_success)
+        self.environment.events.request.add_listener(on_request)
 
     def test_catch_response(self):
         self.assertEqual(500, self.locust.client.get("/fail").status_code)

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -724,7 +724,7 @@ class TestCatchResponse(WebserverTestCase):
         self.num_failures = 0
         self.num_success = 0
 
-        def on_failure(request_type, name, response_time, response_length, exception):
+        def on_failure(request_type, name, response_time, response_length, exception, **kwargs):
             self.num_failures += 1
             self.last_failure_exception = exception
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1269,7 +1269,7 @@ class TestMasterRunner(LocustTestCase):
         self.assertEqual(2, exception["count"])
 
     def test_exception_is_caught(self):
-        """ Test that exceptions are stored, and execution continues """
+        """Test that exceptions are stored, and execution continues"""
 
         class MyTaskSet(TaskSet):
             def __init__(self, *a, **kw):
@@ -1308,7 +1308,7 @@ class TestMasterRunner(LocustTestCase):
         self.assertEqual(2, exception["count"])
 
     def test_master_reset_connection(self):
-        """ Test that connection will be reset when network issues found """
+        """Test that connection will be reset when network issues found"""
         with mock.patch("locust.runners.FALLBACK_INTERVAL", new=0.1):
             with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
                 master = self.get_runner()

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -311,11 +311,13 @@ class TestLocustRunner(LocustTestCase):
             class task_set(TaskSet):
                 @task
                 def my_task(self):
-                    self.user.environment.events.request_success.fire(
+                    self.user.environment.events.request.fire(
                         request_type="GET",
                         name="/test",
                         response_time=666,
                         response_length=1337,
+                        exception=None,
+                        context={},
                     )
                     sleep(2)
 
@@ -334,11 +336,13 @@ class TestLocustRunner(LocustTestCase):
             class task_set(TaskSet):
                 @task
                 def my_task(self):
-                    self.user.environment.events.request_success.fire(
+                    self.user.environment.events.request.fire(
                         request_type="GET",
                         name="/test",
                         response_time=666,
                         response_length=1337,
+                        exception=None,
+                        context={},
                     )
                     sleep(2)
 
@@ -447,11 +451,13 @@ class TestMasterWorkerRunners(LocustTestCase):
 
             @task
             def incr_stats(l):
-                l.environment.events.request_success.fire(
+                l.environment.events.request.fire(
                     request_type="GET",
                     name="/",
                     response_time=1337,
                     response_length=666,
+                    exception=None,
+                    context={},
                 )
 
         with mock.patch("locust.runners.WORKER_REPORT_INTERVAL", new=0.3):

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -37,7 +37,7 @@ def get_free_tcp_port():
 
 
 def create_tls_cert(hostname):
-    """ Generate a TLS cert and private key to serve over https """
+    """Generate a TLS cert and private key to serve over https"""
     key = rsa.generate_private_key(public_exponent=2 ** 16 + 1, key_size=2048, backend=default_backend())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
     now = datetime.utcnow()

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -217,6 +217,7 @@ class HttpUser(User):
         session = HttpSession(
             base_url=self.host,
             request_event=self.environment.events.request,
+            user=self,
         )
         session.trust_env = False
         self.client = session

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -186,6 +186,12 @@ class User(object, metaclass=UserMeta):
             return False
 
     def context(self) -> Dict:
+        """
+        Returns user specific context. Override this method to customize data to be forwarded in request event.
+
+        :return: Context data
+        :rtype: Dict
+        """
         return {}
 
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -216,8 +216,7 @@ class HttpUser(User):
 
         session = HttpSession(
             base_url=self.host,
-            request_success=self.environment.events.request_success,
-            request_failure=self.environment.events.request_failure,
+            request_event=self.environment.events.request,
         )
         session.trust_env = False
         self.client = session

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,5 +1,5 @@
 from locust.user.wait_time import constant
-from typing import Any, Callable, List, TypeVar, Union
+from typing import Any, Callable, Dict, List, TypeVar, Union
 from gevent import GreenletExit, greenlet
 from gevent.pool import Group
 from locust.clients import HttpSession
@@ -184,6 +184,9 @@ class User(object, metaclass=UserMeta):
         elif self._state == LOCUST_STATE_RUNNING:
             self._state = LOCUST_STATE_STOPPING
             return False
+
+    def context(self) -> Dict:
+        return {}
 
 
 class HttpUser(User):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     mock
     pyquery
     cryptography
-    black
+    black==21.4b0
 commands =
     flake8 . --count --show-source --statistics
     coverage run -m unittest discover []


### PR DESCRIPTION
Add a single event thats triggered both on request succes/failure #1724
This new event can contain metadata (called context) which can be specified when performing the request.