### PR TITLE
additional typing improvements

### DIFF
--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -49,7 +49,7 @@ class UsersDispatcher(Iterator):
             from 10 to 100.
     """
 
-    def __init__(self, worker_nodes: "List[WorkerNode]", user_classes: List[Type[User]]):
+    def __init__(self, worker_nodes: List["WorkerNode"], user_classes: List[Type[User]]):
         """
         :param worker_nodes: List of worker nodes
         :param user_classes: The user classes
@@ -397,7 +397,7 @@ class UsersDispatcher(Iterator):
                 current_fixed_users_count = {u: self._get_user_current_count(u) for u in fixed_users}
                 spawned_classes: Set[str] = set()
                 while len(spawned_classes) != len(fixed_users):
-                    user_name = next(cycle_fixed_gen)
+                    user_name: Optional[str] = next(cycle_fixed_gen)
                     if not user_name:
                         break
 

--- a/locust/env.py
+++ b/locust/env.py
@@ -17,7 +17,7 @@ from .stats import RequestStats, StatsCSV
 from .runners import Runner, LocalRunner, MasterRunner, WorkerRunner
 from .web import WebUI
 from .user import User
-from .user.task import filter_tasks_by_tags, TaskSet
+from .user.task import filter_tasks_by_tags, TaskSet, TaskHolder
 from .shape import LoadTestShape
 
 
@@ -246,7 +246,7 @@ class Environment:
             tasks_frontier = u.tasks
             while len(tasks_frontier) != 0:
                 t = tasks_frontier.pop()
-                if not callable(t) and hasattr(t, "tasks") and t.tasks:
+                if isinstance(t, TaskHolder):
                     tasks_frontier.extend(t.tasks)
                 elif callable(t):
                     if t not in user_tasks:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -22,16 +22,20 @@ from typing import (
     List,
     NoReturn,
     ValuesView,
-    TypedDict,
     Set,
     Optional,
     Tuple,
     Type,
     Any,
-    Protocol,
     cast,
 )
 from uuid import uuid4
+
+# @TODO: typing.Protocol is in python >= 3.8
+try:
+    from typing import Protocol, TypedDict
+except ImportError:
+    from typing_extensions import Protocol, TypedDict  # type: ignore
 
 import gevent
 import greenlet

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -20,14 +20,19 @@ from typing import (
     Tuple,
     List,
     Union,
-    TypedDict,
     Optional,
     OrderedDict as OrderedDictType,
     Callable,
     TypeVar,
-    Protocol,
     cast,
 )
+
+# @TODO: typing.Protocol is in python >= 3.8
+try:
+    from typing import Protocol, TypedDict
+except ImportError:
+    from typing_extensions import Protocol, TypedDict  # type: ignore
+
 from types import FrameType
 
 from .exception import CatchResponseError

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+from tempfile import NamedTemporaryFile
 import time
 from collections import namedtuple, OrderedDict
 from copy import copy
@@ -8,13 +9,39 @@ import os
 import csv
 import signal
 import gevent
-from typing import Dict, Tuple
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    NoReturn,
+    Tuple,
+    List,
+    Union,
+    TypedDict,
+    Optional,
+    OrderedDict as OrderedDictType,
+    Callable,
+    TypeVar,
+    cast,
+)
+from types import FrameType
 
 from .exception import CatchResponseError
+from .event import Events
 
 import logging
 
+with NamedTemporaryFile(mode="w") as t:
+    CSVWriter = type(csv.writer(t))
+
+if TYPE_CHECKING:
+    from .runners import Runner
+    from .env import Environment
+
 console_logger = logging.getLogger("locust.stats_logger")
+
+S = TypeVar("S", bound="StatsBase")
 
 """Space in table for request name. Auto shrink it if terminal is small (<160 characters)"""
 try:
@@ -25,7 +52,38 @@ except OSError:  # not a real terminal
 STATS_AUTORESIZE = True  # overwrite this if you dont want auto resize while running
 
 
-def resize_handler(signum, frame):
+class StatsBaseDict(TypedDict):
+    name: str
+    method: str
+
+
+class StatsEntryDict(StatsBaseDict):
+    last_request_timestamp: Optional[float]
+    start_time: float
+    num_requests: int
+    num_none_requests: int
+    num_failures: int
+    total_response_time: int
+    max_response_time: int
+    min_response_time: Optional[int]
+    total_content_length: int
+    response_times: Dict[int, int]
+    num_reqs_per_sec: Dict[int, int]
+    num_fail_per_sec: Dict[int, int]
+
+
+class StatsErrorDict(StatsBaseDict):
+    error: str
+    occurrences: int
+
+
+class StatsBase:
+    def __init__(self, name: str, method: str) -> None:
+        self.name = name
+        self.method = method
+
+
+def resize_handler(signum: int, frame: Optional[FrameType]):
     global STATS_NAME_WIDTH
     if STATS_AUTORESIZE:
         try:
@@ -68,7 +126,7 @@ class RequestStatsAdditionError(Exception):
     pass
 
 
-def get_readable_percentiles(percentile_list):
+def get_readable_percentiles(percentile_list: List[float]) -> List[str]:
     """
     Converts a list of percentiles from 0-1 fraction to 0%-100% view for using in console & csv reporting
     :param percentile_list: The list of percentiles in range 0-1
@@ -80,7 +138,7 @@ def get_readable_percentiles(percentile_list):
     ]
 
 
-def calculate_response_time_percentile(response_times, num_requests, percent):
+def calculate_response_time_percentile(response_times: Dict[int, int], num_requests: int, percent: float) -> int:
     """
     Get the response time that a certain number of percent of the requests
     finished within. Arguments:
@@ -101,7 +159,7 @@ def calculate_response_time_percentile(response_times, num_requests, percent):
     return 0
 
 
