### PR TITLE
print_stats table width fix for #2084

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -528,8 +528,8 @@ class StatsEntry:
             "%-"
             + str(STATS_TYPE_WIDTH)
             + "s %-"
-            + str(STATS_NAME_WIDTH - STATS_TYPE_WIDTH)
-            + "s %7d %12s | %7d %7d %7d %7d | %7.2f %11.2f"
+            + str((STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4)
+            + "s %7d %12s |%7d %7d %7d%7d | %7.2f %11.2f"
         ) % (
             (self.method and self.method + " " or ""),
             self.name,
@@ -729,17 +729,12 @@ def setup_distributed_stats_event_listeners(events, stats):
 
 
 def print_stats(stats, current=True):
+    name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     console_logger.info(
-        (
-            "%-"
-            + str(STATS_TYPE_WIDTH)
-            + "s %-"
-            + str(STATS_NAME_WIDTH - STATS_TYPE_WIDTH)
-            + "s %7s %12s | %7s %7s %7s %7s | %7s %11s"
-        )
-        % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Median", "req/s", "failures/s")
+        ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
+        % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
     )
-    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (STATS_NAME_WIDTH - STATS_TYPE_WIDTH)}|{"-" * 7}|{"-" * 13}|{"-" * 8}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 8}|{"-" * 11}'
+    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
     console_logger.info(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -525,11 +525,11 @@ class StatsEntry:
             rps = self.total_rps
             fail_per_sec = self.total_fail_per_sec
         return (
-            " %-"
+            "%-"
             + str(STATS_TYPE_WIDTH)
             + "s %-"
-            + str(STATS_NAME_WIDTH)
-            + "s %7d %12s  | %7d %7d %7d %7d  | %7.2f %11.2f"
+            + str(STATS_NAME_WIDTH - STATS_TYPE_WIDTH)
+            + "s %7d %12s | %7d %7d %7d %7d | %7.2f %11.2f"
         ) % (
             (self.method and self.method + " " or ""),
             self.name,
@@ -602,7 +602,7 @@ class StatsEntry:
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
 
-        tpl = f" %-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8d {' '.join(['%6d'] * len(PERCENTILES_TO_REPORT))}"
+        tpl = f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8d {' '.join(['%6d'] * len(PERCENTILES_TO_REPORT))}"
 
         return tpl % (
             (self.method or "", self.name)
@@ -730,10 +730,16 @@ def setup_distributed_stats_event_listeners(events, stats):
 
 def print_stats(stats, current=True):
     console_logger.info(
-        (" %-" + str(STATS_TYPE_WIDTH) + "s %-" + str(STATS_NAME_WIDTH) + "s %7s %12s  | %7s %7s %7s %7s  | %7s %11s")
+        (
+            "%-"
+            + str(STATS_TYPE_WIDTH)
+            + "s %-"
+            + str(STATS_NAME_WIDTH - STATS_TYPE_WIDTH)
+            + "s %7s %12s | %7s %7s %7s %7s | %7s %11s"
+        )
         % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Median", "req/s", "failures/s")
     )
-    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{"-" * (13 + 1)}|{"-" * 8}|{"-" * 7}|{"-" * 7}|{"-" * (7 + 2)}|{"-" * 8}|{"-" * 12}|'
+    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (STATS_NAME_WIDTH - STATS_TYPE_WIDTH)}|{"-" * 7}|{"-" * 13}|{"-" * 8}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 8}|{"-" * 11}'
     console_logger.info(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
@@ -748,14 +754,14 @@ def print_percentile_stats(stats):
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
     console_logger.info(
         (
-            f" %-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
+            f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
             f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
         )
         % headers
     )
     separator = (
-        f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 9}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
-    )
+        f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
+    )[:-1]
     console_logger.info(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
@@ -772,11 +778,11 @@ def print_error_report(stats):
     if not len(stats.errors):
         return
     console_logger.info("Error report")
-    console_logger.info(" %-18s %-100s" % ("# occurrences", "Error"))
-    separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}|'
+    console_logger.info("%-18s %-100s" % ("# occurrences", "Error"))
+    separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}'
     console_logger.info(separator)
     for error in stats.errors.values():
-        console_logger.info(" %-18i %-100s" % (error.occurrences, error.to_name()))
+        console_logger.info("%-18i %-100s" % (error.occurrences, error.to_name()))
     console_logger.info(separator)
     console_logger.info("")
 

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -11,7 +11,15 @@ import locust
 from locust import HttpUser, TaskSet, task, User, constant, __version__
 from locust.env import Environment
 from locust.rpc.protocol import Message
