### PR TITLE
Bind web ui socket using SO_REUSEADDR

### DIFF
--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -199,7 +199,6 @@ class LocustProcessIntegrationTest(TestCase):
             @events.quitting.add_listener
             def _(environment, **kw):
                 environment.process_exit_code = 42
-            
             class TestUser(User):
                 @task
                 def my_task(self):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -195,12 +195,12 @@ class LocustProcessIntegrationTest(TestCase):
         with temporary_file(
             content=textwrap.dedent(
                 """
-            from locust import User, task, constant, events
+            from locust import User, task, events
             @events.quitting.add_listener
             def _(environment, **kw):
                 environment.process_exit_code = 42
+            
             class TestUser(User):
-                wait_time = constant(3)
                 @task
                 def my_task(self):
                     print("running my_task()")
@@ -208,7 +208,7 @@ class LocustProcessIntegrationTest(TestCase):
             )
         ) as file_path:
             proc = subprocess.Popen(["locust", "-f", file_path], stdout=PIPE, stderr=PIPE)
-            gevent.sleep(1)
+            gevent.sleep(2)
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             stderr = stderr.decode("utf-8")


### PR DESCRIPTION
To make tests more stable (less likely to crash due to port still being taken), and to make fast restarts of Locust less likely to fail