-def diff_response_time_dicts(latest, old):
+def diff_response_time_dicts(latest: Dict[int, int], old: Dict[int, int]) -> Dict[int, int]:
     """
     Returns the delta between two {response_times:request_count} dicts.
 
@@ -155,11 +213,11 @@ class RequestStats:
     def start_time(self):
         return self.total.start_time
 
-    def log_request(self, method, name, response_time, content_length):
+    def log_request(self, method: str, name: str, response_time: int, content_length: int) -> None:
         self.total.log(response_time, content_length)
         self.get(name, method).log(response_time, content_length)
 
-    def log_error(self, method, name, error):
+    def log_error(self, method: str, name: str, error: Optional[Union[Exception, str]]) -> None:
         self.total.log_error(error)
         self.get(name, method).log_error(error)
 
@@ -171,7 +229,7 @@ class RequestStats:
             self.errors[key] = entry
         entry.occurred()
 
-    def get(self, name, method):
+    def get(self, name: str, method: str) -> "StatsEntry":
         """
         Retrieve a StatsEntry instance by name and method
         """
@@ -181,7 +239,7 @@ class RequestStats:
             self.entries[(name, method)] = entry
         return entry
 
-    def reset_all(self):
+    def reset_all(self) -> None:
         """
         Go through all stats entries and reset them to zero
         """
@@ -191,32 +249,33 @@ class RequestStats:
             r.reset()
         self.history = []
 
-    def clear_all(self):
+    def clear_all(self) -> None:
         """
         Remove all stats entries and errors
         """
-        self.total = StatsEntry(self, "Aggregated", None, use_response_times_cache=self.use_response_times_cache)
+        self.total = StatsEntry(self, "Aggregated", "", use_response_times_cache=self.use_response_times_cache)
         self.entries = {}
         self.errors = {}
         self.history = []
 
-    def serialize_stats(self):
+    def serialize_stats(self) -> List["StatsEntryDict"]:
         return [
             self.entries[key].get_stripped_report()
             for key in self.entries.keys()
             if not (self.entries[key].num_requests == 0 and self.entries[key].num_failures == 0)
         ]
 
-    def serialize_errors(self):
+    def serialize_errors(self) -> Dict[str, "StatsErrorDict"]:
         return {k: e.to_dict() for k, e in self.errors.items()}
 
 
-class StatsEntry:
+class StatsEntry(StatsBase):
     """
     Represents a single stats entry (name and method)
     """
 
-    def __init__(self, stats: RequestStats, name: str, method: str, use_response_times_cache=False):
+    def __init__(self, stats: Optional[RequestStats], name: str, method: str, use_response_times_cache: bool = False):
+        super().__init__(name, method)
         self.stats = stats
         self.name = name
         """ Name (URL) of this stats entry """
@@ -229,17 +288,17 @@ class StatsEntry:
         We can use this dict to calculate the *current*  median response time, as well as other response
         time percentiles.
         """
-        self.num_requests = 0
+        self.num_requests: int = 0
         """ The number of requests made """
-        self.num_none_requests = 0
+        self.num_none_requests: int = 0
         """ The number of requests made with a None response time (typically async requests) """
-        self.num_failures = 0
+        self.num_failures: int = 0
         """ Number of failed request """
-        self.total_response_time = 0
+        self.total_response_time: int = 0
         """ Total sum of the response times """
-        self.min_response_time = None
+        self.min_response_time: Optional[int] = None
         """ Minimum response time """
-        self.max_response_time = 0
+        self.max_response_time: int = 0
         """ Maximum response time """
         self.num_reqs_per_sec: Dict[int, int] = {}
         """ A {second => request_count} dict that holds the number of requests made per second """
@@ -255,16 +314,16 @@ class StatsEntry:
 
         This dict is used to calculate the median and percentile response times.
         """
-        self.response_times_cache = None
+        self.response_times_cache: OrderedDictType[int, CachedResponseTimes]
         """
         If use_response_times_cache is set to True, this will be a {timestamp => CachedResponseTimes()}
         OrderedDict that holds a copy of the response_times dict for each of the last 20 seconds.
         """
-        self.total_content_length = 0
+        self.total_content_length: int = 0
         """ The sum of the content length of all the requests for this entry """
-        self.start_time = 0.0
+        self.start_time: float = 0.0
         """ Time of the first request for this entry """
-        self.last_request_timestamp = None
+        self.last_request_timestamp: Optional[float] = None
         """ Time of the last request for this entry """
         self.reset()
 
@@ -285,7 +344,7 @@ class StatsEntry:
             self.response_times_cache = OrderedDict()
             self._cache_response_times(int(time.time()))
 
-    def log(self, response_time, content_length):
+    def log(self, response_time: int, content_length: int) -> None:
         # get the time
         current_time = time.time()
         t = int(current_time)
@@ -301,12 +360,12 @@ class StatsEntry:
         # increase total content-length
         self.total_content_length += content_length
 
-    def _log_time_of_request(self, current_time):
+    def _log_time_of_request(self, current_time: float) -> None:
         t = int(current_time)
         self.num_reqs_per_sec[t] = self.num_reqs_per_sec.setdefault(t, 0) + 1
         self.last_request_timestamp = current_time
 
-    def _log_response_time(self, response_time):
+    def _log_response_time(self, response_time: int) -> None:
         if response_time is None:
             self.num_none_requests += 1
             return
@@ -335,13 +394,13 @@ class StatsEntry:
         self.response_times.setdefault(rounded_response_time, 0)
         self.response_times[rounded_response_time] += 1
 
-    def log_error(self, error):
+    def log_error(self, error: Optional[Union[Exception, str]]) -> None:
         self.num_failures += 1
         t = int(time.time())
         self.num_fail_per_sec[t] = self.num_fail_per_sec.setdefault(t, 0) + 1
 
     @property
-    def fail_ratio(self):
+    def fail_ratio(self) -> float:
         try:
             return float(self.num_failures) / self.num_requests
         except ZeroDivisionError:
@@ -351,14 +410,14 @@ class StatsEntry:
                 return 0.0
 
     @property
-    def avg_response_time(self):
+    def avg_response_time(self) -> float:
         try:
             return float(self.total_response_time) / (self.num_requests - self.num_none_requests)
         except ZeroDivisionError:
-            return 0
+            return 0.0
 
     @property
-    def median_response_time(self):
+    def median_response_time(self) -> int:
         if not self.response_times:
             return 0
         median = median_from_dict(self.num_requests - self.num_none_requests, self.response_times) or 0
@@ -369,18 +428,18 @@ class StatsEntry:
         # have one (or very few) really slow requests
         if median > self.max_response_time:
             median = self.max_response_time
-        elif median < self.min_response_time:
+        elif self.min_response_time is not None and median < self.min_response_time:
             median = self.min_response_time
 
         return median
 
     @property
-    def current_rps(self):
-        if self.stats.last_request_timestamp is None:
+    def current_rps(self) -> float:
+        if self.stats is None or self.stats.last_request_timestamp is None:
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
-        reqs = [
+        reqs: List[Union[int, float]] = [
             self.num_reqs_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp) - 2)
         ]
         return avg(reqs)
@@ -421,7 +480,7 @@ class StatsEntry:
         except ZeroDivisionError:
             return 0
 
-    def extend(self, other):
+    def extend(self, other: "StatsEntry") -> None:
         """
         Extend the data from the current StatsEntry with the stats from another
         StatsEntry instance.
