### PR TITLE
fix(charts): prevent displaying stats before requests are made

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -217,20 +217,28 @@ function updateStats() {
             renderTable(report);
             renderWorkerTable(report);
 
-            if (report.state !== "stopped"){
-                // get total stats row
-                var total = report.stats[report.stats.length-1];
-                // update charts
-                stats_history["time"].push(new Date().toLocaleTimeString());
-                stats_history["user_count"].push({"value": report.user_count});
-                stats_history["current_rps"].push({"value": total.current_rps, "users": report.user_count});
-                stats_history["current_fail_per_sec"].push({"value": total.current_fail_per_sec, "users": report.user_count});
-                stats_history["response_time_percentile_50"].push({"value": report.current_response_time_percentile_50, "users": report.user_count});
-                stats_history["response_time_percentile_95"].push({"value": report.current_response_time_percentile_95, "users": report.user_count});
-                update_stats_charts()
-            } else {
+            if (report.state === "stopped") {
                 appearStopped();
+                return;
             }
+
+            // get total stats row
+            var total = report.stats[report.stats.length-1];
+
+            // ignore stats without requests
+            if (total.num_requests < 1) {
+                return;
+            }
+
+            // update charts
+            stats_history["time"].push(new Date().toLocaleTimeString());
+            stats_history["user_count"].push({"value": report.user_count});
+            stats_history["current_rps"].push({"value": total.current_rps, "users": report.user_count});
+            stats_history["current_fail_per_sec"].push({"value": total.current_fail_per_sec, "users": report.user_count});
+            stats_history["response_time_percentile_50"].push({"value": report.current_response_time_percentile_50, "users": report.user_count});
+            stats_history["response_time_percentile_95"].push({"value": report.current_response_time_percentile_95, "users": report.user_count});
+            update_stats_charts();
+
         } catch(i){
             console.debug(i);
         }

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -79,6 +79,20 @@ $('#swarm_form').submit(function(event) {
         function(response) {
             if (response.success) {
                 setHostName(response.host);
+
+                // add run marker to close off the previous run if any
+                if(stats_history["time"].length < 1) {
+                    return;
+                }
+
+                let time = new Date().toLocaleTimeString();
+                stats_history["markers"].push({xAxis: time});
+                stats_history["time"].push(time);
+                stats_history["user_count"].push({"value": null});
+                stats_history["current_rps"].push({"value": null});
+                stats_history["current_fail_per_sec"].push({"value": null});
+                stats_history["response_time_percentile_50"].push({"value": null});
+                stats_history["response_time_percentile_95"].push({"value": null});
             }
         }
     );
@@ -174,12 +188,23 @@ $("#workers .stats_label").click(function(event) {
     renderWorkerTable(window.report);
 });
 
+function createMarkLine() {
+    return {
+        symbol: "none",
+        label: {
+            formatter: params => `Run #${params.dataIndex + 1}`
+        },
+        lineStyle: {color: "#5b6f66"},
+        data: stats_history["markers"],
+    }
+}
+
 function update_stats_charts(){
     if(stats_history["time"].length > 0){
         rpsChart.chart.setOption({
             xAxis: {data: stats_history["time"]},
             series: [
-                {data: stats_history["current_rps"]},
+                {data: stats_history["current_rps"], markLine: createMarkLine()},
                 {data: stats_history["current_fail_per_sec"]},
             ]
         });
@@ -187,17 +212,15 @@ function update_stats_charts(){
         responseTimeChart.chart.setOption({
             xAxis: {data: stats_history["time"]},
             series: [
-                {data: stats_history["response_time_percentile_50"]},
+                {data: stats_history["response_time_percentile_50"], markLine: createMarkLine()},
                 {data: stats_history["response_time_percentile_95"]},
             ]
         });
 
         usersChart.chart.setOption({
-            xAxis: {
-                data: stats_history["time"]
-            },
+            xAxis: {data: stats_history["time"]},
             series: [
-                {data: stats_history["user_count"]},
+                {data: stats_history["user_count"], markLine: createMarkLine()},
             ]
         });
     }

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -589,7 +589,7 @@ class StatsEntry:
                 percent,
             )
         # if time was not in response times cache window
-        return 0
+        return None
 
     def percentile(self):
         if not self.num_requests:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -579,7 +579,7 @@ class StatsEntry:
                 break
 
         if cached:
-            # If we fond an acceptable cached response times, we'll calculate a new response
+            # If we found an acceptable cached response times, we'll calculate a new response
             # times dict of the last 10 seconds (approximately) by diffing it with the current
             # total response times. Then we'll use that to calculate a response time percentile
             # for that timeframe
@@ -588,6 +588,8 @@ class StatsEntry:
                 self.num_requests - cached.num_requests,
                 percent,
             )
+        # if time was not in response times cache window
+        return 0
 
     def percentile(self):
         if not self.num_requests:

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -6,4 +6,5 @@ var stats_history = {
     "current_fail_per_sec": {{ current_fail_per_sec_data | tojson }},
     "response_time_percentile_50": {{ response_time_percentile_50_data | tojson }},
     "response_time_percentile_95": {{ response_time_percentile_95_data | tojson }},
+    "markers": [],
 };

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -584,7 +584,7 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
         s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
         # an empty response times cache, current time will not be in this cache
         s.response_times_cache = {}
-        self.assertEqual(0, s.get_current_response_time_percentile(0.95))
+        self.assertEqual(None, s.get_current_response_time_percentile(0.95))
 
     def test_diff_response_times_dicts(self):
         self.assertEqual(

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -580,6 +580,12 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
 
         self.assertEqual(95, s.get_current_response_time_percentile(0.95))
 
+    def test_get_current_response_time_percentile_outside_cache_window(self):
+        s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
+        # an empty response times cache, current time will not be in this cache
+        s.response_times_cache = {}
+        self.assertEqual(0, s.get_current_response_time_percentile(0.95))
+
     def test_diff_response_times_dicts(self):
         self.assertEqual(
             {1: 5, 6: 8},

--- a/locust/web.py
+++ b/locust/web.py
@@ -426,7 +426,7 @@ class WebUI:
             "user_count": self.environment.runner.user_count,
             "version": version,
             "host": host,
-            "history": stats.history,
+            "history": stats.history if stats.num_requests > 0 else {},
             "override_host_warning": override_host_warning,
             "num_users": options and options.num_users,
             "spawn_rate": options and options.spawn_rate,


### PR DESCRIPTION
Stat history would be charted by the client as a stream of consciousness
from the runners until they are stopped.
The client will no longer show unquantified stats (represented by the
number of requests).

Issue: #1852

State checking logic on the client has also been flattened to simplify the flow.

Considerations:
- By only showing stats that contain request, there might be an appearance of unresponsiveness until requests are made because the chart will no longer be "ticking" without them.
- The aggregated `total` stats are used to determine the number of requests, this is to allow a transition from `ready` state to `running` state to be displayed.
- The times on the x-axis of charts diverge between a page that has been running for a while and a page refresh, this is because the client stores the time that it fetched the stats rather than the times of the stats themselves. 