-from locust.stats import CachedResponseTimes, RequestStats, StatsEntry, diff_response_time_dicts, PERCENTILES_TO_REPORT
+from locust.stats import (
+    CachedResponseTimes,
+    RequestStats,
+    StatsEntry,
+    diff_response_time_dicts,
+    PERCENTILES_TO_REPORT,
+    STATS_NAME_WIDTH,
+    STATS_TYPE_WIDTH,
+)
 from locust.stats import StatsCSVFileWriter
 from locust.stats import stats_history
 from locust.test.testcases import LocustTestCase
@@ -309,14 +317,26 @@ class TestStatsPrinting(LocustTestCase):
 
         self.stats = RequestStats()
         for i in range(100):
-            self.stats.log_request("GET", "test_entry", i, 2000 + i)
-            if i % 5 == 0:
-                self.stats.log_error("GET", "test_entry", RuntimeError("error"))
+            for method, name, freq in [
+                (
+                    "GET",
+                    "test_entry",
+                    5,
+                ),
+                (
+                    "DELETE",
+                    "test" * int((STATS_NAME_WIDTH - STATS_TYPE_WIDTH) / len("test")),
+                    3,
+                ),
+            ]:
+                self.stats.log_request(method, name, i, 2000 + i)
+                if i % freq == 0:
+                    self.stats.log_error(method, name, RuntimeError(f"{method} error"))
 
     def test_print_percentile_stats(self):
         locust.stats.print_percentile_stats(self.stats)
         info = self.mocked_log.info
-        self.assertEqual(7, len(info))
+        self.assertEqual(8, len(info))
         self.assertEqual("Response time percentiles (approximated)", info[0])
         # check that headline contains same number of column as the value rows
         headlines = info[1].replace("# reqs", "#reqs").split()
@@ -327,12 +347,12 @@ class TestStatsPrinting(LocustTestCase):
     def test_print_stats(self):
         locust.stats.print_stats(self.stats)
         info = self.mocked_log.info
-        self.assertEqual(6, len(info))
+        self.assertEqual(7, len(info))
 
         headlines = info[0].replace("# ", "#").split()
 
-        # check number of columns in separator, which will end with a pipe as well
-        self.assertEqual(len(headlines), len(info[1].split("|")) + 1)
+        # check number of columns in separator
+        self.assertEqual(len(headlines), len(info[1].split("|")) + 2)
         # check entry row
         self.assertEqual(len(headlines), len(info[2].split()))
         # check aggregated row, which is missing value in "type"-column
@@ -343,12 +363,12 @@ class TestStatsPrinting(LocustTestCase):
     def test_print_error_report(self):
         locust.stats.print_error_report(self.stats)
         info = self.mocked_log.info
-        self.assertEqual(6, len(info))
+        self.assertEqual(7, len(info))
         self.assertEqual("Error report", info[0])
 
         headlines = info[1].replace("# ", "#").split()
         # check number of columns in headlines vs table ascii separator
-        self.assertEqual(len(headlines), len(info[2].split("|")) - 1)
+        self.assertEqual(len(headlines), len(info[2].split("|")))
         # table ascii seprators
         self.assertEqual(info[2], info[-2])
 

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -325,7 +325,7 @@ class TestStatsPrinting(LocustTestCase):
                 ),
                 (
                     "DELETE",
-                    "test" * int((STATS_NAME_WIDTH - STATS_TYPE_WIDTH) / len("test")),
+                    "test" * int((STATS_NAME_WIDTH - STATS_TYPE_WIDTH + 4) / len("test")),
                     3,
                 ),
             ]:


### PR DESCRIPTION
the width of the `print_stats` table was increased in a previous PR, which resulted in line wraps in terminal sizes that previously didn't have it (see discussion in #2084).

this PR tries to solve that. in the case of a big terminal window causing  `STATS_NAME_WIDTH` to be at max 80 characters, the table is now 1 character less wide than the original implementation (before #2084), 159 columns vs 158 columns.

this is an comparision of the output of the tables with this PR and the original implementation with a 119 column wide terminal:
![image](https://user-images.githubusercontent.com/815510/166649423-719d7373-9a9b-413d-b17a-03c6a0a94785.png)

the original implementation would allow a request name of maximum 34 characters in the `DELETE` request type case, and 37 characters in the `GET` request type case.

with the new implementation, the maximum request name length, with 119 columns, would always be 32 characters.
