### PR TITLE
Register stats from request_success and request_failure

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -78,8 +78,13 @@ class Runner:
             self.stats.log_request(request_type, name, response_time, response_length)
             self.stats.log_error(request_type, name, exception)
 
+        # temporarily set log level to ignore warnings to suppress deprication message
+        loglevel = logging.getLogger().level
+        logging.getLogger().setLevel(logging.ERROR)
         self.environment.events.request_success.add_listener(on_request_success)
         self.environment.events.request_failure.add_listener(on_request_failure)
+        logging.getLogger().setLevel(loglevel)
+
         self.connection_broken = False
 
         # register listener that resets stats when spawning is complete

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -71,12 +71,15 @@ class Runner:
         self.target_user_count = None
 
         # set up event listeners for recording requests
-        def on_request(request_type, name, response_time, response_length, exception, context, **kwargs):
+        def on_request_success(request_type, name, response_time, response_length, **_kwargs):
             self.stats.log_request(request_type, name, response_time, response_length)
-            if exception:
-                self.stats.log_error(request_type, name, exception)
 
-        self.environment.events.request.add_listener(on_request)
+        def on_request_failure(request_type, name, response_time, response_length, exception, **_kwargs):
+            self.stats.log_request(request_type, name, response_time, response_length)
+            self.stats.log_error(request_type, name, exception)
+
+        self.environment.events.request_success.add_listener(on_request_success)
+        self.environment.events.request_failure.add_listener(on_request_failure)
         self.connection_broken = False
 
         # register listener that resets stats when spawning is complete


### PR DESCRIPTION
Old update was causing issues when using a custom user that manually triggered request_success/request_failure. Resulting in some sneaky errors. This should keep old users from breaking while still allowing for use of the new request event.