### PR TITLE
fix: stopping state when running more than one worker node.

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -970,7 +970,6 @@ class MasterRunner(DistributedRunner):
                 gevent.sleep(FALLBACK_INTERVAL)
                 continue
             msg.node_id = client_id
-            logger.debug(f"Received a message: {msg.type}")  # noisy?
             if msg.type == "client_ready":
                 if not msg.data:
                     logger.error(f"An old (pre 2.0) worker tried to connect ({client_id}). That's not going to work.")


### PR DESCRIPTION
As per the issue https://github.com/locustio/locust/issues/2111 when running locust in distributed mode with more than 1 worker when the job is stopped the state is kept as STOPPING. Doing some investigation I realised after it removes a client from the list it gets back as a `ready` one, thus when the `check_stopped()` is called it checks the state for all clients, as the operation is fast, before checking the second client the first one is already `ready` and pass the `update_state(STATE_STOPPED)`

This PR intends to fix this bug hence to fix the continuously RPS in the graph even with the test "stopped" (issue with the graph shown bellow).

![image](https://user-images.githubusercontent.com/2206761/173906594-e11bb42e-40bf-42f3-8912-c19009ee8d8d.png)
