### PR TITLE
dispatch: rebalance users with a fixed count

### DIFF
--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -221,6 +221,14 @@ class UsersDispatcher(Iterator):
         we started from 0 user. So, if we were currently running 500 users, then the `_distribute_users` will
         perform a fake ramp-up without any waiting and return the final distribution.
         """
+        # Reset users before recalculating since the current users is used to calculate how many
+        # fixed users to add.
+        self._users_on_workers = {
+            worker_node.id: {user_class.__name__: 0 for user_class in self._user_classes}
+            for worker_node in self._worker_nodes
+        }
+        self._try_dispatch_fixed = True
+
         users_on_workers, user_gen, worker_gen, active_users = self._distribute_users(self._current_user_count)
 
         self._users_on_workers = users_on_workers


### PR DESCRIPTION
Fixes https://github.com/locustio/locust/issues/2091

* Resets the user worker count before rebalancing since `_user_gen` compares the expected number of fixed count users with the users in `self._users_on_workers`
* Sets `self._try_dispatch_fixed = True` to include fixed users in the rebalance
* Extends `TestAddWorker` and `TestRemoveWorker` to add a test for fixed count (which both fail without this commit) - these just copy `test_remove_worker_during_ramp_up` and `test_add_worker_during_ramp_up` with a fixed user