### PR TITLE
Allow workers to bypass version check by sending -1 as version

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -850,7 +850,7 @@ class MasterRunner(DistributedRunner):
                 if not msg.data:
                     logger.error(f"An old (pre 2.0) worker tried to connect ({client_id}). That's not going to work.")
                     continue
-                elif msg.data != __version__:
+                elif msg.data != __version__ and msg.data != -1:
                     logger.warning(
                         f"A worker ({client_id}) running a different version ({msg.data}) connected, master version is {__version__}"
                     )

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1461,6 +1461,19 @@ class TestMasterRunner(LocustTestCase):
             server.mocked_send(Message("quit", None, "zeh_fake_client3"))
             self.assertEqual(3, len(master.clients))
 
+    def test_worker_connect_with_special_versions(self):
+        with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
+            master = self.get_runner()
+            server.mocked_send(Message("client_ready", None, "1.x_style_client_should_not_be_allowed"))
+            self.assertEqual(1, len(self.mocked_log.error))
+            self.assertEqual(0, len(master.clients))
+            server.mocked_send(Message("client_ready", "abcd", "other_version_mismatch_should_just_give_a_warning"))
+            self.assertEqual(1, len(self.mocked_log.warning))
+            self.assertEqual(1, len(master.clients))
+            server.mocked_send(Message("client_ready", -1, "version_check_bypass_should_not_warn"))
+            self.assertEqual(1, len(self.mocked_log.warning))
+            self.assertEqual(2, len(master.clients))
+
     def test_worker_stats_report_median(self):
         with mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server:
             master = self.get_runner()


### PR DESCRIPTION
Also add test case for version checking. Helps a little with #1827.