### PR TITLE
fix misspellings in doc (mostly "it's")

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -555,7 +555,7 @@ Identical to previous version, but now built & deployed to Pypi using Travis.
 * Fixed bug where POST requests (and other methods as well) got incorrectly reported as
   GET requests, if the request resulted in a redirect.
 * Added ability to download exceptions in CSV format. Download links has also been moved
-  to it's own tab in the web UI.
+  to its own tab in the web UI.
 
 
 0.7.2
@@ -608,7 +608,7 @@ msgpack for serializing master/slave data
 -----------------------------------------
 
 Locust now uses `msgpack <http://msgpack.org/>`_ for serializing data that is sent between
-a master node and it's slaves. This adresses a possible attack that can be used to execute
+a master node and its slaves. This addresses a possible attack that can be used to execute
 code remote, if one has access to the internal locust ports that are used for master-slave
 communication. The reason for this exploit was due to the fact that pickle was used.
 

--- a/docs/testing-requests-based SDK's.rst
+++ b/docs/testing-requests-based SDK's.rst
@@ -5,7 +5,7 @@ Testing Requests based SDKs
 =============================
 
 If a prebuilt SDK is available for your target system. Locust has a supported pattern for integrating
-it's usage into your load testing efforts.
+its usage into your load testing efforts.
 
 The only perquisite to achieve this; is that the SDK needs to have an accessible ``request.Sessions``
 class.

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -82,8 +82,8 @@ We've declared two tasks by decorating two methods with ``@task``, one of which 
 When our ``QuickstartUser`` runs it'll pick one of the declared tasks - in this case either ``hello_world`` or
 ``view_items`` - and execute it. Tasks are picked at random, but you can give them different weighting. The above
 configuration will make Locust three times more likely to pick ``view_items`` than ``hello_world``. When a task has
-finished executing, the User will then sleep during it's wait time (in this case between 1 and 5 seconds).
-After it's wait time it'll pick a new task and keep repeating that.
+finished executing, the User will then sleep during its wait time (in this case between 1 and 5 seconds).
+After its wait time it'll pick a new task and keep repeating that.
 
 Note that only methods decorated with ``@task`` will be picked, so you can define your own internal helper methods any way you like.
 


### PR DESCRIPTION
Hello.
Some misspellings I found while reading the documentation.