### PR TITLE
More robust handling of ZMQ/RPC errors

### DIFF
--- a/locust/exception.py
+++ b/locust/exception.py
@@ -54,6 +54,22 @@ class RPCError(Exception):
     """
 
 
+class RPCSendError(Exception):
+    """
+    Exception when sending message to client.
+
+    When raised from zmqrpc, sending can be retried or RPC can be reestablished.
+    """
+
+
+class RPCReceiveError(Exception):
+    """
+    Exception when receiving message from client is interrupted or message is corrupted.
+
+    When raised from zmqrpc, client connection should be reestablished.
+    """
+
+
 class AuthCredentialsError(ValueError):
     """
     Exception when the auth credentials provided

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -46,14 +46,11 @@ class BaseSocket:
             raise RPCReceiveError("ZMQ interrupted or corrupted message") from e
         except zmqerr.ZMQError as e:
             raise RPCError("ZMQ network broken") from e
-        return addr, data[1]
-
-    def msg_from_data(self, data):
         try:
-            msg = Message.unserialize(data)
+            msg = Message.unserialize(data[1])
         except (UnicodeDecodeError, msgerr.ExtraData) as e:
             raise RPCReceiveError("ZMQ interrupted or corrupted message") from e
-        return msg
+        return addr, msg
 
     def close(self, linger=None):
         self.socket.close(linger)

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -53,7 +53,7 @@ class BaseSocket:
         return addr, msg
 
     def close(self, linger=None):
-        self.socket.close(linger)
+        self.socket.close(linger=linger)
 
 
 class Server(BaseSocket):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -943,8 +943,7 @@ class MasterRunner(DistributedRunner):
         while True:
             msg: Message
             try:
-                client_id, data = self.server.recv_from_client()
-                msg = self.server.msg_from_data(data)
+                client_id, msg = self.server.recv_from_client()
             except RPCReceiveError as e:
                 logger.error(f"RPCError when receiving from client: {e}. Will reset client {client_id}.")
                 try:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -956,8 +956,6 @@ class MasterRunner(DistributedRunner):
 
     def client_listener(self) -> NoReturn:
         while True:
-            msg: Message = None
-            client_id: str = None
             try:
                 client_id, msg = self.server.recv_from_client()
             except RPCReceiveError as e:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1301,7 +1301,7 @@ class WorkerRunner(DistributedRunner):
                 self.stop()
                 self._send_stats()  # send a final report, in case there were any samples not yet reported
                 self.greenlet.kill(block=True)
-            elif msg.type == "reonnect":
+            elif msg.type == "reconnect":
                 logger.warning("Received reconnect message from master. Resetting RPC connection.")
                 self.reset_connection()
             elif msg.type in self.custom_messages:

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -21,11 +21,7 @@ from locust import (
 )
 from locust.argument_parser import parse_options
 from locust.env import Environment
