### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -73,7 +73,7 @@ nodes_public_ip = [
 ]
 ```
 
-![locust-home](https://github.com/marcosborges/terraform-aws-loadtest-distribuited/raw/v0.4.0/assets/locust-home.png)
+![locust-home](https://github.com/marcosborges/terraform-aws-loadtest-distributed/raw/v0.4.0/assets/locust-home.png)
 
 ---
 
@@ -89,5 +89,5 @@ terraform destroy --auto-approve
 
 - [Terraform aws-get-started >> install-terraform-on-linux](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started#install-terraform-on-linux)
 
-- [Terraform module aws loadtest distribuited](https://registry.terraform.io/modules/marcosborges/loadtest-distribuited/aws/latest)
+- [Terraform module aws loadtest distributed](https://registry.terraform.io/modules/marcosborges/loadtest-distributed/aws/latest)
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -2219,7 +2219,7 @@ class TestMasterRunner(LocustRunnerTestCase):
                 )
             )
             sleep(0.2)
-            # hearbeat received from two workers so they are active, for fake_client3 HEARTBEAT_DEAD_INTERNAL has been breached, so it will be removed from worker list
+            # heartbeat received from two workers so they are active, for fake_client3 HEARTBEAT_DEAD_INTERNAL has been breached, so it will be removed from worker list
             self.assertEqual(0, len(master.clients.missing))
             self.assertEqual(2, master.worker_count)
             master.stop()


### PR DESCRIPTION
There are small typos in:
- examples/terraform/aws/README.md
- locust/test/test_runners.py

Fixes:
- Should read `heartbeat` rather than `hearbeat`.
- Should read `distributed` rather than `distribuited`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md