### PR TITLE
Use UTC time for server stats history, localize times on the client

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -791,7 +791,7 @@ def stats_history(runner):
             break
         if runner.state != "stopped":
             r = {
-                "time": datetime.datetime.now().strftime("%H:%M:%S"),
+                "time": datetime.datetime.utcnow().strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,
                 "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
                 "response_time_percentile_95": stats.total.get_current_response_time_percentile(0.95) or 0,

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -44,7 +44,7 @@
             {% if show_download_link %}
                 <p class="download"><a href="?download=1">Download the Report</a></p>
             {% endif %}
-            <p>During: <span>{{ start_time }} - {{ end_time }}</span></p>
+            <p>During: <span class="l10n datetime">{{ start_time }}</span> - <span class="l10n datetime">{{ end_time }}</span></p>
             <p>Target Host: <span>{{ host }}</span></p>
         </div>
 
@@ -219,6 +219,20 @@
                 ]
             });
         }
+
+        $(".l10n.datetime").html((index, currentContent) => {
+            if (!currentContent || !currentContent.includes(" ") || !currentContent.includes(":")) {
+                return currentContent;
+            }
+
+            let [date, time] = currentContent.split(" ");
+            let utcDateTime = new Date();
+            let [year, month, day] = date.split("-")
+            utcDateTime.setUTCFullYear(year, parseInt(month) - 1, day);
+            utcDateTime.setUTCHours(...(time.split(":")));
+            
+            return utcDateTime.toLocaleString();
+        });
     </script>
 </body>
 </html>

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -225,13 +225,7 @@
                 return currentContent;
             }
 
-            let [date, time] = currentContent.split(" ");
-            let utcDateTime = new Date();
-            let [year, month, day] = date.split("-")
-            utcDateTime.setUTCFullYear(year, parseInt(month) - 1, day);
-            utcDateTime.setUTCHours(...(time.split(":")));
-            
-            return utcDateTime.toLocaleString();
+            return new Date(Date.parse(currentContent.replace(" ", "T") + ".000Z")).toLocaleString();
         });
     </script>
 </body>

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -1,6 +1,6 @@
 {% set time_data = [] %}{% set user_count_data = [] %}{% set current_rps_data = [] %}{% set current_fail_per_sec_data = [] %}{% set response_time_percentile_50_data = [] %}{% set response_time_percentile_95_data = [] %}{% for r in history %}{% do time_data.append(r.time) %}{% do user_count_data.append({"value": r.user_count}) %}{% do current_rps_data.append({"value": r.current_rps, "users": r.user_count}) %}{% do current_fail_per_sec_data.append({"value": r.current_fail_per_sec, "users": r.user_count}) %}{% do response_time_percentile_50_data.append({"value": r.response_time_percentile_50, "users": r.user_count}) %}{% do response_time_percentile_95_data.append({"value": r.response_time_percentile_95, "users": r.user_count}) %}{% endfor %}
 var stats_history = {
-    "time": {{ time_data | tojson }},
+    "time": {{ time_data | tojson }}.map(server_time => new Date(new Date().setUTCHours(...(server_time.split(":")))).toLocaleTimeString()),
     "user_count": {{ user_count_data | tojson }},
     "current_rps": {{ current_rps_data | tojson }},
     "current_fail_per_sec": {{ current_fail_per_sec_data | tojson }},


### PR DESCRIPTION
Server-side stats history time sourcing changed from server time(time zone dependent) to UTC, aligning it with other server-side time values sourced from `time.time()`. This enables the same frame of reference for all clients by knowing it is UTC. Localization is now performed client-side on server-rendered dates and times.  

Localization of the `report.html` start and end datetimes intentionally formats the value according to the client's default locale to keep with the localization theme of this change.

The date strings are manually parsed instead of using `Date.parse()` as recommended by MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parsed
`"It is not recommended to use Date.parse as until ES5, parsing of strings was entirely implementation dependent. There are still many differences in how different hosts parse date strings, therefore date strings should be manually parsed (a library can help if many different formats are to be accommodated)."`

Fixes #1835