### PR TITLE
Update the link for reporting data to a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Even though Locust primarily works with web sites/services, it can be used to te
 
 ## Hackable
 
-Locust's code base is intentionally kept small and doesn't solve everything out of the box. Instead, we try to make it easy to adapt to any situation you may come across, using regular Python code. If you want to [send reporting data to that database & graphing system you like](https://github.com/SvenskaSpel/locust-plugins/blob/master/examples/timescale_listener_ex.py), [wrap calls to a REST API](https://github.com/SvenskaSpel/locust-plugins/blob/master/examples/rest_ex.py) to handle the particulars of your system or run a [totally custom load pattern](https://docs.locust.io/en/latest/custom-load-shape.html#custom-load-shape), there is nothing stopping you!
+Locust's code base is intentionally kept small and doesn't solve everything out of the box. Instead, we try to make it easy to adapt to any situation you may come across, using regular Python code. If you want to [send reporting data to that database & graphing system you like](https://github.com/SvenskaSpel/locust-plugins/blob/master/locust_plugins/dashboards/README.md), [wrap calls to a REST API](https://github.com/SvenskaSpel/locust-plugins/blob/master/examples/rest_ex.py) to handle the particulars of your system or run a [totally custom load pattern](https://docs.locust.io/en/latest/custom-load-shape.html#custom-load-shape), there is nothing stopping you!
 
 ## Links
 


### PR DESCRIPTION
Link was killed in:
https://github.com/SvenskaSpel/locust-plugins/commit/91e431e2c5c4da39b385e8f717809c280c1577ad
And the new link was moved again in:
https://github.com/SvenskaSpel/locust-plugins/commit/9426d6d1ca491260e5fe16807f3991d6f0711b13

As of today, the other two links on this line still appear to be correct.