### PR TITLE
Added option for handling an exception from execute_task

### DIFF
--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -446,7 +446,10 @@ class DefaultTaskSet(TaskSet):
             else:
                 # task is a function
                 task(self.user)
-        except (InterruptTaskSet, ) as e:
+        except (
+            InterruptTaskSet,
+            RescheduleTaskImmediately,
+        ) as e:
             if not self.user.handle_exceptions:
                 raise
             logging.info(f"Exception of type {type(e).__name__} occurred while executing the task.")

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -439,9 +439,14 @@ class DefaultTaskSet(TaskSet):
         return random.choice(self.user.tasks)
 
     def execute_task(self, task):
-        if hasattr(task, "tasks") and issubclass(task, TaskSet):
-            # task is  (nested) TaskSet class
-            task(self.user).run()
-        else:
-            # task is a function
-            task(self.user)
+        try:
+            if hasattr(task, "tasks") and issubclass(task, TaskSet):
+                # task is  (nested) TaskSet class
+                task(self.user).run()
+            else:
+                # task is a function
+                task(self.user)
+        except (InterruptTaskSet, ) as e:
+            if not self.user.handle_exceptions:
+                raise
+            logging.info(f"Exception of type {type(e).__name__} occurred while executing the task.")

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -94,6 +94,13 @@ class User(object, metaclass=UserMeta):
             tasks = {ThreadPage:15, write_post:1}
     """
 
+    handle_exceptions = False
+    """
+    If set to True, whenever an exception occurs in the Locust test workflow, this will be handled and
+    logged into stdout as a single line of log with log level INFO. If set to False, it will re-raise
+    the eventual exception (or chain of exceptions) back to the caller.
+    """
+
     weight = 1
     """Probability of user class being chosen. The higher the weight, the greater the chance of it being chosen."""
 


### PR DESCRIPTION
I'm willing to introduce this little change in order to handle the chain of exceptions raised when a Locust Task workflow would be manually driven.

A concrete example occurs when raising manually the `InterruptTaskSet`, to skip and reschedule immediately a task: this would lead to series of not handled exceptions, reaching back its parent caller, defined in `execute_task` function.

Such chain of exceptions is printed in stdout, with the following traceback:

```
[2022-02-21 12:26:46,925] venus/ERROR/common.base.load_testing_base: Returned HTTP status code 503: Service Temporary Unavailable
Traceback (most recent call last):
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/clients.py", line 21, in raise_for_status
    Response.raise_for_status(self)
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/requests/models.py", line 960, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error for url: https://my_faulty_server.com

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/task.py", line 297, in run
    self.execute_next_task()
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/task.py", line 322, in execute_next_task
    self.execute_task(self._task_queue.pop(0))
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/task.py", line 436, in execute_task
    task(self.user)
locust.exception.InterruptTaskSet

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/users.py", line 171, in run_user
    user.run()
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/users.py", line 139, in run
    self._taskset_instance.run()
  File "/home/mirkochip/miniconda3/envs/locust/lib/python3.9/site-packages/locust/user/task.py", line 307, in run
    raise RescheduleTaskImmediately(e.reschedule) from e
locust.exception.RescheduleTaskImmediately: True
2022-02-21T12:26:46Z <Greenlet at 0x7f514991dae0: run_user(<get_invoices.GetInvoices object at 0x7f51498be9a0)> failed with RescheduleTaskImmediately
```

Setting the flag, defined as class attribute `handle_exceptions = True` in the class containing the Locust task definition, would "replace" the traceback reported above with this single line of log:

`[2022-02-21 12:27:11,018] venus/INFO/root: Exception InterruptTaskSet occurred.`

This would make the console log more fluid and cleaner.