### PR TITLE
Ensure that the exception dictionaries are not mutated when generating a html report

### DIFF
--- a/locust/html.py
+++ b/locust/html.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from jinja2 import Environment, FileSystemLoader
 import os
 import pathlib
@@ -37,11 +35,9 @@ def get_html_report(environment, show_download_link=True):
 
     requests_statistics = list(chain(sort_stats(stats.entries), [stats.total]))
     failures_statistics = sort_stats(stats.errors)
-    exceptions_statistics = []
-    exceptions = deepcopy(environment.runner.exceptions)
-    for exc in exceptions.values():
-        exc["nodes"] = ", ".join(exc["nodes"])
-        exceptions_statistics.append(exc)
+    exceptions_statistics = [
+        {**exc, "nodes": ", ".join(exc["nodes"])} for exc in environment.runner.exceptions.values()
+    ]
 
     history = stats.history
 

--- a/locust/html.py
+++ b/locust/html.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from jinja2 import Environment, FileSystemLoader
 import os
 import pathlib
@@ -36,7 +38,8 @@ def get_html_report(environment, show_download_link=True):
     requests_statistics = list(chain(sort_stats(stats.entries), [stats.total]))
     failures_statistics = sort_stats(stats.errors)
     exceptions_statistics = []
-    for exc in environment.runner.exceptions.values():
+    exceptions = deepcopy(environment.runner.exceptions)
+    for exc in exceptions.values():
         exc["nodes"] = ", ".join(exc["nodes"])
         exceptions_statistics.append(exc)
 

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -356,6 +356,14 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         # self.assertEqual(200, r.status_code)
         self.assertIn("<h2>Exceptions Statistics</h2>", r.text)
 
+        # Prior to 088a98bf8ff4035a0de3becc8cd4e887d618af53, the "nodes" field for each exception in
+        # "self.runner.exceptions" was accidentally mutated in "get_html_report" to a string.
+        # This assertion reproduces the issue and it is left there to make sure there's no
+        # regression in the future.
+        self.assertTrue(
+            isinstance(next(iter(self.runner.exceptions.values()))["nodes"], set), "exception object has been mutated"
+        )
+
 
 class TestWebUIAuth(LocustTestCase):
     def setUp(self):


### PR DESCRIPTION
This PR fixes the following issue:

```
[2021-06-09 20:36:13,702] master1/CRITICAL/locust.runners: Unhandled exception in greenlet: <Greenlet at 0x7ff41a2846a0: <bound method MasterRunner.client_listener of <locust.runners.MasterRunner object at 0x7ff3ea9d4b80>>>
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/adminuser/.venv/lib/python3.8/site-packages/locust/runners.py", line 842, in client_listener
    self.log_exception(msg.node_id, msg.data["msg"], msg.data["traceback"])
  File "/home/adminuser/.venv/lib/python3.8/site-packages/locust/runners.py", line 422, in log_exception
    row["nodes"].add(node_id)
AttributeError: 'str' object has no attribute 'add'
```

If a user generated a html report during a load test run, then the `nodes` field in every `exception` dict was mutated to a string.

This also caused the following when hovering on one of the exception in the web UI:

<img width="292" alt="Screen Shot 2021-06-09 at 18 08 27" src="https://user-images.githubusercontent.com/52334444/121436109-f4b37b00-c94d-11eb-8943-11119925ef2e.png">
