### PR TITLE
Remove Host dialog box if env set

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -527,6 +527,15 @@ def ui_extra_args_dict(args=None) -> Dict[str, str]:
     locust_args = default_args_dict()
 
     parser = get_parser()
+    parser.add_argument(
+        "--not-show-host-form",
+        dest="not_show_host_form",
+        action="store_true",
+        help="Don't show Host form if LOCUST_HOST is set",
+        default=True,
+        env_var="LOCUST_NOT_SHOW_HOST_FORM",
+    )
+
     all_args = vars(parser.parse_args(args))
 
     extra_args = {k: v for k, v in all_args.items() if k not in locust_args and k in parser.args_included_in_web_ui}

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -51,7 +51,7 @@
             <div style="clear:both;"></div>
         </div>
     </div>
-    
+
     <div class="dialogs">
         <div class="dialog start" id="start">
             <div style="position:relative;">
@@ -73,13 +73,15 @@
                         <label for="spawn_rate">Spawn rate <span style="color:#8a8a8a;">(users started/second)</span></label>
                         <input type="text" name="spawn_rate" id="spawn_rate" class="val" value="{{ spawn_rate or "1" }}" onfocus="this.select()"/><br>
                     {% endif %}
-                    <label for="host">
-                        Host <span style="color:#8a8a8a;">(e.g. http://www.example.com)</span>
-                        {% if override_host_warning %}
-                            <span style="color:#8a8a8a; font-size:12px;">(setting this will override the host on all User classes)</span></label>
-                        {% endif %}
-                    </label>
-                    <input type="text" name="host" id="host" class="val" autocapitalize="off" autocorrect="off" value="{{ host  or "" }}" onfocus="this.select()"/><br>
+                    {% if show_host_form %}
+                        <label for="host">
+                            Host <span style="color:#8a8a8a;">(e.g. http://www.example.com)</span>
+                            {% if override_host_warning %}
+                                <span style="color:#8a8a8a; font-size:12px;">(setting this will override the host on all User classes)</span></label>
+                            {% endif %}
+                        </label>
+                        <input type="text" name="host" id="host" class="val" autocapitalize="off" autocorrect="off" value="{{ host  or "" }}" onfocus="this.select()"/><br>
+                    {% endif %}
                     {% if extra_options %}<label>Custom parameters:</label>{% endif %}
                     {% for key, value in extra_options.items() %}
                         {% if not ((value is none) or (value is boolean)) %}
@@ -131,7 +133,7 @@
             </div>
         </div>
     </div>
-    
+
     <div class="main" id="main">
         <nav class="menu">
             <ul class="tabs container">

--- a/locust/web.py
+++ b/locust/web.py
@@ -426,6 +426,11 @@ class WebUI:
         stats = self.environment.runner.stats
         extra_options = argument_parser.ui_extra_args_dict()
 
+        show_host_form = True
+        if self.environment.host and extra_options["not_show_host_form"]:
+            show_host_form = False
+        extra_options.pop("not_show_host_form")
+
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,
@@ -441,5 +446,6 @@ class WebUI:
             "is_shape": self.environment.shape_class,
             "stats_history_enabled": options and options.stats_history_enabled,
             "tasks": dumps({}),
+            "show_host_form": show_host_form,
             "extra_options": extra_options,
         }


### PR DESCRIPTION
A feature to choose if the Host form is displayed if env var (LOCUST_HOST) is set.

My requirement is that I am using Locust with an SDK for my target system and it is he who sets the target via an environment variable. 
So I don't want the Locust user to be able to change the target in the UI, because that won't have any effect.