### PR TITLE
Allow cross process communication using custom messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,9 +130,10 @@ Runner classes
 .. autoclass:: locust.runners.LocalRunner
 
 .. autoclass:: locust.runners.MasterRunner
+    :members: register_message, send_message
 
 .. autoclass:: locust.runners.WorkerRunner
-
+    :members: register_message, send_message
 
 Web UI class
 ============

--- a/docs/running-locust-distributed.rst
+++ b/docs/running-locust-distributed.rst
@@ -90,8 +90,8 @@ nodes has connected before the test is started.
 Communicating across nodes
 =============================================
 
-When running Locust in distributed mode, you may want to communicate between nodes in order to coordinate 
-data. This can be easily accomplished with custom messages using the built in messaging hooks:
+When running Locust in distributed mode, you may want to communicate between master and worker nodes in 
+order to coordinate data. This can be easily accomplished with custom messages using the built in messaging hooks:
 
 .. code-block:: python
 
@@ -110,20 +110,26 @@ data. This can be easily accomplished with custom messages using the built in me
 
     @events.init.add_listener
     def on_locust_init(environment, **_kwargs):
-        if isinstance(environment.runner, WorkerRunner):
+        if not isinstance(environment.runner, MasterRunner):
             environment.runner.register_message('test_users', setup_test_users)
-        elif isinstance(environment.runner, MasterRunner):
+        if not isinstance(environment.runner, WorkerRunner):
             environment.runner.register_message('acknowledge_users', on_acknowledge)
 
     @events.test_start.add_listener
     def on_test_start(environment, **_kwargs):
-        if isinstance(environment.runner, MasterRunner):
+        if not isinstance(environment.runner, MasterRunner):
             users = [
                 {"name": "User1"},
                 {"name": "User2"},
                 {"name": "User3"},
             ]
             environment.runner.send_message('test_users', users)  
+
+Note that when running locally (i.e. non-distributed), this functionality will be preserved; 
+the messages will simply be handled by the same runner that sends them.  
+
+A more complete example can be found in the `examples directory <https://github.com/locustio/locust/tree/master/examples>`_ of the Locust 
+source code.
 
 
 Running distributed with Docker

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -1,0 +1,37 @@
+from locust import HttpUser, task, events, between
+from locust.runners import MasterRunner, WorkerRunner
+
+# Fired when the worker recieves a message of type 'test_users'
+def setup_test_users(environment, msg, **kwargs):
+    for user in msg.data:
+        print(f"User {user['name']} recieved")
+    environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
+
+# Fired when the master recieves a message of type 'acknowledge_users'
+def on_acknowledge(msg, **kwargs):
+    print(msg.data)
+
+@events.init.add_listener
+def on_locust_init(environment, **_kwargs):
+    if isinstance(environment.runner, WorkerRunner):
+        environment.runner.register_message('test_users', setup_test_users)
+    elif isinstance(environment.runner, MasterRunner):
+        environment.runner.register_message('acknowledge_users', on_acknowledge)
+
+@events.test_start.add_listener
+def on_test_start(environment, **_kwargs):
+    if isinstance(environment.runner, MasterRunner):
+        users = [
+            {"name": "User1"},
+            {"name": "User2"},
+            {"name": "User3"},
+        ]
+        environment.runner.send_message('test_users', users)  
+
+class WebsiteUser(HttpUser):
+    host = "http://127.0.0.1:8089"
+    wait_time = between(2, 5)
+    
+    @task
+    def task(self):
+        pass

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -6,8 +6,8 @@ usernames = []
 
 def setup_test_users(environment, msg, **kwargs):
     # Fired when the worker recieves a message of type 'test_users'
-    usernames.extend(map(lambda u: u['name'], msg.data))
-    environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
+    usernames.extend(map(lambda u: u["name"], msg.data))
+    environment.runner.send_message("acknowledge_users", f"Thanks for the {len(msg.data)} users!")
 
 
 def on_acknowledge(msg, **kwargs):
