### PR TITLE
Add table linkage, you can see the data of the three tables at the sa…

### DIFF
--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -237,6 +237,7 @@ var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per S
 var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 charts.push(rpsChart, responseTimeChart, usersChart);
+echarts.connect([rpsChart.chart,responseTimeChart.chart,usersChart.chart])
 update_stats_charts()
 
 const markerFlags = {


### PR DESCRIPTION
<!-- 
No questions here please! If you have a question about how to use Locust read the documentation or ask on slack (https://locustio.slack.com)

You can also ask questions on StackOverflow, https://stackoverflow.com/questions/ask just remember to tag your question with "locust".
-->

### Is your feature request related to a problem? Please describe.
<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
During the test, I want to see the corresponding values of the three tables at the same time. Now I can only use the mouse to point to the corresponding table one by one, which is very inconvenient.
### Describe the solution you'd like
<!-- A clear and concise description of what you want to happen -->
I would like to point to any of the tables and see the values in the three graphs at the same time.
### Describe alternatives you've considered
<!-- A clear and concise description of any alternative solutions or features you've considered -->
I saw that the table we used was echart, and I checked the api document for the multi-table linkage display function.
### Additional context
<!-- Add any other context or screenshots about the feature request here -->
I want locust can be like this.
![image](https://user-images.githubusercontent.com/7769918/165502474-c9b4b571-eb83-4f5a-b427-4b0d8982c0ab.png)
