### PR TITLE
WorkerRunner: read --expect-workers from job parameters

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1161,7 +1161,11 @@ class WorkerRunner(DistributedRunner):
                     argument_parser.setup_parser_arguments(default_parser)
                     self.environment.parsed_options = default_parser.parse(args=[])
                 custom_args_from_master = {
-                    k: v for k, v in job["parsed_options"].items() if k not in argument_parser.default_args_dict()
+                    k: v
+                    for k, v in job["parsed_options"].items()
+                    if k not in argument_parser.default_args_dict()
+                    # expect_workers is sometimes needed on workers, e.g. in locust-plugins global rps limiter
+                    or k == "expect_workers"
                 }
                 vars(self.environment.parsed_options).update(custom_args_from_master)
 


### PR DESCRIPTION
So that a worker can know how many other processes will be running. This is kind of ugly and arbitrary, but I dont have time to do a proper re-think of argument passing.