### PR TITLE
Fix "socket operation on non-socket" at shutdown, by reverting #1935

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -825,9 +825,6 @@ class MasterRunner(DistributedRunner):
             logger.debug("Sending quit message to client %s" % (client.id))
             self.server.send_to_client(Message("quit", None, client.id))
         gevent.sleep(0.5)  # wait for final stats report from all workers
-        self.server.close()
-        # ensure heartbeat_worker doesnt try to re-establish connection to workers and throw lots of exceptions
-        self.clients._worker_nodes = {}
         self.greenlet.kill(block=True)
 
     def check_stopped(self):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -87,7 +87,7 @@ def mocked_rpc():
             return msg.node_id, msg
 
         def close(self):
-            pass
+            raise RPCError()
 
     return MockedRpcServerClient
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -941,6 +941,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             # give time for users to generate stats, and stats to be sent to master
             sleep(0.1)
             master_env.events.quitting.fire(environment=master_env, reverse=True)
+            master.quit()
             sleep(0.1)
             # make sure users are killed
             self.assertEqual(0, worker.user_count)

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -940,7 +940,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             self.assertEqual(2, worker.user_count)
             # give time for users to generate stats, and stats to be sent to master
             sleep(0.1)
-            master.quit()
+            master_env.events.quitting.fire(environment=master_env, reverse=True)
             sleep(0.1)
             # make sure users are killed
             self.assertEqual(0, worker.user_count)


### PR DESCRIPTION
This reverts #1935 ("fix master runner not close rpc server"), because it caused real issues for regular runs (#1971) (maybe as-a-library worked, idk). 

This will reintroduce the problem regarding repeated as-a-library-runs @lizhaode was trying to fix in that PR, but we cant have regular runs throwing exceptions...

(this also reverts my attempted fix in #1972)