@@ -18,9 +18,9 @@ def on_acknowledge(msg, **kwargs):
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
     if isinstance(environment.runner, WorkerRunner):
-        environment.runner.register_message('test_users', setup_test_users)
+        environment.runner.register_message("test_users", setup_test_users)
     elif isinstance(environment.runner, MasterRunner):
-        environment.runner.register_message('acknowledge_users', on_acknowledge)
+        environment.runner.register_message("acknowledge_users", on_acknowledge)
 
 
 @events.test_start.add_listener
@@ -44,7 +44,7 @@ def on_test_start(environment, **_kwargs):
                 end_index = len(users)
 
             data = users[start_index:end_index]
-            environment.runner.send_message('test_users', data, worker)
+            environment.runner.send_message("test_users", data, worker)
 
 
 class WebsiteUser(HttpUser):

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -1,15 +1,19 @@
 from locust import HttpUser, task, events, between
 from locust.runners import MasterRunner, WorkerRunner
 
-# Fired when the worker recieves a message of type 'test_users'
+usernames = []
+
+
 def setup_test_users(environment, msg, **kwargs):
-    for user in msg.data:
-        print(f"User {user['name']} recieved")
+    # Fired when the worker recieves a message of type 'test_users'
+    usernames.extend(map(lambda u: u['name'], msg.data))
     environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
 
-# Fired when the master recieves a message of type 'acknowledge_users'
+
 def on_acknowledge(msg, **kwargs):
+    # Fired when the master recieves a message of type 'acknowledge_users'
     print(msg.data)
+
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
@@ -18,20 +22,39 @@ def on_locust_init(environment, **_kwargs):
     elif isinstance(environment.runner, MasterRunner):
         environment.runner.register_message('acknowledge_users', on_acknowledge)
 
+
 @events.test_start.add_listener
 def on_test_start(environment, **_kwargs):
+    # When the test is started, evenly divides list between
+    # worker nodes to ensure unique data across threads
     if isinstance(environment.runner, MasterRunner):
-        users = [
-            {"name": "User1"},
-            {"name": "User2"},
-            {"name": "User3"},
-        ]
-        environment.runner.send_message('test_users', users)  
+        users = []
+        for i in range(environment.runner.target_user_count):
+            users.append({"name": f"User{i}"})
+
+        worker_count = environment.runner.worker_count
+        chunk_size = int(len(users) / worker_count)
+
+        for i, worker in enumerate(environment.runner.clients):
+            start_index = i * chunk_size
+
+            if i + 1 < worker_count:
+                end_index = start_index + chunk_size
+            else:
+                end_index = len(users)
+
+            data = users[start_index:end_index]
+            environment.runner.send_message('test_users', data, worker)
+
 
 class WebsiteUser(HttpUser):
     host = "http://127.0.0.1:8089"
     wait_time = between(2, 5)
-    
+
+    def __init__(self, parent):
+        self.username = usernames.pop()
+        super(WebsiteUser, self).__init__(parent)
+
     @task
     def task(self):
-        pass
+        print(self.username)

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -17,9 +17,9 @@ def on_acknowledge(msg, **kwargs):
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
-    if isinstance(environment.runner, WorkerRunner):
+    if not isinstance(environment.runner, MasterRunner):
         environment.runner.register_message("test_users", setup_test_users)
-    elif isinstance(environment.runner, MasterRunner):
+    if not isinstance(environment.runner, WorkerRunner):
         environment.runner.register_message("acknowledge_users", on_acknowledge)
 
 
@@ -27,7 +27,7 @@ def on_locust_init(environment, **_kwargs):
 def on_test_start(environment, **_kwargs):
     # When the test is started, evenly divides list between
     # worker nodes to ensure unique data across threads