@@ -461,49 +520,27 @@ class StatsEntry:
             # lag behind a second or two, but since StatsEntry.current_response_time_percentile()
             # (which is what the response times cache is used for) uses an approximation of the
             # last 10 seconds anyway, it should be fine to ignore this.
-            last_time = self.last_request_timestamp and int(self.last_request_timestamp) or None
+            last_time = int(self.last_request_timestamp) if self.last_request_timestamp else None
             if last_time and last_time > (old_last_request_timestamp and int(old_last_request_timestamp) or 0):
                 self._cache_response_times(last_time)
 
-    def serialize(self):
-        return {
-            "name": self.name,
-            "method": self.method,
-            "last_request_timestamp": self.last_request_timestamp,
-            "start_time": self.start_time,
-            "num_requests": self.num_requests,
-            "num_none_requests": self.num_none_requests,
-            "num_failures": self.num_failures,
-            "total_response_time": self.total_response_time,
-            "max_response_time": self.max_response_time,
-            "min_response_time": self.min_response_time,
-            "total_content_length": self.total_content_length,
-            "response_times": self.response_times,
-            "num_reqs_per_sec": self.num_reqs_per_sec,
-            "num_fail_per_sec": self.num_fail_per_sec,
-        }
+    def serialize(self) -> StatsEntryDict:
+        return cast(StatsEntryDict, {key: getattr(self, key, None) for key in StatsEntryDict.__annotations__.keys()})
 
     @classmethod
-    def unserialize(cls, data):
+    def unserialize(cls, data: StatsEntryDict) -> "StatsEntry":
+        """Return the unserialzed version of the specified dict"""
         obj = cls(None, data["name"], data["method"])
-        for key in [
-            "last_request_timestamp",
-            "start_time",
-            "num_requests",
-            "num_none_requests",
-            "num_failures",
-            "total_response_time",
-            "max_response_time",
-            "min_response_time",
-            "total_content_length",
-            "response_times",
-            "num_reqs_per_sec",
-            "num_fail_per_sec",
-        ]:
-            setattr(obj, key, data[key])
+        valid_keys = StatsEntryDict.__annotations__.keys()
+
+        for key, value in data.items():
+            if key in ["name", "method"] or key not in valid_keys:
+                continue
+
+            setattr(obj, key, value)
         return obj
 
-    def get_stripped_report(self):
+    def get_stripped_report(self) -> StatsEntryDict:
         """
         Return the serialized version of this StatsEntry, and then clear the current stats.
         """
@@ -511,7 +548,7 @@ class StatsEntry:
         self.reset()
         return report
 
-    def to_string(self, current=True):
+    def to_string(self, current=True) -> str:
         """
         Return the stats as a string suitable for console output. If current is True, it'll show
         the RPS and failure rate for the last 10 seconds. If it's false, it'll show the total stats
@@ -542,10 +579,10 @@ class StatsEntry:
             fail_per_sec or 0,
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.to_string(current=True)
 
-    def get_response_time_percentile(self, percent):
+    def get_response_time_percentile(self, percent: float) -> int:
         """
         Get the response time that a certain number of percent of the requests
         finished within.
@@ -554,7 +591,7 @@ class StatsEntry:
         """
         return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
 
-    def get_current_response_time_percentile(self, percent):
+    def get_current_response_time_percentile(self, percent: float) -> Optional[int]:
         """
         Calculate the *current* response time for a certain percentile. We use a sliding
         window of (approximately) the last 10 seconds (specified by CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
@@ -572,13 +609,13 @@ class StatsEntry:
         # when trying to fetch the cached response_times. We construct this list in such a way
         # that it's ordered by preference by starting to add t-10, then t-11, t-9, t-12, t-8,
         # and so on
-        acceptable_timestamps = []
+        acceptable_timestamps: List[int] = []
         acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
         for i in range(1, 9):
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW - i)
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + i)
 
-        cached = None
+        cached: Optional[CachedResponseTimes] = None
         for ts in acceptable_timestamps:
             if ts in self.response_times_cache:
                 cached = self.response_times_cache[ts]
@@ -597,7 +634,7 @@ class StatsEntry:
         # if time was not in response times cache window
         return None
 
-    def percentile(self):
+    def percentile(self) -> str:
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
 
@@ -609,7 +646,7 @@ class StatsEntry:
             + (self.num_requests,)
         )
 
