### PR TITLE
Bump FastHttpUser/geventhttpclient dependency to 2.0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     requests >=2.23.0
     msgpack >=0.6.2
     pyzmq >=22.2.1, !=23.0.0
-    geventhttpclient >=1.5.1
+    geventhttpclient >=2.0.2
     ConfigArgParse >=1.0
     psutil >=5.6.7
     Flask-BasicAuth >=0.2.0


### PR DESCRIPTION
Not really a strict requirement, but older versions have a couple of issues I dont want people to have to encounter.