-    if isinstance(environment.runner, MasterRunner):
+    if not isinstance(environment.runner, WorkerRunner):
         users = []
         for i in range(environment.runner.target_user_count):
             users.append({"name": f"User{i}"})

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -735,7 +735,7 @@ class MasterRunner(DistributedRunner):
         :param data: Optional data to send
         """
         for client in self.clients.all:
-            logger.debug("Sending {msg_type} message to client {client_id}")
+            logger.debug(f"Sending {msg_type} message to client {client.id}")
             self.server.send_to_client(Message(msg_type, data, client.id))
 
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -433,6 +433,12 @@ class DistributedRunner(Runner):
         setup_distributed_stats_event_listeners(self.environment.events, self.stats)
 
     def register_message(self, msg_type, listener):
+        """
+        Register a listener for a custom message from another node
+
+        :param msg_type: The type of the message to listen for
+        :param listener: The function to execute when the message is received
+        """
         self.custom_messages[msg_type] = listener
 
 class WorkerNode:
@@ -722,6 +728,12 @@ class MasterRunner(DistributedRunner):
         return len(self.clients.ready) + len(self.clients.spawning) + len(self.clients.running)
 
     def send_message(self, msg_type, data=None):
+        """
+        Sends a message to all attached worker nodes
+
+        :param msg_type: The type of the message to send
+        :param data: Optional data to send
+        """
         for client in self.clients.all:
             logger.debug("Sending {msg_type} message to client {client_id}")
             self.server.send_to_client(Message(msg_type, data, client.id))
@@ -852,6 +864,12 @@ class WorkerRunner(DistributedRunner):
             gevent.sleep(WORKER_REPORT_INTERVAL)
 
     def send_message(self, msg_type, data=None):
+        """
+        Sends a message to master node
+
+        :param msg_type: The type of the message to send
+        :param data: Optional data to send
+        """
         logger.debug("Sending {msg_type} message to master")
         self.client.send(Message(msg_type, data, self.client_id))
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -441,6 +441,7 @@ class DistributedRunner(Runner):
         """
         self.custom_messages[msg_type] = listener
 
+
 class WorkerNode:
     def __init__(self, id, state=STATE_INIT, heartbeat_liveness=HEARTBEAT_LIVENESS):
         self.id = id
@@ -727,17 +728,22 @@ class MasterRunner(DistributedRunner):
     def worker_count(self):
         return len(self.clients.ready) + len(self.clients.spawning) + len(self.clients.running)
 
-    def send_message(self, msg_type, data=None):
+    def send_message(self, msg_type, data=None, client_id=None):
         """
-        Sends a message to all attached worker nodes
+        Sends a message to attached worker node(s)
 
         :param msg_type: The type of the message to send
         :param data: Optional data to send
+        :param client_id: Optional id of the target worker node.
+                            If None, will send to all attached workers
         """
-        for client in self.clients.all:
-            logger.debug(f"Sending {msg_type} message to client {client.id}")
-            self.server.send_to_client(Message(msg_type, data, client.id))
-
+        if client_id:
+            logger.debug(f"Sending {msg_type} message to client {client_id}")
+            self.server.send_to_client(Message(msg_type, data, client_id))
+        else:
+            for client in self.clients.all:
+                logger.debug(f"Sending {msg_type} message to client {client.id}")
+                self.server.send_to_client(Message(msg_type, data, client.id))
 
 
 class WorkerRunner(DistributedRunner):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -720,7 +720,10 @@ class MasterRunner(DistributedRunner):
             elif msg.type == "exception":
                 self.log_exception(msg.node_id, msg.data["msg"], msg.data["traceback"])
             elif msg.type in self.custom_messages:
+                logger.debug(f"Recieved {msg.type} message from worker {msg.node_id}")
                 self.custom_messages[msg.type](environment=self.environment, msg=msg)
+            else:
+                logger.warning(f"Unknown message type recieved from worker {msg.node_id}: {msg.type}")
 
             self.check_stopped()
 