-    def _cache_response_times(self, t):
+    def _cache_response_times(self, t: int) -> None:
         self.response_times_cache[t] = CachedResponseTimes(
             response_times=copy(self.response_times),
             num_requests=self.num_requests,
@@ -623,19 +660,20 @@ class StatsEntry:
 
         if len(self.response_times_cache) > cache_size:
             # only keep the latest 20 response_times dicts
-            for i in range(len(self.response_times_cache) - cache_size):
+            for _ in range(len(self.response_times_cache) - cache_size):
                 self.response_times_cache.popitem(last=False)
 
 
-class StatsError:
-    def __init__(self, method, name, error, occurrences=0):
+class StatsError(StatsBase):
+    def __init__(self, method: str, name: str, error: Optional[Union[Exception, str]], occurrences: int = 0):
+        super().__init__(name, method)
         self.method = method
         self.name = name
         self.error = error
         self.occurrences = occurrences
 
     @classmethod
-    def parse_error(cls, error):
+    def parse_error(cls, error: Optional[Union[Exception, str]]) -> str:
         string_error = repr(error)
         target = "object at 0x"
         target_index = string_error.find(target)
@@ -649,14 +687,14 @@ class StatsError:
         return string_error.replace(hex_address, "0x....")
 
     @classmethod
-    def create_key(cls, method, name, error):
+    def create_key(cls, method: str, name: str, error: Optional[Union[Exception, str]]) -> str:
         key = f"{method}.{name}.{StatsError.parse_error(error)!r}"
         return hashlib.md5(key.encode("utf-8")).hexdigest()
 
-    def occurred(self):
+    def occurred(self) -> None:
         self.occurrences += 1
 
-    def to_name(self):
+    def to_name(self) -> str:
         error = self.error
         if isinstance(error, CatchResponseError):
             # standalone
@@ -671,24 +709,19 @@ class StatsError:
 
         return f"{self.method} {self.name}: {unwrapped_error}"
 
-    def to_dict(self):
-        return {
-            "method": self.method,
-            "name": self.name,
-            "error": StatsError.parse_error(self.error),
-            "occurrences": self.occurrences,
-        }
+    def to_dict(self) -> StatsErrorDict:
+        return cast(StatsErrorDict, {key: getattr(self, key, None) for key in StatsErrorDict.__annotations__.keys()})
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: StatsErrorDict) -> "StatsError":
         return cls(data["method"], data["name"], data["error"], data["occurrences"])
 
 
-def avg(values):
+def avg(values: List[Union[float, int]]) -> float:
     return sum(values, 0.0) / max(len(values), 1)
 
 
