### PR TITLE
Repair broken hyperlinks in documentation

### DIFF
--- a/docs/running-cloud-integration.rst
+++ b/docs/running-cloud-integration.rst
@@ -22,9 +22,9 @@ The prerequisites are:
 More information
 ===================
 
-- :ref:`Example <https://github.com/locustio/locust/blob/master/examples/terraform/aws/README.md>`
+- `Example <https://github.com/locustio/locust/blob/master/examples/terraform/aws/README.md>`
 
-- :ref:`Terraform aws-get-started >> install-terraform-on-linux <https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started#install-terraform-on-linux>`
+- `Terraform aws-get-started >> install-terraform-on-linux <https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started#install-terraform-on-linux>`
 
-- :ref:`Terraform module aws loadtest distributed <https://registry.terraform.io/modules/marcosborges/loadtest-distribuited/aws/latest>`
+- `Terraform module aws loadtest distributed <https://registry.terraform.io/modules/marcosborges/loadtest-distribuited/aws/latest>`
 


### PR DESCRIPTION
A small PR to fix currently not working/visible hyperlinks under the [More information](http://docs.locust.io/en/stable/running-cloud-integration.html#more-information)-section

I'm not familiar with how `:ref:` statements work in `.rst` files, so if they are important for these links (I don't think so), please feel free to improve on my PR.