### PR TITLE
Ensure `test_start` is run to completion on worker

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1102,15 +1102,6 @@ class WorkerRunner(DistributedRunner):
         """
         self.target_user_classes_count = user_classes_count
         self.target_user_count = sum(user_classes_count.values())
-        if self.worker_state != STATE_RUNNING and self.worker_state != STATE_SPAWNING:
-            self.stats.clear_all()
-            self.exceptions = {}
-            self.cpu_warning_emitted = False
-            self.worker_cpu_warning_emitted = False
-            self.environment._filter_tasks_by_tags()
-            self.environment.events.test_start.fire(environment=self.environment)
-
-        self.worker_state = STATE_SPAWNING
 
         for user_class in self.user_classes:
             if self.environment.host:
@@ -1191,6 +1182,16 @@ class WorkerRunner(DistributedRunner):
                     or k in ["expect_workers", "tags", "exclude_tags"]
                 }
                 vars(self.environment.parsed_options).update(custom_args_from_master)
+
+                if self.worker_state != STATE_RUNNING and self.worker_state != STATE_SPAWNING:
+                    self.stats.clear_all()
+                    self.exceptions = {}
+                    self.cpu_warning_emitted = False
+                    self.worker_cpu_warning_emitted = False
+                    self.environment._filter_tasks_by_tags()
+                    self.environment.events.test_start.fire(environment=self.environment)
+
+                self.worker_state = STATE_SPAWNING
 
                 if self.spawning_greenlet:
                     # kill existing spawning greenlet before we launch new one

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1879,9 +1879,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             test_start_exec_count = 0
 
             @worker_env.events.test_start.add_listener
-            def on_test_start(environment, **kwargs):
-                if not isinstance(environment.runner, runners.WorkerRunner):
-                    return
+            def on_test_start(*_, **__):
                 nonlocal test_start_exec_count
                 test_start_exec_count += 1
                 sleep(3)

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1856,6 +1856,53 @@ class TestMasterWorkerRunners(LocustTestCase):
 
             self.assertTrue(test_start_event_fired[0])
 
+    def test_long_running_test_start_is_run_to_completion_on_worker(self):
+        """Test for https://github.com/locustio/locust/issues/1986"""
+
+        class MyUser1(User):
+            wait_time = constant(0)
+
+            @task
+            def my_task(self):
+                pass
+
+        with mock.patch("locust.runners.WORKER_REPORT_INTERVAL", new=0.3):
+            master_env = Environment(user_classes=[MyUser1])
+            master = master_env.create_master_runner("*", 0)
+
+            sleep(0)
+
+            # start 1 worker runner
+            worker_env = Environment(user_classes=[MyUser1])
+            worker = worker_env.create_worker_runner("127.0.0.1", master.server.port)
+
+            test_start_exec_count = 0
+
+            @worker_env.events.test_start.add_listener
+            def on_test_start(environment, **kwargs):
+                if not isinstance(environment.runner, runners.WorkerRunner):
+                    return
+                nonlocal test_start_exec_count
+                test_start_exec_count += 1
+                sleep(3)
+
+            # give worker time to connect
+            sleep(0.1)
+
+            gevent.spawn(master.start, 3, spawn_rate=1)
+
+            t0 = time.perf_counter()
+            while master.user_count != 3:
+                self.assertLessEqual(time.perf_counter() - t0, 5, "Expected 3 users to be spawned")
+                sleep(0.1)
+
+            master.quit()
+
+            # make sure users are killed
+            self.assertEqual(0, worker.user_count)
+
+            self.assertEqual(test_start_exec_count, 1)
+
 
 class TestMasterRunner(LocustRunnerTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #1986

I tested with the steps indicated in https://github.com/locustio/locust/issues/1986#issue-1116128138 and only a single `'test_start' triggered 1 times.` is printed.

TODO:
- [x] Write a test case