### PR TITLE
Remove `user_classes_count` from heartbeat payload

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1096,7 +1096,6 @@ class WorkerRunner(DistributedRunner):
                         {
                             "state": self.worker_state,
                             "current_cpu_usage": self.current_cpu_usage,
-                            "user_classes_count": self.user_classes_count,
                         },
                         self.client_id,
                     )

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -907,9 +907,6 @@ class MasterRunner(DistributedRunner):
                         logger.info(
                             "Worker %s self-healed with heartbeat, setting state to %s." % (str(c.id), client_state)
                         )
-                        user_classes_count = msg.data.get("user_classes_count")
-                        if user_classes_count:
-                            c.user_classes_count = user_classes_count
                         if self._users_dispatcher is not None:
                             self._users_dispatcher.add_worker(worker_node=c)
                             if not self._users_dispatcher.dispatch_in_progress and self.state == STATE_RUNNING:


### PR DESCRIPTION
`user_classes_count` is already part of the stats payload so having it in the heartbeat payload is redundant and makes the payload larger.

TODO:
* [ ] Add/update test to validate the content of the heartbeat payload