-def median_from_dict(total, count):
+def median_from_dict(total: int, count: Dict[int, int]) -> int:
     """
     total is the number of requests made
     count is a dict {response_time: count}
@@ -699,15 +732,17 @@ def median_from_dict(total, count):
             return k
         pos -= count[k]
 
+    return k
 
-def setup_distributed_stats_event_listeners(events, stats):
-    def on_report_to_master(client_id, data):
+
+def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats) -> None:
+    def on_report_to_master(client_id: str, data: Dict[str, Any]) -> None:
         data["stats"] = stats.serialize_stats()
         data["stats_total"] = stats.total.get_stripped_report()
         data["errors"] = stats.serialize_errors()
         stats.errors = {}
 
-    def on_worker_report(client_id, data):
+    def on_worker_report(client_id: str, data: Dict[str, Any]) -> None:
         for stats_data in data["stats"]:
             entry = StatsEntry.unserialize(stats_data)
             request_key = (entry.name, entry.method)
@@ -727,7 +762,7 @@ def setup_distributed_stats_event_listeners(events, stats):
     events.worker_report.add_listener(on_worker_report)
 
 
-def print_stats(stats, current=True):
+def print_stats(stats: RequestStats, current=True) -> None:
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     console_logger.info(
         ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
@@ -743,7 +778,7 @@ def print_stats(stats, current=True):
     console_logger.info("")
 
 
-def print_percentile_stats(stats):
+def print_percentile_stats(stats: RequestStats) -> None:
     console_logger.info("Response time percentiles (approximated)")
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
     console_logger.info(
@@ -768,7 +803,7 @@ def print_percentile_stats(stats):
     console_logger.info("")
 
 
-def print_error_report(stats):
+def print_error_report(stats: RequestStats) -> None:
     if not len(stats.errors):
         return
     console_logger.info("Error report")
@@ -781,8 +816,8 @@ def print_error_report(stats):
     console_logger.info("")
 
 
-def stats_printer(stats):
-    def stats_printer_func():
+def stats_printer(stats: RequestStats) -> Callable[[], None]:
+    def stats_printer_func() -> None:
         while True:
             print_stats(stats)
             gevent.sleep(CONSOLE_STATS_INTERVAL_SEC)
@@ -790,11 +825,11 @@ def stats_printer(stats):
     return stats_printer_func
 
 
-def sort_stats(stats):
+def sort_stats(stats: Dict[Any, S]) -> List[S]:
     return [stats[key] for key in sorted(stats.keys())]
 
 
-def stats_history(runner):
+def stats_history(runner: "Runner") -> None:
     """Save current stats info to history for charts of report."""
     while True:
         stats = runner.stats
@@ -816,8 +851,7 @@ def stats_history(runner):
 class StatsCSV:
     """Write statistics to csv_writer stream."""
 
-    def __init__(self, environment, percentiles_to_report):
-        super().__init__()
+    def __init__(self, environment: "Environment", percentiles_to_report: List[float]) -> None:
         self.environment = environment
         self.percentiles_to_report = percentiles_to_report
 
@@ -851,7 +885,7 @@ class StatsCSV:
             "Nodes",
         ]
 
-    def _percentile_fields(self, stats_entry, use_current=False):
+    def _percentile_fields(self, stats_entry: StatsEntry, use_current: bool = False) -> Union[List[str], List[int]]:
         if not stats_entry.num_requests:
             return self.percentiles_na
         elif use_current:
@@ -859,12 +893,12 @@ class StatsCSV:
         else:
             return [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
 
-    def requests_csv(self, csv_writer):
+    def requests_csv(self, csv_writer: CSVWriter) -> None:
         """Write requests csv with header and data rows."""
         csv_writer.writerow(self.requests_csv_columns)
         self._requests_data_rows(csv_writer)
 
-    def _requests_data_rows(self, csv_writer):
+    def _requests_data_rows(self, csv_writer: CSVWriter) -> None:
         """Write requests csv data row, excluding header."""
         stats = self.environment.stats
         for stats_entry in chain(sort_stats(stats.entries), [stats.total]):
@@ -887,11 +921,11 @@ class StatsCSV:
                 )
             )
 
-    def failures_csv(self, csv_writer):
+    def failures_csv(self, csv_writer: CSVWriter) -> None:
         csv_writer.writerow(self.failures_columns)
         self._failures_data_rows(csv_writer)
 
-    def _failures_data_rows(self, csv_writer):
+    def _failures_data_rows(self, csv_writer: CSVWriter) -> None:
         for stats_error in sort_stats(self.environment.stats.errors):
             csv_writer.writerow(
                 [
@@ -902,11 +936,14 @@ class StatsCSV:
                 ]
             )
 
-    def exceptions_csv(self, csv_writer):
+    def exceptions_csv(self, csv_writer: CSVWriter) -> None:
         csv_writer.writerow(self.exceptions_columns)
         self._exceptions_data_rows(csv_writer)
 
-    def _exceptions_data_rows(self, csv_writer):
+    def _exceptions_data_rows(self, csv_writer: CSVWriter) -> None:
+        if self.environment.runner is None:
+            return
+
         for exc in self.environment.runner.exceptions.values():
             csv_writer.writerow([exc["count"], exc["msg"], exc["traceback"], ", ".join(exc["nodes"])])
 
@@ -914,7 +951,13 @@ class StatsCSV:
 class StatsCSVFileWriter(StatsCSV):
     """Write statistics to to CSV files"""
 
-    def __init__(self, environment, percentiles_to_report, base_filepath, full_history=False):
+    def __init__(
+        self,
+        environment: "Environment",
+        percentiles_to_report: List[float],
+        base_filepath: str,
+        full_history: bool = False,
+    ):
         super().__init__(environment, percentiles_to_report)
         self.base_filepath = base_filepath
         self.full_history = full_history
@@ -927,11 +970,11 @@ class StatsCSVFileWriter(StatsCSV):
 
         self.failures_csv_filehandle = open(self.base_filepath + "_failures.csv", "w")
         self.failures_csv_writer = csv.writer(self.failures_csv_filehandle)
-        self.failures_csv_data_start = 0
+        self.failures_csv_data_start: int = 0
 
         self.exceptions_csv_filehandle = open(self.base_filepath + "_exceptions.csv", "w")
         self.exceptions_csv_writer = csv.writer(self.exceptions_csv_filehandle)
-        self.exceptions_csv_data_start = 0
+        self.exceptions_csv_data_start: int = 0
 
         self.stats_history_csv_columns = [
             "Timestamp",
@@ -950,10 +993,10 @@ class StatsCSVFileWriter(StatsCSV):
             "Total Average Content Size",
         ]
 
-    def __call__(self):
+    def __call__(self) -> None:
         self.stats_writer()
 
-    def stats_writer(self):
+    def stats_writer(self) -> NoReturn:
         """Writes all the csv files for the locust run."""
 
         # Write header row for all files and save position for non-append files
@@ -969,7 +1012,7 @@ class StatsCSVFileWriter(StatsCSV):
         self.exceptions_csv_data_start = self.exceptions_csv_filehandle.tell()
 
         # Continuously write date rows for all files
-        last_flush_time = 0
+        last_flush_time: float = 0.0
         while True:
             now = time.time()
 
@@ -996,7 +1039,7 @@ class StatsCSVFileWriter(StatsCSV):
 
             gevent.sleep(CSV_STATS_INTERVAL_SEC)
 
-    def _stats_history_data_rows(self, csv_writer, now):
+    def _stats_history_data_rows(self, csv_writer: CSVWriter, now: float) -> None:
         """
         Write CSV rows with the *current* stats. By default only includes the
         Aggregated stats entry, but if self.full_history is set to True, a row for each entry will
@@ -1007,7 +1050,7 @@ class StatsCSVFileWriter(StatsCSV):
 
         stats = self.environment.stats
         timestamp = int(now)
-        stats_entries = []
+        stats_entries: List[StatsEntry] = []
         if self.full_history:
             stats_entries = sort_stats(stats.entries)
 
@@ -1016,7 +1059,7 @@ class StatsCSVFileWriter(StatsCSV):
                 chain(
                     (
                         timestamp,
-                        self.environment.runner.user_count,
+                        self.environment.runner.user_count if self.environment.runner is not None else 0,
                         stats_entry.method or "",
                         stats_entry.name,
                         f"{stats_entry.current_rps:2f}",
@@ -1035,23 +1078,23 @@ class StatsCSVFileWriter(StatsCSV):
                 )
             )
 
-    def requests_flush(self):
+    def requests_flush(self) -> None:
         self.requests_csv_filehandle.flush()
 
-    def stats_history_flush(self):
+    def stats_history_flush(self) -> None:
         self.stats_history_csv_filehandle.flush()
 
-    def failures_flush(self):
+    def failures_flush(self) -> None:
         self.failures_csv_filehandle.flush()
 
-    def exceptions_flush(self):
+    def exceptions_flush(self) -> None:
         self.exceptions_csv_filehandle.flush()
 
-    def close_files(self):
+    def close_files(self) -> None:
         self.requests_csv_filehandle.close()
         self.stats_history_csv_filehandle.close()
         self.failures_csv_filehandle.close()
         self.exceptions_csv_filehandle.close()
 
-    def stats_history_file_name(self):
+    def stats_history_file_name(self) -> str:
         return self.base_filepath + "_stats_history.csv"

--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
 import inspect
 from json import dumps
+from typing import List, Type, Dict
 
 from .task import TaskSet
