### PR TITLE
Fix Regression in Full History CSV Percentiles

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -843,11 +843,15 @@ class StatsCSV:
         ]
 
     def _percentile_fields(self, stats_entry, use_current = False):
+        print('In _percentile_fields')
         if not stats_entry.num_requests:
+            print('N/A')
             return self.percentiles_na
         elif use_current:
+            print('Giving current response times.')
             return [int(stats_entry.get_current_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
         else:
+            print('Giving total response times.')
             return [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
 
     def requests_csv(self, csv_writer):
@@ -906,6 +910,7 @@ class StatsCSVFileWriter(StatsCSV):
     """Write statistics to to CSV files"""
 
     def __init__(self, environment, percentiles_to_report, base_filepath, full_history=False):
+        print('Writer initialized with full_history set to... {}'.format(full_history))
         super().__init__(environment, percentiles_to_report)
         self.base_filepath = base_filepath
         self.full_history = full_history
@@ -1002,6 +1007,7 @@ class StatsCSVFileWriter(StatsCSV):
         if self.full_history:
             stats_entries = sort_stats(stats.entries)
 
+        print('Running _stats_history_data_rows... self.full_history is... {}'.format(self.full_history))
         for stats_entry in chain(stats_entries, [stats.total]):
             csv_writer.writerow(
                 chain(

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -842,7 +842,7 @@ class StatsCSV:
             "Nodes",
         ]
 
-    def _percentile_fields(self, stats_entry, use_current = False):
+    def _percentile_fields(self, stats_entry, use_current=False):
         if not stats_entry.num_requests:
             return self.percentiles_na
         elif use_current:
@@ -1013,7 +1013,7 @@ class StatsCSVFileWriter(StatsCSV):
                         f"{stats_entry.current_rps:2f}",
                         f"{stats_entry.current_fail_per_sec:2f}",
                     ),
-                    self._percentile_fields(stats_entry, use_current = self.full_history),
+                    self._percentile_fields(stats_entry, use_current=self.full_history),
                     (
                         stats_entry.num_requests,
                         stats_entry.num_failures,

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -843,15 +843,11 @@ class StatsCSV:
         ]
 
     def _percentile_fields(self, stats_entry, use_current = False):
-        print('In _percentile_fields')
         if not stats_entry.num_requests:
-            print('N/A')
             return self.percentiles_na
         elif use_current:
-            print('Giving current response times.')
             return [int(stats_entry.get_current_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
         else:
-            print('Giving total response times.')
             return [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
 
     def requests_csv(self, csv_writer):
@@ -910,7 +906,6 @@ class StatsCSVFileWriter(StatsCSV):
     """Write statistics to to CSV files"""
 
     def __init__(self, environment, percentiles_to_report, base_filepath, full_history=False):
-        print('Writer initialized with full_history set to... {}'.format(full_history))
         super().__init__(environment, percentiles_to_report)
         self.base_filepath = base_filepath
         self.full_history = full_history
@@ -1007,7 +1002,6 @@ class StatsCSVFileWriter(StatsCSV):
         if self.full_history:
             stats_entries = sort_stats(stats.entries)
 
-        print('Running _stats_history_data_rows... self.full_history is... {}'.format(self.full_history))
         for stats_entry in chain(stats_entries, [stats.total]):
             csv_writer.writerow(
                 chain(

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -842,12 +842,13 @@ class StatsCSV:
             "Nodes",
         ]
 
-    def _percentile_fields(self, stats_entry):
-        return (
-            [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
-            if stats_entry.num_requests
-            else self.percentiles_na
-        )
+    def _percentile_fields(self, stats_entry, use_current = False):
+        if not stats_entry.num_requests:
+            return self.percentiles_na
+        elif use_current:
+            return [int(stats_entry.get_current_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
+        else:
+            return [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
 
     def requests_csv(self, csv_writer):
         """Write requests csv with header and data rows."""
@@ -1012,7 +1013,7 @@ class StatsCSVFileWriter(StatsCSV):
                         f"{stats_entry.current_rps:2f}",
                         f"{stats_entry.current_fail_per_sec:2f}",
                     ),
-                    self._percentile_fields(stats_entry),
+                    self._percentile_fields(stats_entry, use_current = self.full_history),
                     (
                         stats_entry.num_requests,
                         stats_entry.num_failures,

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -251,7 +251,6 @@
                 Joakim Hamrén (<a href="https://twitter.com/Jahaaja/">@jahaaja</a>)<br>
                 <a href="http://esn.me/">ESN Social Software</a> (<a href="https://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
                 Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)<br>
-                Taylor didn't do much, but he put his name here as a sanity check to see if his fork was really being deployed.
 
 
                 <h1>License</h1>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -250,7 +250,7 @@
                 <a href="http://heyman.info/">Jonatan Heyman</a> (<a href="https://twitter.com/jonatanheyman/">@jonatanheyman</a>)<br>
                 Joakim Hamrén (<a href="https://twitter.com/Jahaaja/">@jahaaja</a>)<br>
                 <a href="http://esn.me/">ESN Social Software</a> (<a href="https://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
-                Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)<br>
+                Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)
 
 
                 <h1>License</h1>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -250,7 +250,8 @@
                 <a href="http://heyman.info/">Jonatan Heyman</a> (<a href="https://twitter.com/jonatanheyman/">@jonatanheyman</a>)<br>
                 Joakim Hamrén (<a href="https://twitter.com/Jahaaja/">@jahaaja</a>)<br>
                 <a href="http://esn.me/">ESN Social Software</a> (<a href="https://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
-                Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)
+                Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)<br>
+                Taylor didn't do much, but he put his name here as a sanity check to see if his fork was really being deployed.
 
 
                 <h1>License</h1>


### PR DESCRIPTION
The docstring for _stats_history_data_rows says it should be outputting `*current* stats` (emphasis not added by me). In the original commit from December 3rd, 2019, it was properly using the `get_current_response_time_percentile` function.

On August 18th, 2020, the code was all reformatted and it looks like a regression was accidentally introduced when they switched over to using `get_response_time_percentile` instead.

This PR simply fixes that regression, switching back to using `get_current_response_time_percentile`.

The bug is easiest to observe if you have a spikey/bursty test shape. During bursts, latency increases. During quieter times, latency goes back down. This is properly reflected in the Locust Web UI's graph tab, but the full history CSV file doesn't show that - instead there's only a slight decline in latency between bursts, because it's showing the 95th percentile since the test began rather than just for the past 10 seconds.

I suspect the bug went just over a year without being noticed because it's unusual to either (1) use a custom load shape for a test and (2) to closely examine the full history CSV file.