@@ -858,8 +861,10 @@ class WorkerRunner(DistributedRunner):
                 self._send_stats()  # send a final report, in case there were any samples not yet reported
                 self.greenlet.kill(block=True)
             elif msg.type in self.custom_messages:
-                logger.debug("Recieved {msg_type} message on from master")
+                logger.debug(f"Recieved {msg.type} message from master")
                 self.custom_messages[msg.type](environment=self.environment, msg=msg)
+            else:
+                logger.warning(f"Unknown message type recieved: {msg.type}")
 
     def stats_reporter(self):
         while True:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -432,7 +432,7 @@ class DistributedRunner(Runner):
         super().__init__(*args, **kwargs)
         setup_distributed_stats_event_listeners(self.environment.events, self.stats)
 
-    def add_message(self, msg_type, listener):
+    def register_message(self, msg_type, listener):
         self.custom_messages[msg_type] = listener
 
 class WorkerNode:
@@ -713,7 +713,7 @@ class MasterRunner(DistributedRunner):
             elif msg.type == "exception":
                 self.log_exception(msg.node_id, msg.data["msg"], msg.data["traceback"])
             elif msg.type in self.custom_messages:
-                self.custom_messages[msg.type](msg)
+                self.custom_messages[msg.type](environment=self.environment, msg=msg)
 
             self.check_stopped()
 
@@ -841,7 +841,7 @@ class WorkerRunner(DistributedRunner):
                 self.greenlet.kill(block=True)
             elif msg.type in self.custom_messages:
                 logger.debug("Recieved {msg_type} message on from master")
-                self.custom_messages[msg.type](msg)
+                self.custom_messages[msg.type](environment=self.environment, msg=msg)
 
     def stats_reporter(self):
         while True:

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1338,7 +1338,7 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(5, len(server.outbox))
             for _, msg in server.outbox:
                 self.assertEqual("test_custom_msg", msg.type)
-                self.assertEqual(123, msg.data['test_data'])
+                self.assertEqual(123, msg.data["test_data"])
 
     def test_custom_message_receive(self):
         class MyUser(User):
@@ -1359,12 +1359,10 @@ class TestMasterRunner(LocustTestCase):
             master = self.get_runner()
             master.register_message("test_custom_msg", on_custom_msg)
 
-            server.mocked_send(
-                Message("test_custom_msg", {'test_data': 123}, "dummy_id")
-            )
+            server.mocked_send(Message("test_custom_msg", {"test_data": 123}, "dummy_id"))
 
             self.assertTrue(test_custom_msg[0])
-            self.assertEqual(123, test_custom_msg_data[0]['test_data'])
+            self.assertEqual(123, test_custom_msg_data[0]["test_data"])
 
 
 class TestWorkerRunner(LocustTestCase):
@@ -1527,9 +1525,9 @@ class TestWorkerRunner(LocustTestCase):
             environment = Environment()
             worker = self.get_runner(environment=environment, user_classes=[MyUser])
             client.outbox.clear()
-            worker.send_message('test_custom_msg', {'test_data': 123})
+            worker.send_message("test_custom_msg", {"test_data": 123})
             self.assertEqual("test_custom_msg", client.outbox[0].type)
-            self.assertEqual(123, client.outbox[0].data['test_data'])
+            self.assertEqual(123, client.outbox[0].data["test_data"])
             worker.quit()
 
     def test_custom_message_receive(self):
@@ -1552,12 +1550,10 @@ class TestWorkerRunner(LocustTestCase):
             worker = self.get_runner(environment=environment, user_classes=[MyUser])
             worker.register_message("test_custom_msg", on_custom_msg)
 
-            client.mocked_send(
-                Message("test_custom_msg", {'test_data': 123}, "dummy_client_id")
-            )
+            client.mocked_send(Message("test_custom_msg", {"test_data": 123}, "dummy_client_id"))
 
             self.assertTrue(test_custom_msg[0])
