### PR TITLE
Upgrade to flask 2

### DIFF
--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -19,7 +19,7 @@ from locust.test.mock_logging import MockedLoggingHandler
 
 
 app = Flask(__name__)
-app.jinja_options["extensions"].append("jinja2.ext.do")
+app.jinja_env.add_extension("jinja2.ext.do")
 
 
 @app.route("/ultra_fast")
@@ -103,7 +103,7 @@ def basic_auth():
 def no_content_length():
     r = send_file(
         BytesIO("This response does not have content-length in the header".encode("utf-8")),
-        add_etags=False,
+        etag=False,
         mimetype="text/plain",
     )
     r.headers.remove("Content-Length")

--- a/locust/web.py
+++ b/locust/web.py
@@ -99,7 +99,7 @@ class WebUI:
         self.tls_key = tls_key
         app = Flask(__name__)
         self.app = app
-        app.jinja_options["extensions"].append("jinja2.ext.do")
+        app.jinja_env.add_extension("jinja2.ext.do")
         app.debug = True
         app.root_path = os.path.dirname(os.path.abspath(__file__))
         self.app.config["BASIC_AUTH_ENABLED"] = False
@@ -215,8 +215,8 @@ class WebUI:
                     os.path.abspath(self.stats_csv_writer.stats_history_file_name()),
                     mimetype="text/csv",
                     as_attachment=True,
-                    attachment_filename=_download_csv_suggest_file_name("requests_full_history"),
-                    add_etags=True,
+                    download_name=_download_csv_suggest_file_name("requests_full_history"),
+                    etag=True,
                     cache_timeout=None,
                     conditional=True,
                     last_modified=None,

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     version=version,
     install_requires=[
         "gevent>=20.9.0",
-        "flask==1.1.2",
-        "Werkzeug>=1.0.1",
+        "flask>=2.0.0",
+        "Werkzeug>=2.0.0",
         "requests>=2.9.1",
         "msgpack>=0.6.2",
         "pyzmq>=16.0.2",

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     mock
     pyquery
     cryptography
-    black==21.4b0
+    black==21.5b2
 commands =
     flake8 . --count --show-source --statistics
     coverage run -m unittest discover []


### PR DESCRIPTION
I noticed in issue #1759 that the flask version was pinned to the 1.x branch to fix compatibility issues. This PR introduces the necessary changes to bump Flask and werkzeug to version 2.x .