### PR TITLE
Log an error for every failed attempt to connect to master

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1336,6 +1336,14 @@ class WorkerRunner(DistributedRunner):
         self.client.send(Message("client_ready", __version__, self.client_id))
         success = self.connection_event.wait(timeout=CONNECT_TIMEOUT)
         if not success:
+            if self.retry < 3:
+                logger.debug(
+                    f"Failed to connect to master {self.master_host}:{self.master_port}, retry {self.retry}/{CONNECT_RETRY_COUNT}."
+                )
+            else:
+                logger.warning(
+                    f"Failed to connect to master {self.master_host}:{self.master_port}, retry {self.retry}/{CONNECT_RETRY_COUNT}."
+                )
             if self.retry > CONNECT_RETRY_COUNT:
                 raise ConnectionError()
             self.connect_to_master()


### PR DESCRIPTION
The connection timeout and number of attempts are hardcoded (60 attempts with an interval of 5 seconds each), so a complete failure of the worker to connect to master will take very long.

These log lines will allow to troubleshoot issues with the connection to master.