### PR TITLE
modified check_stopped condition

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -608,7 +608,7 @@ class MasterRunner(DistributedRunner):
         if (
             not self.state == STATE_INIT
             and not self.state == STATE_STOPPED
-            and all(map(lambda x: x.state != STATE_RUNNING and x.state != STATE_SPAWNING, self.clients.all))
+            and all(map(lambda x: x.state not in (STATE_RUNNING, STATE_SPAWNING, STATE_INIT), self.clients.all))
         ):
             self.update_state(STATE_STOPPED)
 


### PR DESCRIPTION
added STATE_INIT to condition in check_stopped condition for clients - it looks like there's possibility that master is not in STATE_INIT anymore, but some client didn't have enough time to change the state