### PR TITLE
Missing colons after else keyword in Event Hooks doc

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -36,14 +36,14 @@ You can check to ensure you aren't running on the master node by checking the ty
     def on_test_start(environment, **kwargs):
         if not isinstance(environment.runner, MasterRunner):
             print("Beginning test setup")
-        else
+        else:
             print("Started test from Master node")
 
     @events.test_stop.add_listener
     def on_test_stop(environment, **kwargs):
         if not isinstance(environment.runner, MasterRunner):
             print("Cleaning up test data")
-        else
+        else:
             print("Stopped test from Master node")
 
 You can also use events `to add custom command line arguments <https://github.com/locustio/locust/tree/master/examples/add_command_line_argument.py>`_. 


### PR DESCRIPTION
Just a very small fix in the doc.