### PR TITLE
Fix running the web UI with class defined hosts

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -318,7 +318,7 @@ class Runner:
             raise ValueError("wait is True but the amount of users to add is greater than the spawn rate")
 
         for user_class in self.user_classes:
-            if self.environment.host is not None:
+            if self.environment.host:
                 user_class.host = self.environment.host
 
         if self.state != STATE_INIT and self.state != STATE_STOPPED:
@@ -674,7 +674,7 @@ class MasterRunner(DistributedRunner):
             return
 
         for user_class in self.user_classes:
-            if self.environment.host is not None:
+            if self.environment.host:
                 user_class.host = self.environment.host
 
         self.spawn_rate = spawn_rate
@@ -1085,7 +1085,7 @@ class WorkerRunner(DistributedRunner):
         self.worker_state = STATE_SPAWNING
 
         for user_class in self.user_classes:
-            if self.environment.host is not None:
+            if self.environment.host:
                 user_class.host = self.environment.host
 
         user_classes_spawn_count = {}


### PR DESCRIPTION
I have the use case of two clients, each defining `host` as a class attribute. When running with `--headless`, it works fine, but when running with the UI, I kept getting errors like

```
                                               
[2021-12-09 14:32:00,340] localhost.localdomain/ERROR/locust.user.task: Invalid URL '/index.html': No schema supplied. Perhaps you meant http:///index.html?                    
Traceback (most recent call last):                                                                                                                                                            
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/locust/user/task.py", line 296, in run                                                                 
    self.execute_next_task()
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/locust/user/task.py", line 321, in execute_next_task
    self.execute_task(self._task_queue.pop(0))
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/locust/user/task.py", line 434, in execute_task
    task(self.user)
  File "/home/chaen/dirac/diracScaleTests/bug.py", line 15, in hello_world
    self.client.get("/index.html")
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/requests/sessions.py", line 555, in get
    return self.request('GET', url, **kwargs)
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/locust/clients.py", line 128, in request
    response = self._send_request_safe_mode(method, url, **kwargs)
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/locust/clients.py", line 195, in _send_request_safe_mode
    return super().request(method, url, **kwargs)
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/requests/models.py", line 316, in prepare
    self.prepare_url(url, params)
  File "/home/chaen/miniconda3/envs/diracprod/lib/python3.9/site-packages/requests/models.py", line 390, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL '/index.html': No schema supplied. Perhaps you meant http:///index.html?
```

This is because the web UI returns `''` as host when left empty (as opposed to `None` that the code expected).

I changed the test conditions for overwriting the values, and added a test