### PR TITLE
Clean up some logging messages

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -426,7 +426,7 @@ def main():
         """
         Shut down locust by firing quitting event, printing/writing stats and exiting
         """
-        logger.info("Running teardowns...")
+        logger.debug("Running teardowns...")
 
         if input_listener_greenlet is not None:
             input_listener_greenlet.kill(block=False)
@@ -443,12 +443,12 @@ def main():
         else:
             code = 0
 
-        logger.info("Shutting down (exit code %s), bye." % code)
+        logger.info("Shutting down (exit code %s)" % code)
         if stats_printer_greenlet is not None:
             stats_printer_greenlet.kill(block=False)
         if headless_master_greenlet is not None:
             headless_master_greenlet.kill(block=False)
-        logger.info("Cleaning up runner...")
+        logger.debug("Cleaning up runner...")
         if runner is not None:
             runner.quit()
 

--- a/locust/test/test_log.py
+++ b/locust/test/test_log.py
@@ -79,7 +79,7 @@ class TestLoggingOptions(LocustTestCase):
             output,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
+            "%s/INFO/locust.main: Shutting down (exit code 0)" % socket.gethostname(),
             output,
         )
         self.assertIn(
@@ -191,7 +191,7 @@ class TestLoggingOptions(LocustTestCase):
             log_content,
         )
         self.assertIn(
-            "%s/INFO/locust.main: Shutting down (exit code 0), bye." % socket.gethostname(),
+            "%s/INFO/locust.main: Shutting down (exit code 0)" % socket.gethostname(),
             log_content,
         )
         # check that message of custom logger also went into log file

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -279,7 +279,7 @@ class LocustProcessIntegrationTest(TestCase):
             stderr = stderr.decode("utf-8")
             self.assertIn("Starting web interface at", stderr)
             self.assertIn("Starting Locust", stderr)
-            self.assertIn("Shutting down (exit code 42), bye", stderr)
+            self.assertIn("Shutting down (exit code 42)", stderr)
             self.assertEqual(42, proc.returncode)
 
     def test_webserver(self):
@@ -302,7 +302,7 @@ class LocustProcessIntegrationTest(TestCase):
             stderr = stderr.decode("utf-8")
             self.assertIn("Starting web interface at", stderr)
             self.assertIn("Starting Locust", stderr)
-            self.assertIn("Shutting down (exit code 0), bye", stderr)
+            self.assertIn("Shutting down (exit code 0)", stderr)
             self.assertEqual(0, proc.returncode)
 
     def test_default_headless_spawn_options(self):
@@ -353,7 +353,7 @@ class LocustProcessIntegrationTest(TestCase):
             stderr = stderr.decode("utf-8")
             self.assertIn("Starting Locust", stderr)
             self.assertIn("No run time limit set, use CTRL+C to interrupt", stderr)
-            self.assertIn("Shutting down (exit code 0), bye", stderr)
+            self.assertIn("Shutting down (exit code 0)", stderr)
             self.assertEqual(0, proc.returncode)
 
     def test_default_headless_spawn_options_with_shape(self):
@@ -618,7 +618,7 @@ class LocustProcessIntegrationTest(TestCase):
             self.assertIn("Test task is running", output)
             # ensure stats printer printed at least one report before shutting down and that there was a final report printed as well
             self.assertRegex(output, r".*Aggregated[\S\s]*Shutting down[\S\s]*Aggregated.*")
-            self.assertIn("Shutting down (exit code 0), bye.", output)
+            self.assertIn("Shutting down (exit code 0)", output)
             self.assertEqual(0, proc.returncode)
 
     def test_html_report_option(self):


### PR DESCRIPTION
Make "Running teardowns..." and "cleaning up runner..." log messages debug instead of info. Shorten "Shutting down ..." message.