-from locust.exception import (
-    RPCError,
-    StopUser,
-    RPCReceiveError
-)
+from locust.exception import RPCError, StopUser, RPCReceiveError
 from locust.main import create_environment
 from locust.rpc import Message
 from locust.runners import (
@@ -2926,7 +2922,7 @@ class TestMasterRunner(LocustRunnerTestCase):
             self.assertEqual(1, len(master.clients))
             self.assertEqual("ack", server.outbox[0][1].type)
             self.assertEqual(1, len(server.outbox))
-    
+
     def test_worker_sends_bad_message_to_master(self):
         """
         Validate master sends reconnect message to worker when it receives a bad message.
@@ -2952,7 +2948,9 @@ class TestMasterRunner(LocustRunnerTestCase):
             self.assertEqual(4, len(server.outbox))
 
             # Expected message order in outbox: ack, spawn, reconnect, ack
-            self.assertEqual("reconnect", server.outbox[2][1].type, "Master didn't send worker reconnect message when expected.")
+            self.assertEqual(
+                "reconnect", server.outbox[2][1].type, "Master didn't send worker reconnect message when expected."
+            )
 
 
 class TestWorkerRunner(LocustTestCase):
@@ -3262,8 +3260,8 @@ class TestWorkerRunner(LocustTestCase):
             )
             sleep(0.6)
             self.assertEqual(STATE_RUNNING, worker.state)
-            with self.assertLogs('locust.runners') as capture:
-                with mock.patch('locust.rpc.rpc.Client.close') as close:
+            with self.assertLogs("locust.runners") as capture:
+                with mock.patch("locust.rpc.rpc.Client.close") as close:
                     client.mocked_send(
                         Message(
                             "reconnect",
@@ -3275,7 +3273,10 @@ class TestWorkerRunner(LocustTestCase):
                     worker.spawning_greenlet.join()
                     worker.quit()
                     close.assert_called_once()
-            self.assertIn("WARNING:locust.runners:Received reconnect message from master. Resetting RPC connection.", capture.output)
+            self.assertIn(
+                "WARNING:locust.runners:Received reconnect message from master. Resetting RPC connection.",
+                capture.output,
+            )
 
     def test_change_user_count_during_spawning(self):
         class MyUser(User):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -85,7 +85,7 @@ def mocked_rpc(raise_on_close=True):
                 raise RPCError()
             return msg.node_id, msg
 
-        def close(self):
+        def close(self, linger=None):
             if self.raise_error_on_close:
                 raise RPCError()
             else:

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -2944,7 +2944,6 @@ class TestMasterRunner(LocustRunnerTestCase):
             master.start(10, 10)
             sleep(0.1)
             server.mocked_send(Message("stats", BAD_MESSAGE, "zeh_fake_client1"))
-            print(server.outbox)
             self.assertEqual(4, len(server.outbox))
 
             # Expected message order in outbox: ack, spawn, reconnect, ack

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -24,8 +24,7 @@ class ZMQRPC_tests(LocustTestCase):
 
     def test_client_send(self):
         self.client.send(Message("test", "message", "identity"))
-        addr, data = self.server.recv_from_client()
-        msg = self.server.msg_from_data(data)
+        addr, msg = self.server.recv_from_client()
         self.assertEqual(addr, "identity")
         self.assertEqual(msg.type, "test")
         self.assertEqual(msg.data, "message")

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -2,7 +2,7 @@ from time import sleep
 import zmq
 from locust.rpc import zmqrpc, Message
 from locust.test.testcases import LocustTestCase
-from locust.exception import RPCError
+from locust.exception import RPCError, RPCSendError, RPCReceiveError
 
 
 class ZMQRPC_tests(LocustTestCase):
@@ -24,7 +24,8 @@ class ZMQRPC_tests(LocustTestCase):
 
     def test_client_send(self):
         self.client.send(Message("test", "message", "identity"))
-        addr, msg = self.server.recv_from_client()
+        addr, data = self.server.recv_from_client()
+        msg = self.server.msg_from_data(data)
         self.assertEqual(addr, "identity")
         self.assertEqual(msg.type, "test")
         self.assertEqual(msg.data, "message")
@@ -50,5 +51,5 @@ class ZMQRPC_tests(LocustTestCase):
         with self.assertRaises(RPCError):
             server = zmqrpc.Server("127.0.0.1", server.port)
         server.close()
-        with self.assertRaises(RPCError):
+        with self.assertRaises(RPCSendError):
             server.send_to_client(Message("test", "message", "identity"))


### PR DESCRIPTION
When using Boomer as a worker runner, I encountered some occasional errors on the master when receiving reports from the workers. In that situation, current Locust would break itself by attempting to reset the entire RPC server. Firstly, various issues prevented that from completing successfully. This broke the entire test instead of just fixing the one worker. Secondly, that isn't always necessary for the master to do. In most cases, subsequent reports from the workers are fine. In some other cases, the worker with the bad message resetting its connection to the master can resolve it. This will now reserve the master resetting its server to times when the master gets an error attempting to send to a worker, or if there's any other unexpected `RPCError` that gets thrown.