### PR TITLE
Measure elapsed time using time.perf_counter() 

### DIFF
--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -19,7 +19,7 @@ class XmlRpcClient(ServerProxy):
         func = ServerProxy.__getattr__(self, name)
 
         def wrapper(*args, **kwargs):
-            start_time = time.monotonic()
+            start_time = time.perf_counter()
             request_meta = {
                 "request_type": "xmlrpc",
                 "name": name,
@@ -32,7 +32,7 @@ class XmlRpcClient(ServerProxy):
                 request_meta["response"] = func(*args, **kwargs)
             except Fault as e:
                 request_meta["exception"] = e
-            request_meta["response_time"] = (time.monotonic() - start_time) * 1000
+            request_meta["response_time"] = (time.perf_counter() - start_time) * 1000
             self._request_event.fire(**request_meta)  # This is what makes the request actually get logged in Locust
             return request_meta["response"]
 

--- a/examples/grpc/locustfile.py
+++ b/examples/grpc/locustfile.py
@@ -28,7 +28,7 @@ class GrpcClient:
         func = self._stub_class.__getattribute__(self._stub, name)
 
         def wrapper(*args, **kwargs):
-            start_time = time.monotonic()
+            start_time = time.perf_counter()
             request_meta = {
                 "request_type": "grpc",
                 "name": name,
@@ -42,7 +42,7 @@ class GrpcClient:
                 request_meta["response_length"] = len(request_meta["response"].message)
             except grpc.RpcError as e:
                 request_meta["exception"] = e
-            request_meta["response_time"] = (time.monotonic() - start_time) * 1000
+            request_meta["response_time"] = (time.perf_counter() - start_time) * 1000
             events.request.fire(**request_meta)
             return request_meta["response"]
 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -104,7 +104,7 @@ class HttpSession(requests.Session):
 
         # prepend url with hostname unless it's already an absolute URL
         url = self._build_url(url)
-        start_time = time.monotonic()
+        start_time = time.perf_counter()
 
         response = self._send_request_safe_mode(method, url, **kwargs)
 
@@ -114,7 +114,7 @@ class HttpSession(requests.Session):
         # store meta data that is used when reporting the request to locust's statistics
         request_meta = {
             "request_type": method,
-            "response_time": (time.monotonic() - start_time) * 1000,
+            "response_time": (time.perf_counter() - start_time) * 1000,
             "name": name or (response.history and response.history[0] or response).request.path_url,
             "context": context,
             "response": response,

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -5,7 +5,7 @@ import json as unshadowed_json  # some methods take a named parameter called jso
 from base64 import b64encode
 from urllib.parse import urlparse, urlunparse
 from ssl import SSLError
-from timeit import default_timer
+import time
 
 from http.cookiejar import CookieJar
 
@@ -161,7 +161,7 @@ class FastHttpSession:
         # prepend url with hostname unless it's already an absolute URL
         url = self._build_url(path)
 
-        start_time = default_timer()
+        start_time = time.perf_counter()
 
         if self.user:
             context = {**self.user.context(), **context}
@@ -208,7 +208,7 @@ class FastHttpSession:
             try:
                 request_meta["response_length"] = len(response.content or "")
             except HTTPParseError as e:
-                request_meta["response_time"] = int((default_timer() - start_time) * 1000)
+                request_meta["response_time"] = (time.perf_counter() - start_time) * 1000
                 request_meta["response_length"] = 0
                 request_meta["exception"] = e
                 self.environment.events.request.fire(**request_meta)
@@ -217,7 +217,7 @@ class FastHttpSession:
         # Record the consumed time
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
-        request_meta["response_time"] = int((default_timer() - start_time) * 1000)
+        request_meta["response_time"] = int((time.perf_counter() - start_time) * 1000)
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -13,19 +13,19 @@ class LoadTestShape:
     """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
 
     def __init__(self):
-        self.start_time = time.monotonic()
+        self.start_time = time.perf_counter()
 
     def reset_time(self):
         """
         Resets start time back to 0
         """
-        self.start_time = time.monotonic()
+        self.start_time = time.perf_counter()
 
     def get_run_time(self):
         """
         Calculates run time in seconds of the load test
         """
-        return time.monotonic() - self.start_time
+        return time.perf_counter() - self.start_time
 
     def get_current_user_count(self):
         """

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1755,7 +1755,7 @@ class TestStopTimeout(LocustTestCase):
 
         # Wait a moment and then ensure the user count has started to drop but
         # not immediately to user_count
-        sleep(1)
+        sleep(1.1)
         user_count = len(runner.user_greenlets)
         self.assertTrue(user_count > 5, "User count has decreased too quickly: %i" % user_count)
         self.assertTrue(user_count < 10, "User count has not decreased at all: %i" % user_count)

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -53,9 +53,9 @@ class TestWaitTime(LocustTestCase):
         self.assertEqual(0, MyUser(self.environment).wait_time())
         self.assertEqual(0, TaskSet1(MyUser(self.environment)).wait_time())
         taskset = TaskSet1(MyUser(self.environment))
-        start_time = time.monotonic()
+        start_time = time.perf_counter()
         taskset.wait()
-        self.assertLess(time.monotonic() - start_time, 0.002)
+        self.assertLess(time.perf_counter() - start_time, 0.002)
 
     def test_constant_pacing(self):
         class MyUser(User):
@@ -68,12 +68,12 @@ class TestWaitTime(LocustTestCase):
 
         ts2 = TS(MyUser(self.environment))
 
-        previous_time = time.monotonic()
+        previous_time = time.perf_counter()
         for i in range(7):
             ts.wait()
-            since_last_run = time.monotonic() - previous_time
+            since_last_run = time.perf_counter() - previous_time
             self.assertLess(abs(0.1 - since_last_run), 0.02)
-            previous_time = time.monotonic()
+            previous_time = time.perf_counter()
             time.sleep(random.random() * 0.1)
             _ = ts2.wait_time()
             _ = ts2.wait_time()


### PR DESCRIPTION
... instead of a mix of time.monotonic(), which sometimes has less precision, and timeit (used in FastHttpUser), which has undesirable effects like disabling GC.

Also, in FastHttpUser, dont round response times to millisecond for no reason.

Note: On Linux/mac .perf_counter() calls .monotonic() in the end, so there is no difference there