### PR TITLE
fix: when run from web with `-f a_file_folder/` caused page title is None as  `locustfile` argument is None

### DIFF
--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -348,6 +348,9 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(self.environment.host, "https://localhost")
         self.assertListEqual(["User1", "User2"], response.json()["user_classes"])
 
+        self.assertIsNotNone(self.environment.locustfile, 'verify locustfile is not empty')
+        self.assertEqual(self.environment.locustfile, "User1,User2", "Verify locustfile variable used in web ui title")
+
         # stop
         gevent.sleep(1)
         response = requests.get("http://127.0.0.1:%i/stop" % self.web_port)

--- a/locust/web.py
+++ b/locust/web.py
@@ -555,6 +555,9 @@ class WebUI:
 
     def _update_user_classes(self, user_classes):
         self.environment.user_classes = list(user_classes.values())
+        # populate the locustfile which used in web ui title only
+        if self.environment.locustfile is None:
+            self.environment.locustfile = ",".join(self.environment.user_classes_by_name.keys())
 
         # Validating UserClasses
         self.environment._remove_user_classes_with_weight_zero()


### PR DESCRIPTION
Steps:
1. run the locust with command `-f a_file_folder/` the locustfile argument is a folder, so in the main.py it will return `locustfile` as `None`
2. When start the test, then the page title `Locust for None` is showed, we need to correct the `locustfile` variable at this situation