-            self.assertEqual(123, test_custom_msg_data[0]['test_data'])
+            self.assertEqual(123, test_custom_msg_data[0]["test_data"])
             worker.quit()
 
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1357,7 +1357,7 @@ class TestMasterRunner(LocustTestCase):
                 test_custom_msg_data[0] = msg.data
             
             master = self.get_runner()
-            master.add_message("test_custom_msg", on_custom_msg)
+            master.register_message("test_custom_msg", on_custom_msg)
 
             server.mocked_send(
                 Message("test_custom_msg", {'test_data': 123}, "dummy_id")
@@ -1548,7 +1548,7 @@ class TestWorkerRunner(LocustTestCase):
                 test_custom_msg_data[0] = msg.data
             
             worker = self.get_runner(environment=environment, user_classes=[MyUser])
-            worker.add_message("test_custom_msg", on_custom_msg)
+            worker.register_message("test_custom_msg", on_custom_msg)
 
             client.mocked_send(
                 Message("test_custom_msg", {'test_data': 123}, "dummy_client_id")

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1338,7 +1338,7 @@ class TestMasterRunner(LocustTestCase):
             self.assertEqual(5, len(server.outbox))
             for _, msg in server.outbox:
                 self.assertEqual("test_custom_msg", msg.type)
-                self.assertEqual(123, msg.data['test_data'])            
+                self.assertEqual(123, msg.data['test_data'])
 
     def test_custom_message_receive(self):
         class MyUser(User):
@@ -1355,7 +1355,7 @@ class TestMasterRunner(LocustTestCase):
             def on_custom_msg(msg, **kw):
                 test_custom_msg[0] = True
                 test_custom_msg_data[0] = msg.data
-            
+
             master = self.get_runner()
             master.register_message("test_custom_msg", on_custom_msg)
 
@@ -1364,7 +1364,9 @@ class TestMasterRunner(LocustTestCase):
             )
 
             self.assertTrue(test_custom_msg[0])
-            self.assertEqual(123, test_custom_msg_data[0]['test_data'])            
+            self.assertEqual(123, test_custom_msg_data[0]['test_data'])
+
+
 class TestWorkerRunner(LocustTestCase):
     def setUp(self):
         super().setUp()
@@ -1527,7 +1529,7 @@ class TestWorkerRunner(LocustTestCase):
             client.outbox.clear()
             worker.send_message('test_custom_msg', {'test_data': 123})
             self.assertEqual("test_custom_msg", client.outbox[0].type)
-            self.assertEqual(123, client.outbox[0].data['test_data'])            
+            self.assertEqual(123, client.outbox[0].data['test_data'])
             worker.quit()
 
     def test_custom_message_receive(self):
@@ -1546,7 +1548,7 @@ class TestWorkerRunner(LocustTestCase):
             def on_custom_msg(msg, **kw):
                 test_custom_msg[0] = True
                 test_custom_msg_data[0] = msg.data
-            
+
             worker = self.get_runner(environment=environment, user_classes=[MyUser])
             worker.register_message("test_custom_msg", on_custom_msg)
 
@@ -1555,8 +1557,9 @@ class TestWorkerRunner(LocustTestCase):
             )
 
             self.assertTrue(test_custom_msg[0])
-            self.assertEqual(123, test_custom_msg_data[0]['test_data'])            
+            self.assertEqual(123, test_custom_msg_data[0]['test_data'])
             worker.quit()
+
 
 class TestMessageSerializing(unittest.TestCase):
     def test_message_serialize(self):


### PR DESCRIPTION
This pull fixes #1780 and #1506. 

Added two methods, `register_message` and `send_message` to the two `DistributedRunner` classes.

`register_message` takes a custom message type and a callback function to call when the specified message is received. The callback's parameters are `environment` (obviously the runner's environment) and `msg`, which is the message itself. 

`send_message` takes a custom message type and optional data to send with the message, allowing a user to easily send their own custom messages.

Updated tests/documentation where necessary, added an example implementation to the examples directory (`examples\custom_messages.py`). 