### PR TITLE
Test Report: Implement table sorting

### DIFF
--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -129,7 +129,7 @@
                         <tr>
                             <th class="sortable">Method</th>
                             <th class="sortable">Name</th>
-                            <th>Error</th>
+                            <th class="sortable">Error</th>
                             <th class="sortable">Occurrences</th>
                         </tr>
                     </thead>
@@ -155,7 +155,7 @@
                         <tr>
                             <th class="sortable">Count</th>
                             <th class="sortable">Message</th>
-                            <th>Traceback</th>
+                            <th class="sortable">Traceback</th>
                             <th class="sortable">Nodes</th>
                         </tr>
                     </thead>

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -243,7 +243,7 @@
         $('.sortable').click(function() {
             var table = $(this).parents('table').eq(0)
             var rowArray = table.find('tr:gt(0)').toArray()
-            var aggregatedRow = $(rowArray).get(-1)
+            var aggregatedRow = rowArray.pop()
             var rows = rowArray.sort(comparer($(this).index()))
             this.asc = !this.asc
             if (!this.asc){rows = rows.reverse()}

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -54,16 +54,16 @@
             <table class="stats">
                 <thead>
                     <tr>
-                        <th>Method</th>
-                        <th>Name</th>
-                        <th># Requests</th>
-                        <th># Fails</th>
-                        <th>Average (ms)</th>
-                        <th>Min (ms)</th>
-                        <th>Max (ms)</th>
-                        <th>Average size (bytes)</th>
-                        <th>RPS</th>
-                        <th>Failures/s</th>
+                        <th class="sortable">Method</th>
+                        <th class="sortable">Name</th>
+                        <th class="sortable"># Requests</th>
+                        <th class="sortable"># Fails</th>
+                        <th class="sortable">Average (ms)</th>
+                        <th class="sortable">Min (ms)</th>
+                        <th class="sortable">Max (ms)</th>
+                        <th class="sortable">Average size (bytes)</th>
+                        <th class="sortable">RPS</th>
+                        <th class="sortable">Failures/s</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -90,16 +90,16 @@
             <table class="stats">
                 <thead>
                     <tr>
-                        <th>Method</th>
-                        <th>Name</th>
-                        <th>50%ile (ms)</th>
-                        <th>60%ile (ms)</th>
-                        <th>70%ile (ms)</th>
-                        <th>80%ile (ms)</th>
-                        <th>90%ile (ms)</th>
-                        <th>95%ile (ms)</th>
-                        <th>99%ile (ms)</th>
-                        <th>100%ile (ms)</th>
+                        <th class="sortable">Method</th>
+                        <th class="sortable">Name</th>
+                        <th class="sortable">50%ile (ms)</th>
+                        <th class="sortable">60%ile (ms)</th>
+                        <th class="sortable">70%ile (ms)</th>
+                        <th class="sortable">80%ile (ms)</th>
+                        <th class="sortable">90%ile (ms)</th>
+                        <th class="sortable">95%ile (ms)</th>
+                        <th class="sortable">99%ile (ms)</th>
+                        <th class="sortable">100%ile (ms)</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -127,10 +127,10 @@
                 <table class="stats">
                     <thead>
                         <tr>
-                            <th>Method</th>
-                            <th>Name</th>
+                            <th class="sortable">Method</th>
+                            <th class="sortable">Name</th>
                             <th>Error</th>
-                            <th>Occurrences</th>
+                            <th class="sortable">Occurrences</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -153,10 +153,10 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>Count</th>
-                            <th>Message</th>
+                            <th class="sortable">Count</th>
+                            <th class="sortable">Message</th>
                             <th>Traceback</th>
-                            <th>Nodes</th>
+                            <th class="sortable">Nodes</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -183,7 +183,7 @@
             <h2>Final ratio</h2>
             <div class="tasks" data-tasks="{{ escape(tasks) }}"></div>
         </div>
-    
+
     </div>
 
     {# <script type="text/javascript" src="/static/jquery-1.11.3.min.js"></script> #}
@@ -237,6 +237,26 @@
         });
 
         fillTasksFromObj()
+    </script>
+
+    <script>
+        $('.sortable').click(function() {
+            var table = $(this).parents('table').eq(0)
+            var rowArray = table.find('tr:gt(0)').toArray()
+            var aggregatedRow = $(rowArray).get(-1)
+            var rows = rowArray.sort(comparer($(this).index()))
+            this.asc = !this.asc
+            if (!this.asc){rows = rows.reverse()}
+            for (var i = 0; i < rows.length; i++){table.append(rows[i])}
+            table.append(aggregatedRow)
+        })
+        function comparer(index) {
+            return function(a,b) {
+                var valA = getCellValue(a, index), valB = getCellValue(b, index)
+                return $.isNumeric(valA) && $.isNumeric(valB) ? valA - valB : valA.toString().localeCompare(valB)
+            }
+        }
+        function getCellValue(row, index) { return $(row).children('td').eq(index).text() }
     </script>
 </body>
 </html>


### PR DESCRIPTION
This PR implements the following feature request #2132.

It enables sorting the statistic tables by clicking on the respective table headers.
To make the headers clickable, the class `sortable` needs to be applied. This makes it possible to ex-/include columns from being sort-able.

I only excluded the error messages as well as the stacktraces from being sort-able from now on.
Changes are welcome. 