### PR TITLE
fix --html report in web mode

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -397,7 +397,7 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
     stats_group.add_argument(
         "--html",
         dest="html_file",
-        help="Store HTML report file",
+        help="Store HTML report to file path specified",
         env_var="LOCUST_HTML",
     )
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -457,6 +457,12 @@ def main():
         logger.info("Got SIGTERM signal")
         shutdown()
 
+    def save_html_report():
+        html_report = get_html_report(environment, show_download_link=False)
+        logger.info("writing html report to file: %s", options.html_file)
+        with open(options.html_file, "w", encoding="utf-8") as file:
+            file.write(html_report)
+
     gevent.signal_handler(signal.SIGTERM, sig_term_handler)
 
     try:
@@ -466,11 +472,10 @@ def main():
 
         main_greenlet.join()
         if options.html_file:
-            html_report = get_html_report(environment, show_download_link=False)
-            with open(options.html_file, "w", encoding="utf-8") as file:
-                file.write(html_report)
+            save_html_report()
     except KeyboardInterrupt:
-        pass
+        if options.html_file:
+            save_html_report()
     except Exception:
         raise
     shutdown()

--- a/locust/web.py
+++ b/locust/web.py
@@ -120,7 +120,7 @@ class WebUI:
                 self.auth.init_app(self.app)
             else:
                 raise AuthCredentialsError(
-                    "Invalid auth_credentials. It should be a string in the following format: 'user.pass'"
+                    "Invalid auth_credentials. It should be a string in the following format: 'user:pass'"
                 )
         if environment.runner:
             self.update_template_args()
@@ -174,6 +174,8 @@ class WebUI:
                 self._swarm_greenlet.kill(block=True)
                 self._swarm_greenlet = None
             environment.runner.stop()
+            if self.greenlet is not None:
+                self.greenlet.kill(block=True)
             return jsonify({"success": True, "message": "Test stopped"})
 
         @app.route("/stats/reset")


### PR DESCRIPTION
If locust is started by `--headful` argument(web mode), `main_greenlet.join()` will serve forever. `get_html_report` will be inaccessable.

If running locust will be CTRL+C, `get_html_report` will not be received by catching the exception.

In order to keep simple, `get_html_report` is dealt with `shutdown()` according to `--html` argument value.

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>

Edit: Fixes #1944