### PR TITLE
Throw exception when calling response.success()/.failure() if with-block has not been entered

### DIFF
--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -566,8 +566,6 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         r = self.user.client.get("/fail", catch_response=True)
         self.assertRaises(LocustError, r.success)
         self.assertRaises(LocustError, r.failure, "")
-        self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(1, self.environment.stats.total.num_failures)
 
     def test_deprecated_request_events(self):
         status = {"success_amount": 0, "failure_amount": 0}

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -564,8 +564,8 @@ class TestFastHttpCatchResponse(WebserverTestCase):
     def test_catch_response_missing_with_block(self):
         # incorrect usage, missing with-block
         r = self.user.client.get("/fail", catch_response=True)
-        self.assertRaises(LocustError, r.success())
-        self.assertRaises(LocustError, r.failure("wont work"))
+        self.assertRaises(LocustError, r.success)
+        self.assertRaises(LocustError, r.failure, "")
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
 

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -270,8 +270,8 @@ class TestHttpSession(WebserverTestCase):
         s = self.get_client()
         # incorrect usage, missing with-block
         r = s.get("/fail", catch_response=True)
-        self.assertRaises(LocustError, r.success())
-        self.assertRaises(LocustError, r.failure("wont work"))
+        self.assertRaises(LocustError, r.success)
+        self.assertRaises(LocustError, r.failure, "")
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
 

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -272,8 +272,6 @@ class TestHttpSession(WebserverTestCase):
         r = s.get("/fail", catch_response=True)
         self.assertRaises(LocustError, r.success)
         self.assertRaises(LocustError, r.failure, "")
-        self.assertEqual(1, self.environment.stats.total.num_requests)
-        self.assertEqual(1, self.environment.stats.total.num_failures)
 
     def test_user_context(self):
         class TestUser(HttpUser):

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -4,7 +4,7 @@ from locust.user.users import HttpUser
 from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema, RequestException
 
 from locust.clients import HttpSession
-from locust.exception import ResponseError
+from locust.exception import LocustError, ResponseError
 from .testcases import WebserverTestCase
 
 
@@ -263,6 +263,15 @@ class TestHttpSession(WebserverTestCase):
         s = self.get_client()
         with s.get("/fail", catch_response=True) as r:
             pass
+        self.assertEqual(1, self.environment.stats.total.num_requests)
+        self.assertEqual(1, self.environment.stats.total.num_failures)
+
+    def test_catch_response_missing_with_block(self):
+        s = self.get_client()
+        # incorrect usage, missing with-block
+        r = s.get("/fail", catch_response=True)
+        self.assertRaises(LocustError, r.success())
+        self.assertRaises(LocustError, r.failure("wont work"))
         self.assertEqual(1, self.environment.stats.total.num_requests)
         self.assertEqual(1, self.environment.stats.total.num_failures)
 


### PR DESCRIPTION
For when `catch_response=True` is set, but someone forgot to do a with-block...