+from .users import User
 
 
 def print_task_ratio(user_classes, num_users, total):
@@ -47,11 +49,11 @@ def _print_task_ratio(x, level=0):
             _print_task_ratio(v["tasks"], level + 1)
 
 
-def get_ratio(user_classes, user_spawned, total):
+def get_ratio(user_classes: List[Type[User]], user_spawned: Dict[str, int], total: bool) -> Dict[str, Dict[str, float]]:
     user_count = sum(user_spawned.values()) or 1
-    ratio_percent = {u: user_spawned.get(u.__name__, 0) / user_count for u in user_classes}
+    ratio_percent: Dict[Type[User], float] = {u: user_spawned.get(u.__name__, 0) / user_count for u in user_classes}
 
-    task_dict = {}
+    task_dict: Dict[str, Dict[str, float]] = {}
     for u, r in ratio_percent.items():
         d = {"ratio": r}
         d["tasks"] = _get_task_ratio(u.tasks, total, r)

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -2,7 +2,7 @@ import logging
 import random
 import traceback
 from time import time
-from typing import TYPE_CHECKING, Callable, List, Union, TypeVar, Optional, Type, overload
+from typing import TYPE_CHECKING, Callable, List, Union, TypeVar, Optional, Type, overload, Protocol, Dict, Set
 from typing_extensions import final
 
 import gevent
@@ -15,9 +15,13 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-TaskT = TypeVar("TaskT", bound=Union[Callable[..., None], Type["TaskSet"]])
+TaskT = TypeVar("TaskT", Callable[..., None], Type["TaskSet"])
 
 LOCUST_STATE_RUNNING, LOCUST_STATE_WAITING, LOCUST_STATE_STOPPING = ["running", "waiting", "stopping"]
+
+
+class TaskHolder(Protocol[TaskT]):
+    tasks: List[TaskT]
 
 
 @overload
@@ -152,7 +156,12 @@ def get_tasks_from_base_classes(bases, class_dict):
     return new_tasks
 
 
-def filter_tasks_by_tags(task_holder, tags=None, exclude_tags=None, checked=None):
+def filter_tasks_by_tags(
+    task_holder: Type[TaskHolder],
+    tags: Optional[Set[str]] = None,
+    exclude_tags: Optional[Set[str]] = None,
+    checked: Optional[Dict[TaskT, bool]] = None,
+):
     """
     Function used by Environment to recursively remove any tasks/TaskSets from a TaskSet/User that
     shouldn't be executed according to the tag options

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -11,12 +11,15 @@ from typing import (
     Optional,
     Type,
     overload,
-    Protocol,
     Dict,
     Set,
-    runtime_checkable,
 )
-from typing_extensions import final
+
+# @TODO: typing.Protocol and typing.final is in python >= 3.8
+try:
+    from typing import Protocol, final, runtime_checkable
+except ImportError:
+    from typing_extensions import Protocol, final, runtime_checkable  # type: ignore
 
 import gevent
 from gevent import GreenletExit

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -2,7 +2,20 @@ import logging
 import random
 import traceback
 from time import time
-from typing import TYPE_CHECKING, Callable, List, Union, TypeVar, Optional, Type, overload, Protocol, Dict, Set
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    List,
+    Union,
+    TypeVar,
+    Optional,
+    Type,
+    overload,
+    Protocol,
+    Dict,
+    Set,
+    runtime_checkable,
+)
 from typing_extensions import final
 
 import gevent
@@ -20,6 +33,7 @@ TaskT = TypeVar("TaskT", Callable[..., None], Type["TaskSet"])
 LOCUST_STATE_RUNNING, LOCUST_STATE_WAITING, LOCUST_STATE_STOPPING = ["running", "waiting", "stopping"]
 
 
+@runtime_checkable
 class TaskHolder(Protocol[TaskT]):
     tasks: List[TaskT]
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -17,7 +17,7 @@ from gevent import pywsgi
 from .exception import AuthCredentialsError
 from .runners import MasterRunner, STATE_MISSING
 from .log import greenlet_exception_logger
-from .stats import StatsCSVFileWriter, sort_stats
+from .stats import StatsCSVFileWriter, StatsErrorDict, sort_stats
 from . import stats as stats_module, __version__ as version, argument_parser
 from .stats import StatsCSV
 from .user.inspectuser import get_ratio
@@ -264,7 +264,7 @@ class WebUI:
         @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
         def request_stats() -> Response:
             stats: List[Dict[str, Any]] = []
-            errors: List[Dict[str, str]] = []
+            errors: List[StatsErrorDict] = []
 
             if environment.runner is None:
                 report = {
@@ -304,7 +304,7 @@ class WebUI:
                 )
 
             for e in environment.runner.errors.values():
-                err_dict = e.to_dict()
+                err_dict = e.serialize()
                 err_dict["name"] = escape(err_dict["name"])
                 err_dict["error"] = escape(err_dict["error"])
                 errors.append(err_dict)

--- a/locust/web.py
+++ b/locust/web.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import logging
 import os.path
 from functools import wraps
@@ -6,26 +7,28 @@ from html import escape
 from io import StringIO
 from itertools import chain
 from time import time
+from typing import TYPE_CHECKING, Optional, Union, Any, Dict, List
 
 import gevent
-from flask import Flask, make_response, jsonify, render_template, request, send_file
+from flask import Flask, make_response, jsonify, render_template, request, send_file, Response
 from flask_basicauth import BasicAuth
 from gevent import pywsgi
-from typing import Any, Dict
 
 from .exception import AuthCredentialsError
-from .runners import MasterRunner
+from .runners import MasterRunner, STATE_MISSING
 from .log import greenlet_exception_logger
-from .stats import sort_stats
+from .stats import StatsCSVFileWriter, sort_stats
 from . import stats as stats_module, __version__ as version, argument_parser
 from .stats import StatsCSV
 from .user.inspectuser import get_ratio
 from .util.cache import memoize
 from .util.rounding import proper_round
-from .util.timespan import parse_timespan
 from .html import get_html_report
 from flask_cors import CORS
 from json import dumps
+
+if TYPE_CHECKING:
+    from .env import Environment
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +44,7 @@ class WebUI:
     in :attr:`environment.stats <locust.env.Environment.stats>`
     """
 
