### PR TITLE
Convert url for getting tasks to relative

### DIFF
--- a/locust/static/tasks.js
+++ b/locust/static/tasks.js
@@ -42,7 +42,7 @@ function fillTasksFromObj() {
 }
 
 function fillTasksFromRequest() {
-    $.get('/tasks', function (data) {
+    $.get('./tasks', function (data) {
         _renderTasks(data)
     });
 }


### PR DESCRIPTION
I was using Locust UI with kubernetes and after setting up ingress rule to expose the service on custom path I have noticed periodic 404 errors in the browser console occurring each second.

This happens because when using urls with absolute path that starts with `/` custom base path used for exposing the service in ingress rules gets lost so instead of 202 `http://domain.com/locust/tasks` we get 404 `http://domain.com/tasks`.
This change will make it relative so base path `/locust` in example before will be preserved.

This is also related to this issue [#149](https://github.com/locustio/locust/issues/149) and [PR692](https://github.com/locustio/locust/pull/692) that solved this problem for code before 2018