### PR TITLE
fixed_count: ability to spawn a specific number of users (as opposed to just using weights)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,7 @@ User class
 ============
 
 .. autoclass:: locust.User
-    :members: wait_time, tasks, weight, abstract, on_start, on_stop, wait, context, environment
+    :members: wait_time, tasks, weight, fixed_count, abstract, on_start, on_stop, wait, context, environment
 
 HttpUser class
 ================

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -180,7 +180,7 @@ For example, the following User class would sleep for one second, then two, then
         ...
 
 
-weight attribute
+weight and fixed_count attributes
 ----------------
 
 If more than one user class exists in the file, and no user classes are specified on the command line,
@@ -202,6 +202,25 @@ classes. Say for example, web users are three times more likely than mobile user
 
     class MobileUser(User):
         weight = 1
+        ...
+
+Also you can set the :py:attr:`fixed_count <locust.User.fixed_count>` attribute.
+In this case the weight property will be ignored and the exact count users will be spawned.
+These users are spawned first. In the below example the only instance of AdminUser
+will be spawned to make some specific work with more accurate control
+of request count independently of total user count.
+
+.. code-block:: python
+
+    class AdminUser(User):
+        wait_time = constant(600)
+        fixed_count = 1
+        
+        @task
+        def restart_app(self):
+            ...
+
+    class WebUser(User):
         ...
 
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -431,10 +431,14 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
 
     other_group = parser.add_argument_group("Other options")
     other_group.add_argument(
-        "--show-task-ratio", action="store_true", help="Print table of the User classes' task execution ratio"
+        "--show-task-ratio",
+        action="store_true",
+        help="Print table of the User classes' task execution ratio. Use this with non-zero --user option if some classes define non-zero fixed_count property.",
     )
     other_group.add_argument(
-        "--show-task-ratio-json", action="store_true", help="Print json data of the User classes' task execution ratio"
+        "--show-task-ratio-json",
+        action="store_true",
+        help="Print json data of the User classes' task execution ratio. Use this with non-zero --user option if some classes define non-zero fixed_count property.",
     )
     # optparse gives you --version but we have to do it ourselves to get -V too
     other_group.add_argument(

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -4,7 +4,7 @@ import math
 import time
 from collections.abc import Iterator
 from operator import attrgetter
-from typing import Dict, Generator, List, TYPE_CHECKING, Tuple, Type
+from typing import Dict, Generator, List, TYPE_CHECKING, Optional, Tuple, Type
 
 import gevent
 import typing
@@ -98,6 +98,10 @@ class UsersDispatcher(Iterator):
 
         self._rebalance = False
 
+        self._try_dispatch_fixed = True
+
+        self._no_user_to_spawn = False
+
     @property
     def dispatch_in_progress(self):
         return self._dispatch_in_progress
@@ -132,6 +136,9 @@ class UsersDispatcher(Iterator):
                 if self._rebalance:
                     self._rebalance = False
                     yield self._users_on_workers
+                if self._no_user_to_spawn:
+                    self._no_user_to_spawn = False
+                    break
 
         while self._current_user_count > self._target_user_count:
             with self._wait_between_dispatch_iteration_context():
@@ -242,12 +249,17 @@ class UsersDispatcher(Iterator):
             self._current_user_count + self._user_count_per_dispatch_iteration, self._target_user_count
         )
         for user in self._user_generator:
+            if not user:
+                self._no_user_to_spawn = True
+                break
             worker_node = next(self._worker_node_generator)
             self._users_on_workers[worker_node.id][user] += 1
             self._current_user_count += 1
             self._active_users.append((worker_node, user))
             if self._current_user_count >= current_user_count_target:
-                return self._users_on_workers
+                break
+
+        return self._users_on_workers
 
     def _remove_users_from_workers(self) -> Dict[str, Dict[str, int]]:
         """Remove users from the workers until the target number of users is reached for the current dispatch iteration
@@ -264,8 +276,16 @@ class UsersDispatcher(Iterator):
                 return self._users_on_workers
             self._users_on_workers[worker_node.id][user] -= 1
             self._current_user_count -= 1
+            self._try_dispatch_fixed = True
             if self._current_user_count == 0 or self._current_user_count <= current_user_count_target:
                 return self._users_on_workers
+
+    def _get_user_current_count(self, user: str) -> int:
+        count = 0
+        for users_on_node in self._users_on_workers.values():
+            count += users_on_node.get(user, 0)
+
+        return count
 
     def _distribute_users(
         self, target_user_count: int
@@ -307,26 +327,59 @@ class UsersDispatcher(Iterator):
         weighted round-robin algorithm, we'd get AAAAABAAAAAB which would make the distribution
         less accurate during ramp-up/down.
         """
