### PR TITLE
Pass tags and exclude-tags to workers. 

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -199,14 +199,14 @@ class Environment:
 
         if self.tags is not None:
             tags = set(self.tags)
-        elif self.parsed_options is not None:
+        elif self.parsed_options and self.parsed_options.tags:
             tags = set(self.parsed_options.tags)
         else:
             tags = None
 
         if self.exclude_tags is not None:
             exclude_tags = set(self.exclude_tags)
-        elif self.parsed_options:
+        elif self.parsed_options and self.parsed_options.exclude_tags:
             exclude_tags = set(self.parsed_options.exclude_tags)
         else:
             exclude_tags = None

--- a/locust/main.py
+++ b/locust/main.py
@@ -108,8 +108,6 @@ def create_environment(user_classes, options, events=None, shape_class=None, loc
         locustfile=locustfile,
         user_classes=user_classes,
         shape_class=shape_class,
-        tags=options.tags,
-        exclude_tags=options.exclude_tags,
         events=events,
         host=options.host,
         reset_stats=options.reset_stats,

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -311,6 +311,7 @@ class Runner:
             self.exceptions = {}
             self.cpu_warning_emitted = False
             self.worker_cpu_warning_emitted = False
+            self.environment._filter_tasks_by_tags()
             self.environment.events.test_start.fire(environment=self.environment)
 
         if wait and user_count - self.user_count > spawn_rate:
@@ -694,6 +695,7 @@ class MasterRunner(DistributedRunner):
         if self.state != STATE_RUNNING and self.state != STATE_SPAWNING:
             self.stats.clear_all()
             self.exceptions = {}
+            self.environment._filter_tasks_by_tags()
             self.environment.events.test_start.fire(environment=self.environment)
             if self.environment.shape_class:
                 self.environment.shape_class.reset_time()
@@ -1085,6 +1087,7 @@ class WorkerRunner(DistributedRunner):
             self.exceptions = {}
             self.cpu_warning_emitted = False
             self.worker_cpu_warning_emitted = False
+            self.environment._filter_tasks_by_tags()
             self.environment.events.test_start.fire(environment=self.environment)
 
         self.worker_state = STATE_SPAWNING
@@ -1164,8 +1167,8 @@ class WorkerRunner(DistributedRunner):
                     k: v
                     for k, v in job["parsed_options"].items()
                     if k not in argument_parser.default_args_dict()
-                    # expect_workers is sometimes needed on workers, e.g. in locust-plugins global rps limiter
-                    or k == "expect_workers"
+                    # these settings are sometimes needed on workers
+                    or k in ["expect_workers", "tags", "exclude_tags"]
                 }
                 vars(self.environment.parsed_options).update(custom_args_from_master)
 

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -770,7 +770,7 @@ class SecondUser(HttpUser):
     @task
     def task1(self):
         print("task1")
-    
+
     @tag("tag2")
     @task
     def task2(self):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -777,7 +777,6 @@ class SecondUser(HttpUser):
         print("task2")
 """
         )
-        print(content)
         with mock_locustfile(content=content) as mocked:
             proc = subprocess.Popen(
                 [

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -757,3 +757,69 @@ def on_test_stop(environment, **kwargs):
             self.assertIn("test_start on worker", stdout_worker)
             self.assertEqual(0, proc.returncode)
             self.assertEqual(0, proc_worker.returncode)
+
+    def test_distributed_tags(self):
+        content = (
+            MOCK_LOCUSTFILE_CONTENT
+            + """
+from locust import tag
+class SecondUser(HttpUser):
+    host = "http://127.0.0.1:8089"
+    wait_time = between(0, 0.1)
+    @tag("tag1")
+    @task
+    def task1(self):
+        print("task1")
+    
+    @tag("tag2")
+    @task
+    def task2(self):
+        print("task2")
+"""
+        )
+        print(content)
+        with mock_locustfile(content=content) as mocked:
+            proc = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--headless",
+                    "--master",
+                    "--expect-workers",
+                    "1",
+                    "-t",
+                    "1",
+                    "-u",
+                    "2",
+                    "--exit-code-on-error",
+                    "0",
+                    "-L",
+                    "DEBUG",
+                    "--tags",
+                    "tag1",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+            )
+            proc_worker = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--worker",
+                    "-L",
+                    "DEBUG",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+            )
+            stdout, stderr = proc.communicate()
+            stderr = stderr.decode("utf-8")
+            stdout = stdout.decode("utf-8")
+            stdout_worker, stderr_worker = proc_worker.communicate()
+            stdout_worker = stdout_worker.decode("utf-8")
+            self.assertIn("task1", stdout_worker)
+            self.assertNotIn("task2", stdout_worker)
+            self.assertEqual(0, proc.returncode)
+            self.assertEqual(0, proc_worker.returncode)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -712,7 +712,6 @@ def on_test_stop(environment, **kwargs):
         print("test_stop on worker")
 """
         )
-        print(content)
         with mock_locustfile(content=content) as mocked:
             proc = subprocess.Popen(
                 [


### PR DESCRIPTION
This required moving the call to filter_tasks_by_tags from Environment init to Runner.start/start_worker. Fixes #1882