### PR TITLE
Fix for Flask 2.2.0 breaking changes

### DIFF
--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -81,11 +81,11 @@ def create_tls_cert(hostname):
 def clear_all_functools_lru_cache() -> None:
     # Somehow, the code below throws unrelated DeprecationWarning related to Flask.
     # We mute the warnings in order to not pollute the logs when running the tests.
-    # with warnings.catch_warnings(record=True):
-    # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
-    # Taken from https://stackoverflow.com/a/50699209.
-    gc.collect()
-    wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
-    assert len(wrappers) > 0
-    for wrapper in wrappers:
-        wrapper.cache_clear()
+    with warnings.catch_warnings(record=True):
+        # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
+        # Taken from https://stackoverflow.com/a/50699209.
+        gc.collect()
+        wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
+        assert len(wrappers) > 0
+        for wrapper in wrappers:
+            wrapper.cache_clear()

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -79,13 +79,13 @@ def create_tls_cert(hostname):
 
 
 def clear_all_functools_lru_cache() -> None:
-    # Somehow, the code below throws unrelated DeprecationWarning related to Flask.
-    # We mute the warnings in order to not pollute the logs when running the tests.
-    with warnings.catch_warnings(record=True):
-        # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
-        # Taken from https://stackoverflow.com/a/50699209.
-        gc.collect()
-        wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
-        assert len(wrappers) > 0
-        for wrapper in wrappers:
-            wrapper.cache_clear()
+    # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
+    # Taken from https://stackoverflow.com/a/50699209.
+    import tracemalloc
+
+    tracemalloc.start()
+    gc.collect()
+    wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
+    assert len(wrappers) > 0
+    for wrapper in wrappers:
+        wrapper.cache_clear()

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -81,11 +81,11 @@ def create_tls_cert(hostname):
 def clear_all_functools_lru_cache() -> None:
     # Somehow, the code below throws unrelated DeprecationWarning related to Flask.
     # We mute the warnings in order to not pollute the logs when running the tests.
-    with warnings.catch_warnings(record=True):
-        # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
-        # Taken from https://stackoverflow.com/a/50699209.
-        gc.collect()
-        wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
-        assert len(wrappers) > 0
-        for wrapper in wrappers:
-            wrapper.cache_clear()
+    # with warnings.catch_warnings(record=True):
+    # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
+    # Taken from https://stackoverflow.com/a/50699209.
+    gc.collect()
+    wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
+    assert len(wrappers) > 0
+    for wrapper in wrappers:
+        wrapper.cache_clear()

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -81,9 +81,6 @@ def create_tls_cert(hostname):
 def clear_all_functools_lru_cache() -> None:
     # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
     # Taken from https://stackoverflow.com/a/50699209.
-    import tracemalloc
-
-    tracemalloc.start()
     gc.collect()
     wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
     assert len(wrappers) > 0

--- a/locust/web.py
+++ b/locust/web.py
@@ -244,7 +244,6 @@ class WebUI:
                     as_attachment=True,
                     download_name=_download_csv_suggest_file_name("requests_full_history"),
                     etag=True,
-                    cache_timeout=None,
                     conditional=True,
                     last_modified=None,
                 )


### PR DESCRIPTION
Fix for the following bug: https://github.com/locustio/locust/issues/2147

The `web.py` change is obviously the fix, but without the changes to `uitl.py`, **test_index_with_https** has errors with python 3.7 & 3.8: https://github.com/mikenester/locust/runs/7642011804?check_suite_focus=true
```
Traceback (most recent call last):
  File "/home/runner/work/locust/locust/locust/test/test_web.py", line 463, in tearDown
    super().tearDown()
  File "/home/runner/work/locust/locust/locust/test/testcases.py", line 1[88](https://github.com/mikenester/locust/runs/7642011804?check_suite_focus=true#step:9:89), in tearDown
    clear_all_functools_lru_cache()
  File "/home/runner/work/locust/locust/locust/test/util.py", line 88, in clear_all_functools_lru_cache
    wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
  File "/home/runner/work/locust/locust/locust/test/util.py", line 88, in <listcomp>
    wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
ReferenceError: weakly-referenced object no longer exists
```

With this change, a ResourceWarning appears:

```
ResourceWarning: unclosed file <_io.TextIOWrapper name='web_test_stats.csv' mode='w' encoding='UTF-8'>
  gc.collect()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/runner/work/locust/locust/locust/test/util.py:[84](https://github.com/mikenester/locust/runs/7642594464?check_suite_focus=true#step:9:85): ResourceWarning: unclosed file <_io.TextIOWrapper name='web_test_stats_history.csv' mode='w' encoding='UTF-8'>
  gc.collect()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/runner/work/locust/locust/locust/test/util.py:84: ResourceWarning: unclosed file <_io.TextIOWrapper name='web_test_failures.csv' mode='w' encoding='UTF-8'>
  gc.collect()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/runner/work/locust/locust/locust/test/util.py:84: ResourceWarning: unclosed file <_io.TextIOWrapper name='web_test_exceptions.csv' mode='w' encoding='UTF-8'>
  gc.collect()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```