### PR TITLE
Support sharing connection pools between users

### DIFF
--- a/docs/increase-performance.rst
+++ b/docs/increase-performance.rst
@@ -42,7 +42,7 @@ FastHttpUser class
 --------------------
 
 .. autoclass:: locust.contrib.fasthttp.FastHttpUser
-    :members: network_timeout, connection_timeout, max_redirects, max_retries, insecure
+    :members: network_timeout, connection_timeout, max_redirects, max_retries, insecure, concurrency, client_pool
 
 
 FastHttpSession class

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -609,6 +609,28 @@ requests.Session's trust_env attribute to ``False``. If you don't want this you 
 ``locust_instance.client.trust_env`` to ``True``. For further details, refer to the
 `documentation of requests <https://requests.readthedocs.io/en/master/api/#requests.Session.trust_env>`_.
 
+Connection pooling
+------------------
+
+As every :py:class:`HttpUser <locust.HttpUser>` creates new :py:class:`HttpSession <locust.clients.HttpSession>`,
+every user instance has it's own connection pools. This is similar to how real users would interact with a web server.
+
+However, if you want to share connections among all users, you can use a single pool manager. To do this, set
+:py:attr:`pool_manager <locust.HttpUser.pool_manager>` class attribute to an instance of :py:class:`urllib3.PoolManager`.
+
+.. code-block:: python
+
+    from locust import HttpUser
+    from urllib3 import PoolManager
+
+    class MyUser(HttpUser):
+
+        # All users will be limited to 10 concurrent connections at most.
+        pool_manager = PoolManager(maxsize=10, block=True)
+
+For more configuration options, refer to the
+`urllib3 documentation <https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html>`_.
+
 TaskSets
 ================================
 TaskSets is a way to structure tests of hierarchical web sites/systems. You can :ref:`read more about it here <tasksets>`

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -56,7 +56,7 @@ class HttpSession(requests.Session):
 
         # User can group name, or use the group context manager to gather performance statistics under a specific name
         # This is an alternative to passing in the "name" parameter to the requests function
-        self.request_name = None
+        self.request_name: Optional[str] = None
 
         # Check for basic authentication
         parsed_url = urlparse(self.base_url)

--- a/locust/test/test_users.py
+++ b/locust/test/test_users.py
@@ -1,6 +1,9 @@
 import unittest
 
-from locust import User
+from urllib3 import PoolManager
+
+from locust import User, HttpUser
+from locust.test.testcases import WebserverTestCase
 
 
 class TestUserClass(unittest.TestCase):
@@ -25,3 +28,42 @@ class TestUserClass(unittest.TestCase):
 
 class MyModuleScopedUser(User):
     pass
+
+
+class TestHttpUserWithWebserver(WebserverTestCase):
+    def test_shared_pool_manager(self):
+        shared_pool_manager = PoolManager(maxsize=1, block=True)
+
+        class MyUserA(HttpUser):
+            host = "http://127.0.0.1:%i" % self.port
+            pool_manager = shared_pool_manager
+
+        class MyUserB(HttpUser):
+            host = "http://127.0.0.1:%i" % self.port
+            pool_manager = shared_pool_manager
+
+        user_a = MyUserA(self.environment)
+        user_b = MyUserB(self.environment)
+
+        user_a.client.get("/ultra_fast")
+        user_b.client.get("/ultra_fast")
+        user_b.client.get("/ultra_fast")
+        user_a.client.get("/ultra_fast")
+
+        self.assertEqual(1, self.connections_count)
+        self.assertEqual(4, self.requests_count)
+
+    def test_pool_manager_per_user_instance(self):
+        class MyUser(HttpUser):
+            host = "http://127.0.0.1:%i" % self.port
+
+        user_a = MyUser(self.environment)
+        user_b = MyUser(self.environment)
+
+        user_a.client.get("/ultra_fast")
+        user_b.client.get("/ultra_fast")
+        user_b.client.get("/ultra_fast")
+        user_a.client.get("/ultra_fast")
+
+        self.assertEqual(2, self.connections_count)
+        self.assertEqual(4, self.requests_count)


### PR DESCRIPTION
This PR adds support for sharing connection pools between users. It is done by exposing lower level pool (`urllib3.PoolManager` for `HttpUser`, `geventhttpclient.client.HTTPClientPool` for `FastHttpUser`).

Example usage:

```python
from geventhttpclient.client import HTTPClientPool
from locust import FastHttpUser, HttpUser
from urllib3 import PoolManager


# Both users will be limited to 10 concurrent connections at most.

class UserA(HttpUser):
    pool_manager = PoolManager(maxsize=10, block=True)


class UserB(FastHttpUser):
    client_pool = HTTPClientPool(concurrency=10)
```

Fixes #1925.