-    app = None
+    app: Optional[Flask] = None
     """
     Reference to the :class:`flask.Flask` app. Can be used to add additional web routes and customize
     the Flask app in other various ways. Example::
@@ -53,12 +56,12 @@ class WebUI:
             return "your IP is: %s" % request.remote_addr
     """
 
-    greenlet = None
+    greenlet: Optional[gevent.Greenlet] = None
     """
     Greenlet of the running web server
     """
 
-    server = None
+    server: Optional[pywsgi.WSGIServer] = None
     """Reference to the :class:`pyqsgi.WSGIServer` instance"""
 
     template_args: Dict[str, Any]
@@ -67,13 +70,13 @@ class WebUI:
 
     def __init__(
         self,
-        environment,
-        host,
-        port,
-        auth_credentials=None,
-        tls_cert=None,
-        tls_key=None,
-        stats_csv_writer=None,
+        environment: "Environment",
+        host: str,
+        port: int,
+        auth_credentials: Optional[str] = None,
+        tls_cert: Optional[str] = None,
+        tls_key: Optional[str] = None,
+        stats_csv_writer: Optional[StatsCSV] = None,
         delayed_start=False,
     ):
         """
@@ -104,9 +107,9 @@ class WebUI:
         app.debug = True
         app.root_path = os.path.dirname(os.path.abspath(__file__))
         self.app.config["BASIC_AUTH_ENABLED"] = False
-        self.auth = None
-        self.greenlet = None
-        self._swarm_greenlet = None
+        self.auth: Optional[BasicAuth] = None
+        self.greenlet: Optional[gevent.Greenlet] = None
+        self._swarm_greenlet: Optional[gevent.Greenlet] = None
         self.template_args = {}
 
         if auth_credentials is not None:
@@ -128,7 +131,7 @@ class WebUI:
 
         @app.route("/")
         @self.auth_required_if_enabled
-        def index():
+        def index() -> Union[str, Response]:
             if not environment.runner:
                 return make_response("Error: Locust Environment does not have any runner", 500)
             self.update_template_args()
@@ -136,7 +139,7 @@ class WebUI:
 
         @app.route("/swarm", methods=["POST"])
         @self.auth_required_if_enabled
-        def swarm():
+        def swarm() -> Response:
             assert request.method == "POST"
 
             parsed_options_dict = vars(environment.parsed_options) if environment.parsed_options else {}
@@ -153,7 +156,7 @@ class WebUI:
                     # This won't work for parameters that are None
                     parsed_options_dict[key] = type(parsed_options_dict[key])(value)
 
-            if environment.shape_class:
+            if environment.shape_class and environment.runner is not None:
                 environment.runner.start_shape()
                 return jsonify(
                     {"success": True, "message": "Swarming started using shape class", "host": environment.host}
@@ -162,37 +165,43 @@ class WebUI:
             if self._swarm_greenlet is not None:
                 self._swarm_greenlet.kill(block=True)
                 self._swarm_greenlet = None
-            self._swarm_greenlet = gevent.spawn(environment.runner.start, user_count, spawn_rate)
-            self._swarm_greenlet.link_exception(greenlet_exception_handler)
-            return jsonify({"success": True, "message": "Swarming started", "host": environment.host})
+
+            if environment.runner is not None:
+                self._swarm_greenlet = gevent.spawn(environment.runner.start, user_count, spawn_rate)
+                self._swarm_greenlet.link_exception(greenlet_exception_handler)
+                return jsonify({"success": True, "message": "Swarming started", "host": environment.host})
+            else:
+                return jsonify({"success": False, "message": "No runner", "host": environment.host})
 
         @app.route("/stop")
         @self.auth_required_if_enabled
-        def stop():
+        def stop() -> Response:
             if self._swarm_greenlet is not None:
                 self._swarm_greenlet.kill(block=True)
                 self._swarm_greenlet = None
-            environment.runner.stop()
+            if environment.runner is not None:
+                environment.runner.stop()
             return jsonify({"success": True, "message": "Test stopped"})
 
         @app.route("/stats/reset")
         @self.auth_required_if_enabled
-        def reset_stats():
+        def reset_stats() -> str:
             environment.events.reset_stats.fire()
-            environment.runner.stats.reset_all()
-            environment.runner.exceptions = {}
+            if environment.runner is not None:
+                environment.runner.stats.reset_all()
+                environment.runner.exceptions = {}
             return "ok"
 
         @app.route("/stats/report")
         @self.auth_required_if_enabled
-        def stats_report():
+        def stats_report() -> Response:
             res = get_html_report(self.environment, show_download_link=not request.args.get("download"))
             if request.args.get("download"):
                 res = app.make_response(res)
                 res.headers["Content-Disposition"] = f"attachment;filename=report_{time()}.html"
             return res
 
-        def _download_csv_suggest_file_name(suggest_filename_prefix):
+        def _download_csv_suggest_file_name(suggest_filename_prefix: str) -> str:
             """Generate csv file download attachment filename suggestion.
 
             Arguments:
@@ -201,7 +210,7 @@ class WebUI:
 
             return f"{suggest_filename_prefix}_{time()}.csv"
 
