### PR TITLE
Mark package as being typed and add some missing type hints

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
+include locust/py.typed
 recursive-include locust/static *
 recursive-include locust/templates *

--- a/locust/py.typed
+++ b/locust/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The locust package uses inline types.


### PR DESCRIPTION
Partially resolves #2000, not all parts of the public API are fully typed.

This PR adds the `py.typed` file to the package distribution and adds type hints to `@task`, `@tag` and a couple other miscellaneous places.