### PR TITLE
FastHttpUser improvements (including a rename of parameter "url" to "path")

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -139,7 +139,7 @@ class FastHttpSession:
     def request(
         self,
         method: str,
-        path: str,
+        url: str,
         name: str = None,
         data: str = None,
         catch_response: bool = False,
@@ -156,7 +156,7 @@ class FastHttpSession:
         Returns :py:class:`locust.contrib.fasthttp.FastResponse` object.
 
         :param method: method for the new :class:`Request` object.
-        :param path: Path that will be concatenated with the base host URL that has been specified.
+        :param url: path that will be concatenated with the base host URL that has been specified.
             Can also be a full URL, in which case the full URL will be requested, and the base host
             is ignored.
         :param name: (optional) An argument that can be specified to use as label in Locust's
@@ -179,7 +179,7 @@ class FastHttpSession:
             content will not be accounted for in the request time that is reported by Locust.
         """
         # prepend url with hostname unless it's already an absolute URL
-        url = self._build_url(path)
+        built_url = self._build_url(url)
 
         start_time = time.time()  # seconds since epoch
 
@@ -207,15 +207,15 @@ class FastHttpSession:
 
         start_perf_counter = time.perf_counter()
         # send request, and catch any exceptions
-        response = self._send_request_safe_mode(method, url, payload=data, headers=headers, **kwargs)
+        response = self._send_request_safe_mode(method, built_url, payload=data, headers=headers, **kwargs)
         request_meta = {
             "request_type": method,
-            "name": name or path,
+            "name": name or url,
             "context": context,
             "response": response,
             "exception": None,
             "start_time": start_time,
-            "url": url,  # this is a small deviation from HttpSession, which gets the final (possibly redirected) URL
+            "url": built_url,  # this is a small deviation from HttpSession, which gets the final (possibly redirected) URL
         }
 
         if not allow_redirects:
@@ -251,32 +251,32 @@ class FastHttpSession:
             self.environment.events.request.fire(**request_meta)
             return response
 
-    def delete(self, path, **kwargs):
-        return self.request("DELETE", path, **kwargs)
+    def delete(self, url, **kwargs):
+        return self.request("DELETE", url, **kwargs)
 
-    def get(self, path, **kwargs):
+    def get(self, url, **kwargs):
         """Sends a GET request"""
-        return self.request("GET", path, **kwargs)
+        return self.request("GET", url, **kwargs)
 
-    def head(self, path, **kwargs):
+    def head(self, url, **kwargs):
         """Sends a HEAD request"""
-        return self.request("HEAD", path, **kwargs)
+        return self.request("HEAD", url, **kwargs)
 
-    def options(self, path, **kwargs):
+    def options(self, url, **kwargs):
         """Sends a OPTIONS request"""
-        return self.request("OPTIONS", path, **kwargs)
+        return self.request("OPTIONS", url, **kwargs)
 
-    def patch(self, path, data=None, **kwargs):
+    def patch(self, url, data=None, **kwargs):
         """Sends a POST request"""
-        return self.request("PATCH", path, data=data, **kwargs)
+        return self.request("PATCH", url, data=data, **kwargs)
 
-    def post(self, path, data=None, **kwargs):
+    def post(self, url, data=None, **kwargs):
         """Sends a POST request"""
-        return self.request("POST", path, data=data, **kwargs)
+        return self.request("POST", url, data=data, **kwargs)
 
-    def put(self, path, data=None, **kwargs):
+    def put(self, url, data=None, **kwargs):
         """Sends a PUT request"""
-        return self.request("PUT", path, data=data, **kwargs)
+        return self.request("PUT", url, data=data, **kwargs)
 
 
 class FastHttpUser(User):

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -366,7 +366,12 @@ class FastResponse(CompatResponse):
 
     request: Optional[FastRequest] = None
 
-    def __init__(self, ghc_response: HTTPSocketPoolResponse, request: Optional[FastRequest] = None, sent_request: Optional[str] = None):
+    def __init__(
+        self,
+        ghc_response: HTTPSocketPoolResponse,
+        request: Optional[FastRequest] = None,
+        sent_request: Optional[str] = None,
+    ):
         super().__init__(ghc_response, request, sent_request)
 
         self.request = request

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -93,6 +93,7 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertEqual(200, r.status_code)
         r = s.get("/get_cookie?name=testcookie")
         self.assertEqual("1337", r.content.decode())
+        self.assertEqual("1337", r.text)
 
     def test_head(self):
         s = self.get_client()
@@ -126,6 +127,8 @@ class TestFastHttpSession(WebserverTestCase):
         s = self.get_client()
         r = s.post("/request_method", json={"foo": "bar"})
         self.assertEqual(200, r.status_code)
+        self.assertEqual(r.request.body, '{"foo": "bar"}')
+        self.assertEqual(r.request.headers.get("Content-Type", None), "application/json")
 
     def test_catch_response_fail_successful_request(self):
         s = self.get_client()

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -25,12 +25,15 @@ class TestFastHttpSession(WebserverTestCase):
 
     def test_connection_error(self):
         s = FastHttpSession(self.environment, "http://localhost:1", user=None)
-        r = s.get("/", timeout=0.1)
+        r = s.get("/", timeout=0.1, headers={"X-Test-Headers": "hello"})
         self.assertEqual(r.status_code, 0)
         self.assertEqual(None, r.content)
         self.assertEqual(1, len(self.runner.stats.errors))
         self.assertTrue(isinstance(r.error, ConnectionRefusedError))
         self.assertTrue(isinstance(next(iter(self.runner.stats.errors.values())).error, ConnectionRefusedError))
+        self.assertEqual(r.url, "http://localhost:1/")
+        self.assertEqual(r.request.url, r.url)
+        self.assertEqual(r.request.headers.get("X-Test-Headers", ""), "hello")
 
     def test_404(self):
         s = self.get_client()
@@ -44,6 +47,8 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertEqual(204, r.status_code)
         self.assertEqual(1, self.runner.stats.get("/status/204", "GET").num_requests)
         self.assertEqual(0, self.runner.stats.get("/status/204", "GET").num_failures)
+        self.assertEqual(r.url, "http://127.0.0.1:%i/status/204" % self.port)
+        self.assertEqual(r.request.url, r.url)
 
     def test_streaming_response(self):
         """
@@ -312,7 +317,10 @@ class TestFastHttpUserClass(WebserverTestCase):
             host = "http://127.0.0.1:%i" % self.port
 
         locust = MyUser(self.environment)
-        self.assertEqual("hello", locust.client.get("/request_header_test", headers={"X-Header-Test": "hello"}).text)
+        r = locust.client.get("/request_header_test", headers={"X-Header-Test": "hello"})
+        self.assertEqual("hello", r.text)
+        self.assertEqual("hello", r.headers.get("X-Header-Test", None))
+        self.assertEqual("hello", r.request.headers.get("X-Header-Test", None))
 
     def test_client_get(self):
         class MyUser(FastHttpUser):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1213,8 +1213,13 @@ class TestMasterWorkerRunners(LocustTestCase):
                     0, test_shape.get_current_user_count(), "Shape is not seeing stopped runner user count correctly"
                 )
             self.assertDictEqual(master.reported_user_classes_count, {"FixedUser1": 0, "FixedUser2": 0, "TestUser": 0})
