### PR TITLE
add support for custom SSLContext when using FastHttpUser

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -84,7 +84,7 @@ class FastHttpSession:
         self.user = user
         if ssl_context:
             if not isinstance(ssl_context, SSLContext):
-                raise TypeError('You must provide a valid SSLContext.')
+                raise TypeError("You must provide a valid SSLContext.")
             ssl_context_factory = lambda: ssl_context
         elif insecure:
             ssl_context_factory = insecure_ssl_context_factory
@@ -349,7 +349,7 @@ class FastHttpUser(User):
             concurrency=self.concurrency,
             user=self,
             client_pool=self.client_pool,
-            ssl_context=self.ssl_context
+            ssl_context=self.ssl_context,
         )
         """
         Instance of HttpSession that is created upon instantiation of User.

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -110,7 +110,7 @@ class FastHttpSession:
             # store authentication header (we construct this by using _basic_auth_str() function from requests.auth)
             self.auth_header = _construct_basic_auth_str(parsed_url.username, parsed_url.password)
 
-    def _check_ssl_context(ssl_context):
+    def _check_ssl_context(self, ssl_context):
         if not isinstance(ssl_context, gevent.ssl.SSLContext):
             raise TypeError(
                 'You must provide a valid SSLContext. Expected type is gevent.ssl.SSLContext '

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -203,6 +203,58 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertEqual(s.base_url + "/wrong_url/01", kwargs["url"])  # url is unaffected by name
         self.assertDictEqual({"foo": "bar"}, kwargs["context"])
 
+    def test_custom_ssl_context_fail_with_bad_context(self):
+        """
+        Test FastHttpSession with a custom SSLContext factory that will fail as
+        we can not set verify_mode to CERT_NONE when check_hostname is enabled
+        """
+
+        def create_custom_context():
+            context = gevent.ssl.create_default_context()
+            context.check_hostname = True
+            context.verify_mode = gevent.ssl.CERT_NONE
+            return context
+
+        s = FastHttpSession(
+            self.environment,
+            "https://127.0.0.1:%i" % self.port,
+            ssl_context_factory=create_custom_context,
+            user=None,
+        )
+        with self.assertRaises(ValueError) as e:
+            s.get("/")
+        self.assertEqual(e.exception.args, ("Cannot set verify_mode to CERT_NONE when check_hostname is enabled.",))
+
+    def test_custom_ssl_context_passed_correct_to_client_pool(self):
+        """
+        Test FastHttpSession with a custom SSLContext factory with a options.name
+        that will be passed correctly to the ClientPool. It will also test a 2nd
+        factory which is not the correct one.
+        """
+
+        def custom_ssl_context():
+            context = gevent.ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = gevent.ssl.CERT_NONE
+            context.options.name = "FAKEOPTION"
+            return context
+
+        def custom_context_with_wrong_option():
+            context = gevent.ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = gevent.ssl.CERT_NONE
+            context.options.name = "OPTIONFAKED"
+            return context
+
+        s = FastHttpSession(
+            self.environment,
+            "https://127.0.0.1:%i" % self.port,
+            ssl_context_factory=custom_ssl_context,
+            user=None,
+        )
+        self.assertEqual(s.client.clientpool.client_args["ssl_context_factory"], custom_ssl_context)
+        self.assertNotEqual(s.client.clientpool.client_args["ssl_context_factory"], custom_context_with_wrong_option)
+
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def test_request_stats_content_length(self):
@@ -668,24 +720,6 @@ class TestFastHttpSsl(LocustTestCase):
 
     def test_ssl_request_insecure(self):
         s = FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, insecure=True, user=None)
-        r = s.get("/")
-        self.assertEqual(200, r.status_code)
-        self.assertIn("<title>Locust for None</title>", r.content.decode("utf-8"))
-        self.assertIn("<p>Script: <span>None</span></p>", r.text)
-
-    def test_custom_ssl_context(self):
-        def create_custom_context():
-            context = gevent.ssl.create_default_context()
-            context.check_hostname = False
-            context.verify_mode = gevent.ssl.CERT_NONE
-            return context
-
-        s = FastHttpSession(
-            self.environment,
-            "https://127.0.0.1:%i" % self.web_port,
-            ssl_context_factory=create_custom_context,
-            user=None,
-        )
         r = s.get("/")
         self.assertEqual(200, r.status_code)
         self.assertIn("<title>Locust for None</title>", r.content.decode("utf-8"))

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -681,18 +681,12 @@ class TestFastHttpSsl(LocustTestCase):
             return context
 
         s = FastHttpSession(
-            self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None
+            self.environment,
+            "https://127.0.0.1:%i" % self.web_port,
+            ssl_context_factory=create_custom_context,
+            user=None,
         )
         r = s.get("/")
         self.assertEqual(200, r.status_code)
         self.assertIn("<title>Locust for None</title>", r.content.decode("utf-8"))
         self.assertIn("<p>Script: <span>None</span></p>", r.text)
-
-    def test_custom_ssl_context_error_fail(self):
-        def create_custom_context():
-            return {"ssl_context": {"cert": "mycert.pem", "key": "mykey.key"}}
-
-        with self.assertRaises(TypeError):
-            FastHttpSession(
-                self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None
-            )

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -680,7 +680,9 @@ class TestFastHttpSsl(LocustTestCase):
             context.verify_mode = gevent.ssl.CERT_NONE
             return context
 
-        s = FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None)
+        s = FastHttpSession(
+            self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None
+        )
         r = s.get("/")
         self.assertEqual(200, r.status_code)
         self.assertIn("<title>Locust for None</title>", r.content.decode("utf-8"))
@@ -688,7 +690,9 @@ class TestFastHttpSsl(LocustTestCase):
 
     def test_custom_ssl_context_error_fail(self):
         def create_custom_context():
-            return {'ssl_context': {'cert': 'mycert.pem', 'key': 'mykey.key'}}
+            return {"ssl_context": {"cert": "mycert.pem", "key": "mykey.key"}}
 
-        with FastHttpSession(self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None):
-            self.assertRaises(TypeError)
+        with self.assertRaises(TypeError):
+            FastHttpSession(
+                self.environment, "https://127.0.0.1:%i" % self.web_port, ssl_context=create_custom_context(), user=None
+            )


### PR DESCRIPTION
As per https://github.com/locustio/locust/issues/2066, currently there's no option for setting up certificates when using `FastHttpUser`. This PR intends to add a new `ssl_context_factory` param to enabling this functionality by defining a custom `Callable` returning a SSLContext when implementing the user.

As the callable will be called within the class context if it is defined outside the `ApiLocust` class we need to fake an arg there. The two example on how implementing can be found below.

**Option 1**

```python
import gevent
from locust import task
from locust.contrib.fasthttp import FastHttpUser

def my_custom_context(*args):
    context = gevent.ssl.create_default_context()
    context.check_hostname = True
    context.verify_mode = gevent.ssl.CERT_REQUIRED
    context.load_cert_chain(certfile="yourpempath", keyfile="yourkeypath")
    context.load_verify_locations(cafile="yourcapath")
    return context

class ApiLocust(FastHttpUser):
    ssl_context_factory = my_custom_context
    
    def __init__(self, environment):
        super().__init__(environment=environment)

    @task()
    def submit(self):
        self.client.get('/')
```

**Option 2**

```python
import gevent
from locust import task
from locust.contrib.fasthttp import FastHttpUser

class ApiLocust(FastHttpUser):
    
    def __init__(self, environment):
        super().__init__(environment=environment)
   
    def ssl_context_factory(self):
        context = gevent.ssl.create_default_context()
        context.check_hostname = True
        context.verify_mode = gevent.ssl.CERT_REQUIRED
        context.load_cert_chain(certfile="yourpempath", keyfile="yourkeypath")
        context.load_verify_locations(cafile="yourcapath")
        return context

    @task()
    def submit(self):
        self.client.get('/')
```