### PR TITLE
Use `None` instead of mutable `[]` default argument

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -66,7 +66,7 @@ class Environment:
     def __init__(
         self,
         *,
-        user_classes=[],
+        user_classes=None,
         shape_class=None,
         tags=None,
         exclude_tags=None,
@@ -82,7 +82,7 @@ class Environment:
         else:
             self.events = Events()
 
-        self.user_classes = user_classes
+        self.user_classes = user_classes or []
         self.shape_class = shape_class
         self.tags = tags
         self.exclude_tags = exclude_tags


### PR DESCRIPTION
This is a draft.

See https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/