### PR TITLE
fix(style): about dialog cannot be opened in the startup page 

### DIFF
--- a/locust/static/css/application.css
+++ b/locust/static/css/application.css
@@ -252,7 +252,7 @@ body.running .top .top-content .boxes .top_box.box_status .edit-test, body.spawn
 }
 .dialogs .dialog .padder {
   padding: 30px;
-  padding-top: 0px;
+  padding-top: 20px;
 }
 .dialogs .dialog h2 {
   color: #addf82;
@@ -447,7 +447,7 @@ a.close_link {
 }
 .about .padder {
   padding: 30px;
-  padding-top: 20px;
+  padding-top: 0px;
 }
 
 .tasks ul {

--- a/locust/static/css/application.css
+++ b/locust/static/css/application.css
@@ -438,16 +438,16 @@ body.ready .main {
   border: 3px solid #eee;
   background: #132b21;
   box-shadow: 0 0 60px rgba(0, 0, 0, 0.3);
-  z-index: 1;
+  z-index: 100;
 }
-.about a.close_link {
+a.close_link {
   position: absolute;
   right: 10px;
   top: 10px;
 }
 .about .padder {
   padding: 30px;
-  padding-top: 0px;
+  padding-top: 20px;
 }
 
 .tasks ul {

--- a/locust/static/css/application.css
+++ b/locust/static/css/application.css
@@ -430,7 +430,7 @@ body.ready .main {
   width: 398px;
   position: absolute;
   left: 50%;
-  top: 5px;
+  top: 5%;
   margin-left: -169px;
   border-radius: 5px;
   -moz-border-radius: 5px;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -245,38 +245,37 @@
             {% endif %}
             {% block extended_panes %}{% endblock extended_panes %}
         </div>
+    </div>
+    <div class="about" style="display:none;">
+        <div style="position:relative;">
+            <a href="#" class="close_link">Close</a>
+        </div>
+        <div class="padder">
+            <h1>About</h1>
+            <p>
+                The original idea for Locust was Carl Byström's who made a first proof of concept in June 2010.
+                Jonatan Heyman picked up Locust in January 2011, implemented the current concept of Locust classes
+                and made it work distributed across multiple machines.
+            </p>
+            <p>
+                Jonatan, Carl and Joakim Hamrén has continued the development of Locust at their job,
+                ESN Social Software, who have adopted Locust as an inhouse Open Source project.
+            </p>
 
-        <div class="about" style="display:none;">
-            <div style="position:relative;">
-                <a href="#" class="close_link">Close</a>
-            </div>
-            <div class="padder">
-                <h1>About</h1>
-                <p>
-                    The original idea for Locust was Carl Byström's who made a first proof of concept in June 2010.
-                    Jonatan Heyman picked up Locust in January 2011, implemented the current concept of Locust classes
-                    and made it work distributed across multiple machines.
-                </p>
-                <p>
-                    Jonatan, Carl and Joakim Hamrén has continued the development of Locust at their job,
-                    ESN Social Software, who have adopted Locust as an inhouse Open Source project.
-                </p>
-
-                <h1>Authors and Copyright</h1>
-                <a href="http://cgbystrom.com/">Carl Byström</a> (<a href="https://twitter.com/cgbystrom/">@cgbystrom</a>)<br>
-                <a href="http://heyman.info/">Jonatan Heyman</a> (<a href="https://twitter.com/jonatanheyman/">@jonatanheyman</a>)<br>
-                Joakim Hamrén (<a href="https://twitter.com/Jahaaja/">@jahaaja</a>)<br>
-                <a href="http://esn.me/">ESN Social Software</a> (<a href="https://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
-                Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)
+            <h1>Authors and Copyright</h1>
+            <a href="http://cgbystrom.com/">Carl Byström</a> (<a href="https://twitter.com/cgbystrom/">@cgbystrom</a>)<br>
+            <a href="http://heyman.info/">Jonatan Heyman</a> (<a href="https://twitter.com/jonatanheyman/">@jonatanheyman</a>)<br>
+            Joakim Hamrén (<a href="https://twitter.com/Jahaaja/">@jahaaja</a>)<br>
+            <a href="http://esn.me/">ESN Social Software</a> (<a href="https://twitter.com/uprise_ea/">@uprise_ea</a>)<br>
+            Hugo Heyman (<a href="https://twitter.com/hugoheyman/">@hugoheyman</a>)
 
 
-                <h1>License</h1>
-                Open source licensed under the MIT license.
+            <h1>License</h1>
+            Open source licensed under the MIT license.
 
-                <h2>Version <a href="https://github.com/locustio/locust/releases/tag/{{version}}">{{version}}</a></h2>
-                <br>
-                <a href="https://locust.io/">https://locust.io</a>
-            </div>
+            <h2>Version <a href="https://github.com/locustio/locust/releases/tag/{{version}}">{{version}}</a></h2>
+            <br>
+            <a href="https://locust.io/">https://locust.io</a>
         </div>
     </div>
     <nav class="footer">


### PR DESCRIPTION
Fix these issues:
* When you startup the locust web page first time, in the main page, we cannot open the about page when click the bottom link "About"
* In the "Start new load test" and "Edit running load test" page, the top left close button is not formatted correct(disorderred) , so I corrected the close link position to the same as in the "About" dialog page. see the following screenshot:

1. Modified screenshot, which can show the "About" dialog in the startup page:
![image](https://user-images.githubusercontent.com/5029046/187008172-573c5c6e-5fcc-4a7b-a04e-5e6a0920692c.png)

2. The "close" button in the "Start new load test" dialog page:
![image](https://user-images.githubusercontent.com/5029046/187008159-cad5bd1f-b826-40c9-b7ff-62317d0126a1.png)

2. The "close" button in the "Edit running load test" dialog page:
![image](https://user-images.githubusercontent.com/5029046/187008177-e12f703f-f114-4571-acba-3e6d4e771a04.png)

