### PR TITLE
Bump Jinja2 requirements to >=3.1.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     Flask-Cors >=3.0.10
     roundrobin >=0.0.2
     typing-extensions >=3.7.4.3
-    Jinja2 <3.1.0
+    Jinja2 >=3.1.2
     pywin32;platform_system=='Windows'
 
 [options.packages.find]


### PR DESCRIPTION
The current requirements of Jinja2 <3.1.0 breaks the template used in `locust/template/index.html`, specifically on this kind of conditions:
```
{% if not ((value is none) or (value is boolean)) %}
```

The `boolean` test has only been added to Jinja2 starting 3.1.2 (cf [commit introducing new test](https://github.com/pallets/jinja/commit/9bd3cb22c13b7c52550134f3ce7642a9f363fa05))

This PR should also close https://github.com/locustio/locust/issues/2087