### PR TITLE
fix(examples): fix multiple_hosts.py example

### DIFF
--- a/examples/multiple_hosts.py
+++ b/examples/multiple_hosts.py
@@ -9,7 +9,9 @@ class MultipleHostsUser(HttpUser):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.api_client = HttpSession(base_url=os.environ["API_HOST"])
+        self.api_client = HttpSession(
+            base_url=os.environ["API_HOST"], request_event=self.client.request_event, user=self
+        )
 
 
 class UserTasks(TaskSet):


### PR DESCRIPTION
Sync `multiple_hosts.py` creation of `HttpSession` with the new constructor signature.

Fixes: #1775