### PR TITLE
Fixing issue #1961 with incorrect "All users spawned" log messages wh…

### DIFF
--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -28,6 +28,19 @@ def temporary_file(content, suffix="_locustfile.py"):
             os.remove(f.name)
 
 
+@contextmanager
+def patch_env(name: str, value: str):
+    prev_value = os.getenv(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prev_value is None:
+            del os.environ[name]
+        else:
+            os.environ[name] = prev_value
+
+
 def get_free_tcp_port():
     """
     Find an unused TCP port


### PR DESCRIPTION
Issue #1961 I saw this bug on a remote machine. I can't debug there, but I think the reason is that 100ms sometimes is not enough for workers (I guess, the last report from last worker) to send reports (or may be to receive and handle on master side). PR requires polish, but you can see the essence.