### PR TITLE
Fire test_start and test_stop events on worker nodes

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -23,6 +23,27 @@ Here's an example on how to set up an event listener::
             print(f"Successfully made a request to: {name})
             print(f"The response was {response.text}")
 
+When running locust in distributed mode, it may be useful to do some setup on worker nodes before running your tests. 
+You can check to ensure you aren't running on the master node by checking the type of the node's :py:attr:`runner <locust.env.Environment.runner>`::
+
+    from locust import events
+    from locust.runners import MasterRunner
+
+    @events.test_start.add_listener
+    def on_test_start(environment, **kwargs):
+        if not isinstance(environment.runner, MasterRunner):
+            print("Beginning test setup")
+        else
+            print("Started test from Master node")
+
+    @events.test_stop.add_listener
+    def on_test_stop(environment, **kwargs):
+        if not isinstance(environment.runner, MasterRunner):
+            print("Cleaning up test data")
+        else
+            print("Stopped test from Master node")
+
+
 .. note::
 
     To see all available events, please see :ref:`events`.

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -283,8 +283,6 @@ events. You can set up listeners for these events at the module level of your lo
     def on_test_stop(environment, **kwargs):
         print("A new test is ending")
 
-When running Locust distributed the ``test_start`` and ``test_stop`` events will only be fired in the master node.
-
 init
 ----
 

--- a/locust/event.py
+++ b/locust/event.py
@@ -179,15 +179,13 @@ class Events:
 
     test_start: EventHook
     """
-    Fired when a new load test is started. It's not fired again if the number of
-    users change during a test. When running locust distributed the event is only fired
-    on the master node and not on each worker node.
+    Fired on each node when a new load test is started. It's not fired again if the number of
+    users change during a test.
     """
 
     test_stop: EventHook
     """
-    Fired when a load test is stopped. When running locust distributed the event
-    is only fired on the master node and not on each worker node.
+    Fired on each node when a load test is stopped.
     """
 
     reset_stats: EventHook

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -359,6 +359,8 @@ class Runner:
         """
         Stop a running load test by stopping all running users
         """
+        if self.state == STATE_STOPPED:
+            return
         logger.debug("Stopping all users")
         self.update_state(STATE_CLEANUP)
         # if we are currently spawning users we need to kill the spawning greenlet first
@@ -367,6 +369,7 @@ class Runner:
         self.stop_users(self.user_count)
         self.update_state(STATE_STOPPED)
         self.cpu_log_warning()
+        self.environment.events.test_stop.fire(environment=self.environment)
 
     def quit(self):
         """
@@ -415,12 +418,6 @@ class LocalRunner(Runner):
             lambda: super(LocalRunner, self).start(user_count, spawn_rate, wait=wait)
         )
         self.spawning_greenlet.link_exception(greenlet_exception_handler)
-
-    def stop(self):
-        if self.state == STATE_STOPPED:
-            return
-        super().stop()
-        self.environment.events.test_stop.fire(environment=self.environment)
 
 
 class DistributedRunner(Runner):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -305,6 +305,7 @@ class Runner:
             self.cpu_warning_emitted = False
             self.worker_cpu_warning_emitted = False
             self.target_user_count = user_count
+            self.environment.events.test_start.fire(environment=self.environment)
 
         if self.state != STATE_INIT and self.state != STATE_STOPPED:
             logger.debug(
@@ -406,10 +407,6 @@ class LocalRunner(Runner):
             logger.warning(
                 "Your selected spawn rate is very high (>100), and this is known to sometimes cause issues. Do you really need to ramp up that fast?"
             )
-
-        if self.state != STATE_RUNNING and self.state != STATE_SPAWNING:
-            # if we're not already running we'll fire the test_start event
-            self.environment.events.test_start.fire(environment=self.environment)
 
         if self.spawning_greenlet:
             # kill existing spawning_greenlet before we start a new one

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1352,7 +1352,7 @@ class TestWorkerRunner(LocustTestCase):
             test_start_run = [False]
 
             @environment.events.test_start.add_listener
-            def on_test_start(_environment, **kw):
+            def on_test_start(*args, **kw):
                 test_start_run[0] = True
 
             worker = self.get_runner(environment=environment, user_classes=[MyTestUser])
@@ -1383,8 +1383,8 @@ class TestWorkerRunner(LocustTestCase):
             worker.user_greenlets.join()
             # check that locust user got to finish
             self.assertEqual(2, MyTestUser._test_state)
-            # make sure the test_start was never fired on the worker
-            self.assertFalse(test_start_run[0])
+            # make sure the test_start was fired on the worker
+            self.assertTrue(test_start_run[0])
 
     def test_worker_without_stop_timeout(self):
         class MyTestUser(User):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -2707,6 +2707,8 @@ class TestWorkerRunner(LocustTestCase):
                 Message(
                     "spawn",
                     {
+                        "timestamp": 1605538585,
+                        "user_classes_count": {"MyTestUser": 1},
                         "spawn_rate": 1,
                         "num_users": 1,
                         "host": "",
@@ -2730,6 +2732,8 @@ class TestWorkerRunner(LocustTestCase):
                 Message(
                     "spawn",
                     {
+                        "timestamp": 1605538586,
+                        "user_classes_count": {"MyTestUser": 1},
                         "spawn_rate": 1,
                         "num_users": 1,
                         "host": "",
@@ -2746,6 +2750,8 @@ class TestWorkerRunner(LocustTestCase):
                 Message(
                     "spawn",
                     {
+                        "timestamp": 1605538587,
+                        "user_classes_count": {"MyTestUser": 1},
                         "spawn_rate": 1,
                         "num_users": 1,
                         "host": "",
@@ -2784,6 +2790,8 @@ class TestWorkerRunner(LocustTestCase):
                 Message(
                     "spawn",
                     {
+                        "timestamp": 1605538585,
+                        "user_classes_count": {"MyTestUser": 1},
                         "spawn_rate": 1,
                         "num_users": 1,
                         "host": "",
@@ -2817,6 +2825,8 @@ class TestWorkerRunner(LocustTestCase):
                 Message(
                     "spawn",
                     {
+                        "timestamp": 1605538586,
+                        "user_classes_count": {"MyTestUser": 1},
                         "spawn_rate": 1,
                         "num_users": 1,
                         "host": "",


### PR DESCRIPTION
PR to fix #1776 

Added `test_start` and `test_stop` events to the base `Runner` class' `start()` and `stop()` method, respectively

Added/updated relevant tests and documentation. 