-            sleep(1.0)
-            self.assertEqual(STATE_STOPPED, master.state)
+
+            try:
+                with gevent.Timeout(3.0):
+                    while master.state != STATE_STOPPED:
+                        sleep(0.1)
+            finally:
+                self.assertEqual(STATE_STOPPED, master.state)
 
     def test_distributed_shape_with_stop_timeout(self):
         """

--- a/locust/test/testcases.py
+++ b/locust/test/testcases.py
@@ -55,7 +55,11 @@ def request_method():
 
 @app.route("/request_header_test")
 def request_header_test():
-    return request.headers["X-Header-Test"]
+    x_header_test = request.headers["X-Header-Test"]
+    response = Response(x_header_test)
+    response.headers["X-Header-Test"] = x_header_test
+
+    return response
 
 
 @app.route("/post", methods=["POST"])


### PR DESCRIPTION
Sorry for the long "intro", which might seem irrelevant at first... but bear with me :)

In "my" project I had a case where I wanted to create a group of [async] requests, by running them in their own `greenlet`.
Normally it uses the `requests` client via `HttpUser`, but the way `requests` is using the `ConnectionPool` from `urllib3` is not thread-safe[0], which caused the requests to run more or less sequential instead.

This lead me to using a `FastHttpSession` for each async request, which worked great for that part. But instead ran into some typing issues, e.g.:

```python
class FastResponse(CompatResponse):
  headers = None
...
```
Since `geventhttpclient` isn't typed, this causes `mypy` to think that `headers` is always `None`, causing it to get type `Never`, making it hard to actually use these attributes without using `type: ignore`-comments.

The other ~problem~ inconvenience I had, was that `locust.contrib.fasthttp.FastResponse` was so different from `requests.models.Response`, causing "my" code that handles the response (for logging purposes) to get a bunch of special cases depending on what type of response it was. I've tried my best to make it easier to use `FastHttpSession` as a drop-in replacement for `HttpSession`.

One thing that I haven't changed, is that `locust.clients.HttpSession.request` has `url` as argument, where as `locust.contrib.fasthttp.FastHttpSession.request` has `path`. I would love to change that... but thought that it might be a too big breaking change(?).

Also, once again I had problems with `test_runners::test_distributed_shape_with_fixed_users`. I increased it in a previous PR from `0.5` to `1.0`, but seems like it sometimes is not enough, so now I changed so `master.status` is polled in a `gevent.Timeout` with 3 seconds, instead of having a static sleep so the test *shouldn't* fail when it sometimes takes a little longer. That check would take at minimum 0.1 seconds and at maximum 3 seconds when it's actually is a problem.

[0] https://github.com/psf/requests/issues/1871