-        # Normalize the weights so that the smallest weight will be equal to "target_min_weight".
-        # The value "2" was experimentally determined because it gave a better distribution especially
-        # when dealing with weights which are close to each others, e.g. 1.5, 2, 2.4, etc.
-        target_min_weight = 2
-        min_weight = min(u.weight for u in self._user_classes)
-        normalized_weights = [
-            (user_class.__name__, round(target_min_weight * user_class.weight / min_weight))
-            for user_class in self._user_classes
-        ]
-        gen = smooth(normalized_weights)
-        # Instead of calling `gen()` for each user, we cycle through a generator of fixed-length
-        # `generation_length_to_get_proper_distribution`. Doing so greatly improves performance because
-        # we only ever need to call `gen()` a relatively small number of times. The length of this generator
-        # is chosen as the sum of the normalized weights. So, for users A, B, C of weights 2, 5, 6, the length is
-        # 2 + 5 + 6 = 13 which would yield the distribution `CBACBCBCBCABC` that gets repeated over and over
-        # until the target user count is reached.
-        generation_length_to_get_proper_distribution = sum(
-            normalized_weight[1] for normalized_weight in normalized_weights
-        )
-        yield from itertools.cycle(gen() for _ in range(generation_length_to_get_proper_distribution))
+
+        def infinite_cycle_gen(users: List[Tuple[User, int]]) -> Generator[Optional[str], None, None]:
+            if not users:
+                return itertools.cycle([None])
+
+            # Normalize the weights so that the smallest weight will be equal to "target_min_weight".
+            # The value "2" was experimentally determined because it gave a better distribution especially
+            # when dealing with weights which are close to each others, e.g. 1.5, 2, 2.4, etc.
+            target_min_weight = 2
+
+            # 'Value' here means weight or fixed count
+            normalized_values = [
+                (
+                    user.__name__,
+                    round(target_min_weight * value / min([u[1] for u in users])),
+                )
+                for user, value in users
+            ]
+            generation_length_to_get_proper_distribution = sum(
+                normalized_val[1] for normalized_val in normalized_values
+            )
+            gen = smooth(normalized_values)
+
+            # Instead of calling `gen()` for each user, we cycle through a generator of fixed-length
+            # `generation_length_to_get_proper_distribution`. Doing so greatly improves performance because
+            # we only ever need to call `gen()` a relatively small number of times. The length of this generator
+            # is chosen as the sum of the normalized weights. So, for users A, B, C of weights 2, 5, 6, the length is
+            # 2 + 5 + 6 = 13 which would yield the distribution `CBACBCBCBCABC` that gets repeated over and over
+            # until the target user count is reached.
+            return itertools.cycle(gen() for _ in range(generation_length_to_get_proper_distribution))
+
+        fixed_users = {u.__name__: u for u in self._user_classes if u.fixed_count}
+
+        cycle_fixed_gen = infinite_cycle_gen([(u, u.fixed_count) for u in fixed_users.values()])
+        cycle_weighted_gen = infinite_cycle_gen([(u, u.weight) for u in self._user_classes if not u.fixed_count])
+
+        # Spawn users
+        while True:
+            if self._try_dispatch_fixed:
+                spawned_classes = set()
+                while True:
+                    user_name = next(cycle_fixed_gen)
+                    if not user_name:
+                        break
+                    if self._get_user_current_count(user_name) >= fixed_users[user_name].fixed_count:
+                        spawned_classes.add(user_name)
+                    else:
+                        yield user_name
+                    if len(spawned_classes) == len(fixed_users):
+                        break
+                self._try_dispatch_fixed = False
+
+            yield next(cycle_weighted_gen)
 
     @staticmethod
     def _fast_users_on_workers_copy(users_on_workers: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:

--- a/locust/html.py
+++ b/locust/html.py
@@ -4,9 +4,10 @@ import pathlib
 import datetime
 from itertools import chain
 from .stats import sort_stats
-from .user.inspectuser import get_task_ratio_dict
+from .user.inspectuser import get_ratio
 from html import escape
 from json import dumps
+from .runners import MasterRunner
 
 
 def render_template(file, **kwargs):
@@ -62,9 +63,14 @@ def get_html_report(environment, show_download_link=True):
             static_css.append(f.read())
         static_css.extend(["", ""])
 
+    is_distributed = isinstance(environment.runner, MasterRunner)
+    user_spawned = (
+        environment.runner.reported_user_classes_count if is_distributed else environment.runner.user_classes_count
+    )
+
     task_data = {
-        "per_class": get_task_ratio_dict(environment.user_classes),
-        "total": get_task_ratio_dict(environment.user_classes, total=True),
+        "per_class": get_ratio(environment.user_classes, user_spawned, False),
+        "total": get_ratio(environment.user_classes, user_spawned, True),
     }
 
     res = render_template(

--- a/locust/main.py
+++ b/locust/main.py
@@ -20,7 +20,7 @@ from . import stats
 from .stats import print_error_report, print_percentile_stats, print_stats, stats_printer, stats_history
 from .stats import StatsCSV, StatsCSVFileWriter
 from .user import User
-from .user.inspectuser import get_task_ratio_dict, print_task_ratio
+from .user.inspectuser import print_task_ratio, print_task_ratio_json
 from .util.timespan import parse_timespan
 from .exception import AuthCredentialsError
 from .shape import LoadTestShape
@@ -218,18 +218,13 @@ def main():
     if options.show_task_ratio:
         print("\n Task ratio per User class")
         print("-" * 80)
-        print_task_ratio(user_classes)
+        print_task_ratio(user_classes, options.num_users, False)
         print("\n Total task ratio")
         print("-" * 80)
-        print_task_ratio(user_classes, total=True)
+        print_task_ratio(user_classes, options.num_users, True)
         sys.exit(0)
     if options.show_task_ratio_json:
-
-        task_data = {
-            "per_class": get_task_ratio_dict(user_classes),
-            "total": get_task_ratio_dict(user_classes, total=True),
-        }
-        print(dumps(task_data))
+        print_task_ratio_json(user_classes, options.num_users)
         sys.exit(0)
 
     if options.master:

--- a/locust/static/tasks.js
+++ b/locust/static/tasks.js
@@ -29,11 +29,12 @@ function _getTasks_div(root, title) {
 }
 
 
-function initTasks() {
-    var tasks = $('#tasks .tasks')
-    var tasksData = tasks.data('tasks');
-    console.log(tasksData);
-    tasks.append(_getTasks_div(tasksData.per_class, 'Ratio per User class'));
-    tasks.append(_getTasks_div(tasksData.total, 'Total ratio'));
+function updateTasks() {
+    $.get('/tasks', function (data) {
+        var tasks = $('#tasks .tasks');
+        tasks.empty();
+        tasks.append(_getTasks_div(data.per_class, 'Ratio per User class'));
+        tasks.append(_getTasks_div(data.total, 'Total ratio'));
+    });
 }
-initTasks();
+updateTasks();

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -333,6 +333,13 @@
     <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>
     <script type="text/javascript" src="./static/locust.js?v={{ version }}"></script>
     <script type="text/javascript" src="./static/tasks.js?v={{ version }}"></script>
+    <script type="text/javascript">
+        function updateTasksWithTimeout() {
+            updateTasks()
+            setTimeout(updateTasksWithTimeout, 1000);
+        }
+        updateTasksWithTimeout()
+    </script>
     {% block extended_script %}
     {% endblock extended_script %}
 </body>

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -621,6 +621,64 @@ class LocustProcessIntegrationTest(TestCase):
             self.assertIn("Shutting down (exit code 0), bye.", output)
             self.assertEqual(0, proc.returncode)
 
+    def test_spawning_with_fixed(self):
+        LOCUSTFILE_CONTENT = textwrap.dedent(
+            """
+        from locust import User, task, constant
+
+        class User1(User):
+            fixed_count = 2
+            wait_time = constant(1)
+
+            @task
+            def t(self):
+                print("Test task is running")
+
+        class User2(User):
+            wait_time = constant(1)
+            @task
+            def t(self):
+                print("Test task is running")
+
+        class User3(User):
+            wait_time = constant(1)
+            @task
+            def t(self):
+                print("Test task is running")
+        """
+        )
+        with mock_locustfile(content=LOCUSTFILE_CONTENT) as mocked:
+            proc = subprocess.Popen(
+                " ".join(
+                    [
+                        "locust",
+                        "-f",
+                        mocked.file_path,
+                        "--headless",
+                        "--run-time",
+                        "5s",
+                        "-u",
+                        "10",
+                        "-r",
+                        "10",
+                        "--loglevel",
+                        "INFO",
+                    ]
+                ),
+                stderr=STDOUT,
+                stdout=PIPE,
+                shell=True,
+            )
+
+            output = proc.communicate()[0].decode("utf-8")
+            self.assertIn("Ramping to 10 users at a rate of 10.00 per second", output)
+            self.assertIn('All users spawned: {"User1": 2, "User2": 4, "User3": 4} (10 total users)', output)
+            self.assertIn("Test task is running", output)
+            # ensure stats printer printed at least one report before shutting down and that there was a final report printed as well
+            self.assertRegex(output, r".*Aggregated[\S\s]*Shutting down[\S\s]*Aggregated.*")
+            self.assertIn("Shutting down (exit code 0)", output)
+            self.assertEqual(0, proc.returncode)
+
     def test_html_report_option(self):
         with mock_locustfile() as mocked:
             with temporary_file("", suffix=".html") as html_report_file_path:

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -15,10 +15,10 @@ from locust.stats import CachedResponseTimes, RequestStats, StatsEntry, diff_res
 from locust.stats import StatsCSVFileWriter
 from locust.stats import stats_history
 from locust.test.testcases import LocustTestCase
-from locust.user.inspectuser import get_task_ratio_dict
+from locust.user.inspectuser import _get_task_ratio
 
-from .testcases import WebserverTestCase
-from .test_runners import mocked_rpc
+from locust.test.testcases import WebserverTestCase
+from locust.test.test_runners import mocked_rpc
 
 
 _TEST_CSV_STATS_INTERVAL_SEC = 0.2
@@ -794,16 +794,16 @@ class MyTaskSet(TaskSet):
 
 
 class TestInspectUser(unittest.TestCase):
-    def test_get_task_ratio_dict_relative(self):
-        ratio = get_task_ratio_dict([MyTaskSet])
+    def test_get_task_ratio_relative(self):
+        ratio = _get_task_ratio([MyTaskSet], False, 1.0)
         self.assertEqual(1.0, ratio["MyTaskSet"]["ratio"])
         self.assertEqual(0.75, ratio["MyTaskSet"]["tasks"]["root_task"]["ratio"])
         self.assertEqual(0.25, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task1"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task2"]["ratio"])
 
-    def test_get_task_ratio_dict_total(self):
-        ratio = get_task_ratio_dict([MyTaskSet], total=True)
+    def test_get_task_ratio_total(self):
+        ratio = _get_task_ratio([MyTaskSet], True, 1.0)
         self.assertEqual(1.0, ratio["MyTaskSet"]["ratio"])
         self.assertEqual(0.75, ratio["MyTaskSet"]["tasks"]["root_task"]["ratio"])
         self.assertEqual(0.25, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["ratio"])

--- a/locust/test/test_taskratio.py
+++ b/locust/test/test_taskratio.py
@@ -1,7 +1,7 @@
 import unittest
 
 from locust.user import User, TaskSet, task
-from locust.user.inspectuser import get_task_ratio_dict
+from locust.user.inspectuser import get_ratio, _get_task_ratio
 
 
 class TestTaskRatio(unittest.TestCase):
@@ -24,7 +24,7 @@ class TestTaskRatio(unittest.TestCase):
         class MyUser(User):
             tasks = [Tasks]
 
-        ratio_dict = get_task_ratio_dict(Tasks.tasks, total=True)
+        ratio_dict = _get_task_ratio(Tasks.tasks, True, 1.0)
 
         self.assertEqual(
             {
@@ -52,7 +52,7 @@ class TestTaskRatio(unittest.TestCase):
             weight = 3
             tasks = [Tasks]
 
-        ratio_dict = get_task_ratio_dict([UnlikelyUser, MoreLikelyUser], total=True)
+        ratio_dict = get_ratio([UnlikelyUser, MoreLikelyUser], {"UnlikelyUser": 1, "MoreLikelyUser": 3}, True)
 
         self.assertDictEqual(
             {

--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -1,12 +1,41 @@
+from collections import defaultdict
 import inspect
+from json import dumps
 
 from .task import TaskSet
-from .users import User
 
 
-def print_task_ratio(user_classes, total=False, level=0, parent_ratio=1.0):
-    d = get_task_ratio_dict(user_classes, total=total, parent_ratio=parent_ratio)
+def print_task_ratio(user_classes, num_users, total):
+    """
+    This function calculates the task ratio of users based on the user total count.
+    """
+    d = get_ratio(user_classes, _calc_distribution(user_classes, num_users), total)
     _print_task_ratio(d)
+
+
+def print_task_ratio_json(user_classes, num_users):
+    d = _calc_distribution(user_classes, num_users)
+    task_data = {
+        "per_class": get_ratio(user_classes, d, False),
+        "total": get_ratio(user_classes, d, True),
+    }
+
+    print(dumps(task_data, indent=4))
+
+
+def _calc_distribution(user_classes, num_users):
+    fixed_count = sum([u.fixed_count for u in user_classes if u.fixed_count])
+    total_weight = sum([u.weight for u in user_classes if not u.fixed_count])
+    num_users = num_users or (total_weight if not fixed_count else 1)
+    weighted_count = num_users - fixed_count
+    weighted_count = weighted_count if weighted_count > 0 else 0
+    user_classes_count = {}
+
+    for u in user_classes:
+        count = u.fixed_count if u.fixed_count else (u.weight / total_weight) * weighted_count
+        user_classes_count[u.__name__] = round(count)
+
+    return user_classes_count
 
 
 def _print_task_ratio(x, level=0):
@@ -18,33 +47,32 @@ def _print_task_ratio(x, level=0):
             _print_task_ratio(v["tasks"], level + 1)
 
 
-def get_task_ratio_dict(tasks, total=False, parent_ratio=1.0):
-    """
-    Return a dict containing task execution ratio info
-    """
-    if len(tasks) > 0 and hasattr(tasks[0], "weight"):
-        divisor = sum(t.weight for t in tasks)
-    else:
-        divisor = len(tasks) / parent_ratio
-    ratio = {}
-    for task in tasks:
-        ratio.setdefault(task, 0)
-        ratio[task] += task.weight if hasattr(task, "weight") else 1
-
-    # get percentage
-    ratio_percent = dict((k, float(v) / divisor) for k, v in ratio.items())
+def get_ratio(user_classes, user_spawned, total):
+    user_count = sum(user_spawned.values()) or 1
+    ratio_percent = {u: user_spawned.get(u.__name__, 0) / user_count for u in user_classes}
 
     task_dict = {}
-    for locust, ratio in ratio_percent.items():
-        d = {"ratio": ratio}
-        if inspect.isclass(locust):
-            if issubclass(locust, (User, TaskSet)):
-                T = locust.tasks
-            if total:
-                d["tasks"] = get_task_ratio_dict(T, total, ratio)
-            else:
-                d["tasks"] = get_task_ratio_dict(T, total)
+    for u, r in ratio_percent.items():
+        d = {"ratio": r}
+        d["tasks"] = _get_task_ratio(u.tasks, total, r)
+        task_dict[u.__name__] = d
 
-        task_dict[locust.__name__] = d
+    return task_dict
+
+
+def _get_task_ratio(tasks, total, parent_ratio):
+    parent_ratio = parent_ratio if total else 1.0
+    ratio = defaultdict(int)
+    for task in tasks:
+        ratio[task] += 1
+
+    ratio_percent = {t: r * parent_ratio / len(tasks) for t, r in ratio.items()}
+
+    task_dict = {}
+    for t, r in ratio_percent.items():
+        d = {"ratio": r}
+        if inspect.isclass(t) and issubclass(t, TaskSet):
+            d["tasks"] = _get_task_ratio(t.tasks, total, r)
+        task_dict[t.__name__] = d
 
     return task_dict

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -97,6 +97,13 @@ class User(object, metaclass=UserMeta):
     weight = 1
     """Probability of user class being chosen. The higher the weight, the greater the chance of it being chosen."""
 
+    fixed_count = 0
+    """
+    If the value > 0, the weight property will be ignored and the <fixed_count> users will be spawned.
+    These users are spawed first. If target count is not enougth to spawn all <fixed_count> users,
+    the final count of each user is undefined.
+    """
+
     abstract = True
     """If abstract is True, the class is meant to be subclassed, and locust will not spawn users of this class during a test."""
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -99,9 +99,9 @@ class User(object, metaclass=UserMeta):
 
     fixed_count = 0
     """
-    If the value > 0, the weight property will be ignored and the <fixed_count> users will be spawned.
-    These users are spawed first. If target count is not enougth to spawn all <fixed_count> users,
-    the final count of each user is undefined.
+    If the value > 0, the weight property will be ignored and the 'fixed_count'-instances will be spawned.
+    These Users are spawned first. If the total target count (specified by the --users arg) is not enougth
+    to spawn all instances of each User class with the defined property, the final count of each User is undefined.
     """
 
     abstract = True


### PR DESCRIPTION
Issue #1939
Here is the overall working option, but noticed a problem with the display 'Ratio per User class' and 'Total ratio' on web UI.
I'm going to redo the logic a little bit, get_task_ratio_dict it will recalculate the ratio based on the number of users at the moment. I'll make it a separate commit in same branch. Maybe there are other ideas?