### PR TITLE
Added explicit type check for headers in fasthttp.py

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -187,6 +187,8 @@ class FastHttpSession:
             context = {**self.user.context(), **context}
 
         headers = headers or {}
+        if type(headers) is not dict:
+            print("headers is assumed to be a dictionary. You tried to use a: %s instead. That won't work (sorry about that)." % type(headers))
         if auth:
             headers["Authorization"] = _construct_basic_auth_str(auth[0], auth[1])
         elif self.auth_header:

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -187,8 +187,7 @@ class FastHttpSession:
             context = {**self.user.context(), **context}
 
         headers = headers or {}
-        if type(headers) is not dict:
-            print("headers is assumed to be a dictionary. You tried to use a: %s instead. That won't work (sorry about that)." % type(headers))
+        assert(type(headers) is dict), "headers is assumed to be a dictionary. You tried to use a: %s instead. That won't work (sorry about that)." % type(headers)
         if auth:
             headers["Authorization"] = _construct_basic_auth_str(auth[0], auth[1])
         elif self.auth_header:


### PR DESCRIPTION
I accidentally tried to use supply a set instead of a dictionary and it took me way longer than it should have to figure out what was wrong. These two lines of code in locust would have gone a long way to help me out.