### PR TITLE
modernized build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,21 +30,19 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Update pip
         run: |
-          pip install -U wheel
-          pip install -U setuptools
           python -m pip install -U pip
       - name: Get pip cache dir
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "::set-output name=dir::$(python -m pip cache dir)"
       - uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}
+          key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.cfg') }}
       - name: set full Python version in PY env var
         # See https://pre-commit.com/#github-actions-example
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - run: pip install tox codecov
-      - run: tox -e ${{ matrix.tox }}
+      - run: python -m pip install tox
+      - run: python -m tox -e ${{ matrix.tox }}
 
   verify_docker_build:
     name: Always - Docker verify, push to tag 'master' if on master
@@ -121,11 +119,10 @@ jobs:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install --upgrade pip build
       - name: Build + set TAG env var for later use
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           echo "TAG=${GITHUB_REF#refs/*/}" | tee -a $GITHUB_ENV
       - name: Publish tagged version to PyPI
         uses: pypa/gh-action-pypi-publish@master
@@ -159,12 +156,11 @@ jobs:
       - name: Install dependencies
         if: ${{ env.NOT_MERGE_COMMIT == '' }}
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install --upgrade pip build
       - name: Build
         if: ${{ env.NOT_MERGE_COMMIT == '' }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Publish prerelease version to PyPI
         if: ${{ env.NOT_MERGE_COMMIT == '' }}
         uses: pypa/gh-action-pypi-publish@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim as base
 
 FROM base as builder
-RUN apt update && apt install -y git 
+RUN apt-get update && apt-get install -y git 
 # there are no wheels for some packages (geventhttpclient?) for arm64/aarch64, so we need some build dependencies there
 RUN if [ -n "$(arch | grep 'arm64\|aarch64')" ]; then apt install -y --no-install-recommends gcc python3-dev; fi
 RUN python -m venv /opt/venv

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1213,7 +1213,7 @@ class TestMasterWorkerRunners(LocustTestCase):
                     0, test_shape.get_current_user_count(), "Shape is not seeing stopped runner user count correctly"
                 )
             self.assertDictEqual(master.reported_user_classes_count, {"FixedUser1": 0, "FixedUser2": 0, "TestUser": 0})
-            sleep(0.5)
+            sleep(1.0)
             self.assertEqual(STATE_STOPPED, master.state)
 
     def test_distributed_shape_with_stop_timeout(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,10 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 120
+
+[tool.setuptools_scm]
+write_to = "locust/_version.py"
+local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ description = Developer friendly load testing framework
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT
-obsoletes-dist = locustio
+obsoletes_dist = locustio
 classifiers =
     Topic :: Software Development :: Testing :: Traffic Generation
     Development Status :: 5 - Production/Stable
@@ -35,6 +35,22 @@ packages = find:
 include_package_data = true
 zip_safe = false
 python_requires = >= 3.6
+install_requires =
+    gevent >=20.12.1
+    flask >=2.0.0
+    Werkzeug >=2.0.0
+    requests >=2.23.0
+    msgpack >=0.6.2
+    pyzmq >=22.2.1
+    geventhttpclient >=1.5.1
+    ConfigArgParse >=1.0
+    psutil >=5.6.7
+    Flask-BasicAuth >=0.2.0
+    Flask-Cors >=3.0.10
+    roundrobin >=0.0.2
+    typing-extensions >=3.7.4.3
+    Jinja2 <3.1.0
+    pywin32;platform_system=='Windows'
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,4 @@
-import ast
-import os
-import re
-import sys
+# kept for compability, https://setuptools.pypa.io/en/latest/setuptools.html?highlight=setuptools.setup()#setup-cfg-only-projects
+import setuptools
 
-from setuptools import find_packages, setup
-
-ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
-
-setup(
-    name="locust",
-    install_requires=[
-        "gevent>=20.12.1",
-        "flask>=2.0.0",
-        "Werkzeug>=2.0.0",
-        "requests>=2.23.0",
-        "msgpack>=0.6.2",
-        "pyzmq>=22.2.1",
-        "geventhttpclient>=1.5.1",
-        "ConfigArgParse>=1.0",
-        "psutil>=5.6.7",
-        "Flask-BasicAuth>=0.2.0",
-        "Flask-Cors>=3.0.10",
-        "roundrobin>=0.0.2",
-        "typing-extensions>=3.7.4.3",
-        "Jinja2<3.1.0",
-    ],
-    test_suite="locust.test",
-    tests_require=[
-        "cryptography",
-        "mock",
-        "pyquery",
-    ],
-    extras_require={
-        ":sys_platform == 'win32'": ["pywin32"],
-    },
-    use_scm_version={
-        "write_to": "locust/_version.py",
-        "local_scheme": "no-local-version",
-    },
-    setup_requires=["setuptools_scm<=6.0.1"],
-)
+setuptools.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skipsdist = True
 envlist =
     flake8
     black
@@ -24,7 +25,8 @@ allowlist_externals =
     timeout
     grep
 commands =
-    coverage run -m unittest discover []
+    python3 -m pip install .
+    python3 -m coverage run -m unittest discover []
     bash -ec 'PYTHONUNBUFFERED=1 timeout 2s python3 examples/debugging.py >out.txt 2>err.txt || true'
     grep -qm 1 '/hello' out.txt
     bash -ec '! grep . err.txt' # should be empty


### PR DESCRIPTION
i mentioned in a previous PR #2040 that there was problems adding locust as a git dependency; pip or pip-tools got confused that there was a `pyproject.toml`, but no `build-system` section available. all it contained was settings for `black`.

there have been other projects having the [same problem](https://snarky.ca/what-the-heck-is-pyproject-toml/).

the underlying problem seems to have been fixed now, so it is indeed possible to have locust as a git dependency (which I realized after implementing this...). but there are probably other benefits of moderizing the build setup to be PEP517 and PEP518 compatible.

since most stuff already was present in `setup.cfg`, it was quite an easy transition to move away from `setup.py`, however editable installs is not yet supported by `pyproject.toml` and hence a bare bone `setup.py` is needed.

most work had to be done in the github workflow and tox settings.

regarding the changes of `command` to `python -m <module>` in `test.yml`:
https://snarky.ca/why-you-should-use-python-m-pip/