-        def _download_csv_response(csv_data, filename_prefix):
+        def _download_csv_response(csv_data: str, filename_prefix: str) -> Response:
             """Generate csv file download response with 'csv_data'.
 
             Arguments:
@@ -218,7 +227,7 @@ class WebUI:
 
         @app.route("/stats/requests/csv")
         @self.auth_required_if_enabled
-        def request_stats_csv():
+        def request_stats_csv() -> Response:
             data = StringIO()
             writer = csv.writer(data)
             self.stats_csv_writer.requests_csv(writer)
@@ -226,9 +235,9 @@ class WebUI:
 
         @app.route("/stats/requests_full_history/csv")
         @self.auth_required_if_enabled
-        def request_stats_full_history_csv():
+        def request_stats_full_history_csv() -> Response:
             options = self.environment.parsed_options
-            if options and options.stats_history_enabled:
+            if options and options.stats_history_enabled and isinstance(self.stats_csv_writer, StatsCSVFileWriter):
                 return send_file(
                     os.path.abspath(self.stats_csv_writer.stats_history_file_name()),
                     mimetype="text/csv",
@@ -244,7 +253,7 @@ class WebUI:
 
         @app.route("/stats/failures/csv")
         @self.auth_required_if_enabled
-        def failures_stats_csv():
+        def failures_stats_csv() -> Response:
             data = StringIO()
             writer = csv.writer(data)
             self.stats_csv_writer.failures_csv(writer)
@@ -253,10 +262,28 @@ class WebUI:
         @app.route("/stats/requests")
         @self.auth_required_if_enabled
         @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
-        def request_stats():
-            stats = []
+        def request_stats() -> Response:
+            stats: List[Dict[str, Any]] = []
+            errors: List[Dict[str, str]] = []
 
-            for s in chain(sort_stats(self.environment.runner.stats.entries), [environment.runner.stats.total]):
+            if environment.runner is None:
+                report = {
+                    "stats": stats,
+                    "errors": errors,
+                    "total_rps": 0.0,
+                    "fail_ratio": 0.0,
+                    "current_response_time_percentile_95": None,
+                    "current_response_time_percentile_50": None,
+                    "state": STATE_MISSING,
+                    "user_count": 0,
+                }
+
+                if isinstance(environment.runner, MasterRunner):
+                    report.update({"workers": []})
+
+                return jsonify(report)
+
+            for s in chain(sort_stats(environment.runner.stats.entries), [environment.runner.stats.total]):
                 stats.append(
                     {
                         "method": s.method,
@@ -276,7 +303,6 @@ class WebUI:
                     }
                 )
 
-            errors = []
             for e in environment.runner.errors.values():
                 err_dict = e.to_dict()
                 err_dict["name"] = escape(err_dict["name"])
@@ -285,9 +311,11 @@ class WebUI:
 
             # Truncate the total number of stats and errors displayed since a large number of rows will cause the app
             # to render extremely slowly. Aggregate stats should be preserved.
-            report = {"stats": stats[:500], "errors": errors[:500]}
+            truncated_stats = stats[:500]
             if len(stats) > 500:
-                report["stats"] += [stats[-1]]
+                truncated_stats += [stats[-1]]
+
+            report = {"stats": truncated_stats, "errors": errors[:500]}
 
             if stats:
                 report["total_rps"] = stats[len(stats) - 1]["current_rps"]
@@ -299,8 +327,7 @@ class WebUI:
                     "current_response_time_percentile_50"
                 ] = environment.runner.stats.total.get_current_response_time_percentile(0.5)
 
-            is_distributed = isinstance(environment.runner, MasterRunner)
-            if is_distributed:
+            if isinstance(environment.runner, MasterRunner):
                 workers = []
                 for worker in environment.runner.clients.values():
                     workers.append(
@@ -322,7 +349,7 @@ class WebUI:
 
         @app.route("/exceptions")
         @self.auth_required_if_enabled
-        def exceptions():
+        def exceptions() -> Response:
             return jsonify(
                 {
                     "exceptions": [
@@ -332,14 +359,14 @@ class WebUI:
                             "traceback": row["traceback"],
                             "nodes": ", ".join(row["nodes"]),
                         }
-                        for row in environment.runner.exceptions.values()
+                        for row in (environment.runner.exceptions.values() if environment.runner is not None else [])
                     ]
                 }
             )
 
         @app.route("/exceptions/csv")
         @self.auth_required_if_enabled
-        def exceptions_csv():
+        def exceptions_csv() -> Response:
             data = StringIO()
             writer = csv.writer(data)
             self.stats_csv_writer.exceptions_csv(writer)
@@ -347,10 +374,17 @@ class WebUI:
 
         @app.route("/tasks")
         @self.auth_required_if_enabled
-        def tasks():
-            is_distributed = isinstance(self.environment.runner, MasterRunner)
+        def tasks() -> Dict[str, Dict[str, Dict[str, float]]]:
             runner = self.environment.runner
-            user_spawned = runner.reported_user_classes_count if is_distributed else runner.user_classes_count
+            user_spawned: Dict[str, int]
+            if runner is None:
+                user_spawned = {}
+            else:
+                user_spawned = (
+                    runner.reported_user_classes_count
+                    if isinstance(runner, MasterRunner)
+                    else runner.user_classes_count
+                )
 
             task_data = {
                 "per_class": get_ratio(self.environment.user_classes, user_spawned, False),

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     Flask-BasicAuth >=0.2.0
     Flask-Cors >=3.0.10
     roundrobin >=0.0.2
-    typing-extensions >=3.7.4.3 # This provides support for @final, and can probably be removed once we drop 3.7 support
+    typing-extensions >=3.7.4.3 # This provides support for @final, @runtime_checkable, Protocol and TypedDict, and can probably be removed once we drop 3.7 support
     pywin32;platform_system=='Windows'
 
 [options.packages.find]


### PR DESCRIPTION
when doing some "integration" work with `RequestStats`, i noticed that there was a lot of stuff that was missing types and had inferred `Any`.

so this PR started out with the goal to add typing to `locust.stats` which took me down a rabbit hole of also adding types in `locust.env`, `locust.web`, `locust.runners` and `locust.user`.

i had to get creative in some places, which added a bit more code than just the types, mostly due to how many variables has an initial value of `None`.

also, maybe a bit unnecessary... but `StatsEntry` had `serialize` and `unserialize`, while `StatsError` for the same thing had `to_dict` and `from_dict`, so changed it so they have the same names.