### PR TITLE
HttpUser: Unpack known exceptions

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -146,7 +146,7 @@ class HttpSession(requests.Session):
                         e,
                         (
                             requests.exceptions.ConnectionError,
-                            requests.exceptions.ProtocolError,
+                            requests.exceptions.urllib3.exceptions.ProtocolError,
                             requests.packages.urllib3.exceptions.MaxRetryError,
                             requests.packages.urllib3.exceptions.NewConnectionError,
                         ),

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -146,7 +146,7 @@ class HttpSession(requests.Session):
                         e,
                         (
                             requests.exceptions.ConnectionError,
-                            requests.exceptions.urllib3.exceptions.ProtocolError,
+                            requests.packages.urllib3.exceptions.ProtocolError,
                             requests.packages.urllib3.exceptions.MaxRetryError,
                             requests.packages.urllib3.exceptions.NewConnectionError,
                         ),

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -146,6 +146,7 @@ class HttpSession(requests.Session):
                         e,
                         (
                             requests.exceptions.ConnectionError,
+                            requests.exceptions.ProtocolError,
                             requests.packages.urllib3.exceptions.MaxRetryError,
                             requests.packages.urllib3.exceptions.NewConnectionError,
                         ),

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -141,6 +141,18 @@ class HttpSession(requests.Session):
             try:
                 response.raise_for_status()
             except RequestException as e:
+                while (
+                    isinstance(
+                        e,
+                        (
+                            requests.exceptions.ConnectionError,
+                            requests.packages.urllib3.exceptions.MaxRetryError,
+                            requests.packages.urllib3.exceptions.NewConnectionError,
+                        ),
+                    )
+                    and e.__context__  # Not sure if the above exceptions can ever be the lowest level, but it is good to be sure
+                ):
+                    e = e.__context__
                 request_meta["exception"] = e
 
             self.request_event.fire(**request_meta)


### PR DESCRIPTION
Changes something like

ConnectionError(MaxRetryError("HTTPSConnectionPool(host='asdf.se', port=345): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x10f1d0d60>: Failed to establish a new connection: [Errno 61] Connection refused'))"))

Into:

ConnectionRefusedError(61, 'Connection refused')