### PR TITLE
Ability to inject custom html elements in the `head` element

### DIFF
--- a/examples/extend_web_ui/static/custom-stats-table.css
+++ b/examples/extend_web_ui/static/custom-stats-table.css
@@ -1,3 +1,7 @@
+/*
+ Customises stats tables color, alignment. Adds row highlighting.
+ Just a simple extension example. The sky's the limit here :-)
+**/
 
 table.stats {
 	border-collapse: collapse;

--- a/examples/extend_web_ui/static/extend.css
+++ b/examples/extend_web_ui/static/extend.css
@@ -1,0 +1,45 @@
+
+table.stats {
+	border-collapse: collapse;
+	overflow: hidden;
+	box-shadow: 0 0 20px rgba(0,0,0,0.1);
+}
+
+table.stats th, td {
+	padding: 15px;
+	background-color: rgba(255,255,255,0.2);
+	color: #fff;
+}
+
+table.stats th {
+	text-align: left;
+}
+
+table.stats thead {
+	th {
+		background-color: #55608f;
+	}
+}
+
+table.stats tbody {
+	tr {
+		&:hover {
+			background-color: rgba(255,255,255,0.3);
+		}
+	}
+	td {
+		position: relative;
+		&:hover {
+			&:before {
+				content: "";
+				position: absolute;
+				left: 0;
+				right: 0;
+				top: -9999px;
+				bottom: -9999px;
+				background-color: rgba(255,255,255,0.2);
+				z-index: -1;
+			}
+		}
+	}
+}

--- a/examples/extend_web_ui/templates/extend.html
+++ b/examples/extend_web_ui/templates/extend.html
@@ -1,5 +1,9 @@
 {% extends "index.html" %}
 
+{% block extended_head %}
+<link rel="stylesheet" type="text/css" href="./extend/static/extend.css?v={{ version }}" media="screen">
+{% endblock extended_head %}
+
 {% block extended_tabs %}
 <li><a href="#" class="content-length-tab-link">Content Length</a></li>
 {% endblock extended_tabs %}

--- a/examples/extend_web_ui/templates/extend.html
+++ b/examples/extend_web_ui/templates/extend.html
@@ -1,7 +1,7 @@
 {% extends "index.html" %}
 
 {% block extended_head %}
-<link rel="stylesheet" type="text/css" href="./extend/static/extend.css?v={{ version }}" media="screen">
+<link rel="stylesheet" type="text/css" href="./extend/static/custom-stats-table.css?v={{ version }}" media="screen">
 {% endblock extended_head %}
 
 {% block extended_tabs %}

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -4,6 +4,8 @@
     <title>Locust for {{ locustfile }}</title>
     <link rel="stylesheet" type="text/css" href="./static/css/application.css?v={{ version }}" media="screen">
     <link rel="shortcut icon" href="./static/img/favicon.ico" type="image/x-icon"/>
+    {% block extended_head %}
+    {% endblock extended_head %}
 </head>
 <body class="{{state}}">
     <div class="top">


### PR DESCRIPTION
# Problem

There is no (SSR) way to inject custom elements in the `head` when extending the `index.html` jinja2 template

# Solution

Add a new jinja2 block `extend_head` to the `index.html` template to improve customizability. For example:

```jinja2

{% extends "index.html" %}

{% block extended_head %}
<link rel="stylesheet" type="text/css" href="./extend/static/extend.css?v={{ version }}" media="screen">
{% endblock extended_head %}

```

# Test

This is how the `extend_web_ui` example looks like with the new table styling:

![Screenshot from 2021-09-03 18-44-03](https://user-images.githubusercontent.com/308613/131962353-ea8f99ab-132e-4e47-81cf-3e3bf94ae3ab.png)
