### PR TITLE
Fixed #1909 -- Return UTC datetime with the POSIX timestamp for API /stats/report

### DIFF
--- a/locust/html.py
+++ b/locust/html.py
@@ -20,11 +20,11 @@ def get_html_report(environment, show_download_link=True):
     stats = environment.runner.stats
 
     start_ts = stats.start_time
-    start_time = datetime.datetime.fromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M:%S")
+    start_time = datetime.datetime.utcfromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M:%S")
 
     end_ts = stats.last_request_timestamp
     if end_ts:
-        end_time = datetime.datetime.fromtimestamp(end_ts).strftime("%Y-%m-%d %H:%M:%S")
+        end_time = datetime.datetime.utcfromtimestamp(end_ts).strftime("%Y-%m-%d %H:%M:%S")
     else:
         end_time = start_time
 


### PR DESCRIPTION
Template variable `start_time/end_time` from `time.time(): the time in seconds since the epoch`.

However, script element in `templates/report.html` converts datetime to UTC datetime forcely in `$(".l10n.datetime").html()`

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>