### PR TITLE
Fix escaping for exceptions in normal web ui (related to #2126)

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -355,8 +355,8 @@ class WebUI:
                     "exceptions": [
                         {
                             "count": row["count"],
-                            "msg": row["msg"],
-                            "traceback": row["traceback"],
+                            "msg": escape(row["msg"]),
+                            "traceback": escape(row["traceback"]),
                             "nodes": ", ".join(row["nodes"]),
                         }
                         for row in (environment.runner.exceptions.values() if environment.runner is not None else [])


### PR DESCRIPTION
when the stacktrace of exceptions contains some html, then the rendering (and possibly more) breaks.

In my case it was some method with parameter value `'<!DOCTYPE'`. Then the stacktrace stops afterwards