### PR TITLE
Set default stop timeout to 10s

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -457,8 +457,8 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         action="store",
         type=int,
         dest="stop_timeout",
-        default=None,
-        help="Number of seconds to wait for a simulated user to complete any executing task before exiting. Default is to terminate immediately. This parameter only needs to be specified for the master process when running Locust distributed.",
+        default=10,
+        help="Number of seconds to wait for a simulated user to complete any executing task before exiting. Use 0 to terminate immediately. This parameter only needs to be specified for the master process when running Locust distributed.",
         env_var="LOCUST_STOP_TIMEOUT",
     )
     other_group.add_argument(

--- a/locust/env.py
+++ b/locust/env.py
@@ -54,9 +54,9 @@ class Environment:
     reset_stats = False
     """Determines if stats should be reset once all simulated users have been spawned"""
 
-    stop_timeout = None
+    stop_timeout = 0
     """
-    If set, the runner will try to stop the running users gracefully and wait this many seconds
+    If non-zero, the runner will try to stop the running users gracefully and wait this many seconds
     before killing them hard.
     """
 
@@ -85,7 +85,7 @@ class Environment:
         events=None,
         host=None,
         reset_stats=False,
-        stop_timeout=None,
+        stop_timeout=0,
         catch_exceptions=True,
         parsed_options=None,
     ):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -805,8 +805,7 @@ class MasterRunner(DistributedRunner):
                     logger.debug("Sending stop message to client %s" % client.id)
                     self.server.send_to_client(Message("stop", None, client.id))
 
-                # Give an additional 60s for all workers to stop
-                timeout = gevent.Timeout(self.environment.stop_timeout or 0 + 60)
+                timeout = gevent.Timeout(self.environment.stop_timeout + 60)
                 timeout.start()
                 try:
                     while self.user_count != 0:

--- a/locust/test/mock_locustfile.py
+++ b/locust/test/mock_locustfile.py
@@ -12,10 +12,10 @@ from locust import HttpUser, TaskSet, task, between, LoadTestShape
 
 
 def index(l):
-    l.client.get("/")
+    l.client.get("/", timeout=1)
 
 def stats(l):
-    l.client.get("/stats/requests")
+    l.client.get("/stats/requests", timeout=1)
 
 
 class UserTasks(TaskSet):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -324,7 +324,7 @@ class LocustProcessIntegrationTest(TestCase):
                         "0",
                     ],
                     stderr=subprocess.STDOUT,
-                    timeout=2,
+                    timeout=3,
                 )
                 .decode("utf-8")
                 .strip()

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -104,7 +104,7 @@ class mocked_options:
         self.master_bind_port = 5557
         self.heartbeat_liveness = 3
         self.heartbeat_interval = 1
-        self.stop_timeout = None
+        self.stop_timeout = 10
         self.connection_broken = False
 
     def reset_stats(self):
@@ -129,7 +129,7 @@ class TestLocustRunner(LocustTestCase):
                     for i in range(1000000):
                         _ = 3 / 2
 
-            environment = Environment(user_classes=[CpuUser])
+            environment = Environment(user_classes=[CpuUser], stop_timeout=0)
             runner = LocalRunner(environment)
             self.assertFalse(runner.cpu_warning_emitted)
             runner.spawn_users({CpuUser.__name__: 1}, wait=False)
@@ -3316,6 +3316,7 @@ class TestStopTimeout(LocustTestCase):
             tasks = [MyTaskSet]
 
         environment = create_environment([MyTestUser], mocked_options())
+        environment.stop_timeout = 0
         runner = environment.create_local_runner()
         runner.start(1, 1)
         gevent.sleep(short_time / 2)


### PR DESCRIPTION
Potentially a minor breaking change (if you were dependant on users stopping immediately)

Solves issues like #1936 (as long as tasks dont exceed 10s)