### PR TITLE
ft: LoadTestShapes with custom user classes 

### DIFF
--- a/docs/custom-load-shape.rst
+++ b/docs/custom-load-shape.rst
@@ -71,4 +71,3 @@ Extending the return value of the ``tick()`` with the argument ``user_classes`` 
             return None
 
 This shape would create create in the first 10 seconds 10 User of ``UserA``. In the next twenty seconds 40 of type ``UserA / UserB`` and this continues until the stages end.
-Using the extra argument makes it possible to create even more fine grained scenarios.

--- a/docs/custom-load-shape.rst
+++ b/docs/custom-load-shape.rst
@@ -40,3 +40,35 @@ This functionality is further demonstrated in the `examples on github <https://g
 - Step load pattern like Visual Studio
 
 One further method may be helpful for your custom load shapes: `get_current_user_count()`, which returns the total number of active users. This method can be used to prevent advancing to subsequent steps until the desired number of users has been reached. This is especially useful if the initialization process for each user is slow or erratic in how long it takes. If this sounds like your use case, see the `example on github <https://github.com/locustio/locust/tree/master/examples/custom_shape/wait_user_count.py>`_.
+
+
+Extend your shape with custom users
+-----------------------------------
+
+Extending the return value of the ``tick()`` with the argument ``user_classes`` makes it possible to pick the users being created for a ``tick()`` specifically.
+
+.. code-block:: python
+
+    class StagesShapeWithCustomUsers(LoadTestShape):
+
+        stages = [
+            {"duration": 10, "users": 10, "spawn_rate": 10, "user_classes": [UserA]},
+            {"duration": 30, "users": 50, "spawn_rate": 10, "user_classes": [UserA, UserB]},
+            {"duration": 60, "users": 100, "spawn_rate": 10, "user_classes": [UserB]},
+            {"duration": 120, "users": 100, "spawn_rate": 10, "user_classes": [UserA,UserB]},
+
+        def tick(self):
+            run_time = self.get_run_time()
+
+            for stage in self.stages:
+                if run_time < stage["duration"]:
+                    try:
+                        tick_data = (stage["users"], stage["spawn_rate"], stage["user_classes"])
+                    except:
+                        tick_data = (stage["users"], stage["spawn_rate"])
+                    return tick_data
+
+            return None
+
+This shape would create create in the first 10 seconds 10 User of ``UserA``. In the next twenty seconds 40 of type ``UserA / UserB`` and this continues until the stages end.
+Using the extra argument makes it possible to create even more fine grained scenarios.

--- a/examples/custom_shape/staging_user_classes.py
+++ b/examples/custom_shape/staging_user_classes.py
@@ -12,6 +12,7 @@ class WebsiteUserA(HttpUser):
     wait_time = constant(0.5)
     tasks = [UserTasks]
 
+
 class WebsiteUserB(HttpUser):
     wait_time = constant(0.5)
     tasks = [UserTasks]
@@ -50,7 +51,7 @@ class StagesShapeWithCustomUsers(LoadTestShape):
                 # Not the smartest solution, TODO: find something better
                 try:
                     tick_data = (stage["users"], stage["spawn_rate"], stage["user_classes"])
-                except:
+                except KeyError:
                     tick_data = (stage["users"], stage["spawn_rate"])
                 return tick_data
 

--- a/examples/custom_shape/staging_user_classes.py
+++ b/examples/custom_shape/staging_user_classes.py
@@ -1,0 +1,57 @@
+from locust import HttpUser, TaskSet, task, constant
+from locust import LoadTestShape
+
+
+class UserTasks(TaskSet):
+    @task
+    def get_root(self):
+        self.client.get("/")
+
+
+class WebsiteUserA(HttpUser):
+    wait_time = constant(0.5)
+    tasks = [UserTasks]
+
+class WebsiteUserB(HttpUser):
+    wait_time = constant(0.5)
+    tasks = [UserTasks]
+
+
+class StagesShapeWithCustomUsers(LoadTestShape):
+    """
+    A simply load test shape class that has different user and spawn_rate at
+    different stages.
+
+    Keyword arguments:
+
+        stages -- A list of dicts, each representing a stage with the following keys:
+            duration -- When this many seconds pass the test is advanced to the next stage
+            users -- Total user count
+            spawn_rate -- Number of users to start/stop per second
+            stop -- A boolean that can stop that test at a specific stage
+
+        stop_at_end -- Can be set to stop once all stages have run.
+    """
+
+    stages = [
+        {"duration": 60, "users": 10, "spawn_rate": 10, "user_classes": [WebsiteUserA]},
+        {"duration": 100, "users": 50, "spawn_rate": 10, "user_classes": [WebsiteUserB]},
+        {"duration": 180, "users": 100, "spawn_rate": 10, "user_classes": [WebsiteUserA]},
+        {"duration": 220, "users": 30, "spawn_rate": 10},
+        {"duration": 230, "users": 10, "spawn_rate": 10},
+        {"duration": 240, "users": 1, "spawn_rate": 1},
+    ]
+
+    def tick(self):
+        run_time = self.get_run_time()
+
+        for stage in self.stages:
+            if run_time < stage["duration"]:
+                # Not the smartest solution, TODO: find something better
+                try:
+                    tick_data = (stage["users"], stage["spawn_rate"], stage["user_classes"])
+                except:
+                    tick_data = (stage["users"], stage["spawn_rate"])
+                return tick_data
+
+        return None

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -172,8 +172,8 @@ class UsersDispatcher(Iterator):
         :param spawn_rate: The spawn rate
         :param user_classes: The user classes to be used for the new dispatch
         """
-        if user_classes is not None and self._user_classes != user_classes:
-            self._user_classes = user_classes
+        if user_classes is not None and self._user_classes != sorted(user_classes, key=attrgetter("__name__")):
+            self._user_classes = sorted(user_classes, key=attrgetter("__name__"))
             self._user_generator = self._user_gen()
 
         self._target_user_count = target_user_count

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -172,7 +172,7 @@ class UsersDispatcher(Iterator):
         :param spawn_rate: The spawn rate
         :param user_classes: The user classes to be used for the new dispatch
         """
-        if user_classes is not None:
+        if user_classes is not None and user_classes != self._original_user_classes:
             self._user_classes = user_classes
             self._user_generator = self._user_gen()
 

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -56,6 +56,7 @@ class UsersDispatcher(Iterator):
         """
         self._worker_nodes = worker_nodes
         self._sort_workers()
+        self._original_user_classes = sorted(user_classes, key=attrgetter("__name__"))
         self._user_classes = sorted(user_classes, key=attrgetter("__name__"))
 
         assert len(user_classes) > 0
@@ -229,7 +230,7 @@ class UsersDispatcher(Iterator):
         # Reset users before recalculating since the current users is used to calculate how many
         # fixed users to add.
         self._users_on_workers = {
-            worker_node.id: {user_class.__name__: 0 for user_class in self._user_classes}
+            worker_node.id: {user_class.__name__: 0 for user_class in self._original_user_classes}
             for worker_node in self._worker_nodes
         }
         self._try_dispatch_fixed = True
@@ -330,7 +331,7 @@ class UsersDispatcher(Iterator):
         worker_gen = itertools.cycle(self._worker_nodes)
 
         users_on_workers = {
-            worker_node.id: {user_class.__name__: 0 for user_class in self._user_classes}
+            worker_node.id: {user_class.__name__: 0 for user_class in self._original_user_classes}
             for worker_node in self._worker_nodes
         }
 

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -163,12 +163,13 @@ class UsersDispatcher(Iterator):
 
         self._dispatch_in_progress = False
 
-    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: any) -> None:
+    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: Optional[List[User]]) -> None:
         """
         Initialize a new dispatch cycle.
 
         :param target_user_count: The desired user count at the end of the dispatch cycle
         :param spawn_rate: The spawn rate
+        :param user_classes: The user classes to be used for the new dispatch
         """
         self._user_classes = user_classes
         self._user_generator = self._user_gen()

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -163,13 +163,16 @@ class UsersDispatcher(Iterator):
 
         self._dispatch_in_progress = False
 
-    def new_dispatch(self, target_user_count: int, spawn_rate: float) -> None:
+    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: any) -> None:
         """
         Initialize a new dispatch cycle.
 
         :param target_user_count: The desired user count at the end of the dispatch cycle
         :param spawn_rate: The spawn rate
         """
+        self._user_classes = user_classes
+        self._user_generator = self._user_gen()
+
         self._target_user_count = target_user_count
 
         self._spawn_rate = spawn_rate

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -172,7 +172,7 @@ class UsersDispatcher(Iterator):
         :param spawn_rate: The spawn rate
         :param user_classes: The user classes to be used for the new dispatch
         """
-        if user_classes is not None and user_classes != self._original_user_classes:
+        if user_classes is not None and self._user_classes != user_classes:
             self._user_classes = user_classes
             self._user_generator = self._user_gen()
 

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -163,7 +163,7 @@ class UsersDispatcher(Iterator):
 
         self._dispatch_in_progress = False
 
-    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: Optional[List[User]]) -> None:
+    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: Optional[List] = None) -> None:
         """
         Initialize a new dispatch cycle.
 
@@ -171,8 +171,9 @@ class UsersDispatcher(Iterator):
         :param spawn_rate: The spawn rate
         :param user_classes: The user classes to be used for the new dispatch
         """
-        self._user_classes = user_classes
-        self._user_generator = self._user_gen()
+        if user_classes is not None:
+            self._user_classes = user_classes
+            self._user_generator = self._user_gen()
 
         self._target_user_count = target_user_count
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -118,7 +118,7 @@ class Runner:
         self.state = STATE_INIT
         self.spawning_greenlet: Optional[gevent.Greenlet] = None
         self.shape_greenlet: Optional[gevent.Greenlet] = None
-        self.shape_last_state: Union[Tuple[int, float], Tuple[int, float, Optional[List[Type[User]]]], None] = None
+        self.shape_last_tick: Union[Tuple[int, float], Tuple[int, float, Optional[List[Type[User]]]], None] = None
         self.current_cpu_usage: int = 0
         self.cpu_warning_emitted: bool = False
         self.worker_cpu_warning_emitted: bool = False
@@ -362,9 +362,9 @@ class Runner:
                 else:
                     self.stop()
                 self.shape_greenlet = None
-                self.shape_last_state = None
+                self.shape_last_tick = None
                 return
-            elif self.shape_last_state == current_tick:
+            elif self.shape_last_tick == current_tick:
                 gevent.sleep(1)
             else:
                 if len(current_tick) == 2:
@@ -387,7 +387,7 @@ class Runner:
                 #        `(user_count - prev_user_count) / spawn_rate` in order to limit the runtime
                 #        of each load test shape stage.
                 self.start(user_count=user_count, spawn_rate=spawn_rate, user_classes=user_classes)
-                self.shape_last_state = current_tick
+                self.shape_last_tick = current_tick
 
     def stop(self) -> None:
         """
@@ -410,7 +410,7 @@ class Runner:
             if self.shape_greenlet is not None:
                 self.shape_greenlet.kill(block=True)
                 self.shape_greenlet = None
-            self.shape_last_state = None
+            self.shape_last_tick = None
 
         self.stop_users(self.user_classes_count)
 
@@ -889,7 +889,7 @@ class MasterRunner(DistributedRunner):
             ):
                 self.shape_greenlet.kill(block=True)
                 self.shape_greenlet = None
-                self.shape_last_state = None
+                self.shape_last_tick = None
 
             self._users_dispatcher = None
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -476,6 +476,7 @@ class LocalRunner(Runner):
         :param wait: If True calls to this method will block until all users are spawned.
                      If False (the default), a greenlet that spawns the users will be
                      started and the call to this method will return immediately.
+        :param user_classes: The user classes to be dispatched
         """
         self.target_user_count = user_count
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -118,7 +118,7 @@ class Runner:
         self.state = STATE_INIT
         self.spawning_greenlet: Optional[gevent.Greenlet] = None
         self.shape_greenlet: Optional[gevent.Greenlet] = None
-        self.shape_last_state: Tuple[int, float] | Tuple[int, float, Optional[List[Type[User]]]] | None = None
+        self.shape_last_state: Union[Tuple[int, float], Tuple[int, float, Optional[List[Type[User]]]], None] = None
         self.current_cpu_usage: int = 0
         self.cpu_warning_emitted: bool = False
         self.worker_cpu_warning_emitted: bool = False
@@ -352,7 +352,7 @@ class Runner:
     def shape_worker(self) -> None:
         logger.info("Shape worker starting")
         while self.state == STATE_INIT or self.state == STATE_SPAWNING or self.state == STATE_RUNNING:
-            new_state: Tuple[int, float] | Tuple[int, float, Optional[List[Type[User]]]] | None = (
+            new_state: Union[Tuple[int, float], Tuple[int, float, Optional[List[Type[User]]]], None] = (
                 self.environment.shape_class.tick() if self.environment.shape_class is not None else None
             )
             if new_state is None:
@@ -494,7 +494,7 @@ class LocalRunner(Runner):
         if wait and user_count - self.user_count > spawn_rate:
             raise ValueError("wait is True but the amount of users to add is greater than the spawn rate")
 
-        #if user_classes is None:
+        # if user_classes is None:
         #    user_classes = self.user_classes
 
         for user_class in self.user_classes:
@@ -756,7 +756,7 @@ class MasterRunner(DistributedRunner):
             logger.warning("You can't start a distributed test before at least one worker processes has connected")
             return
 
-        #if user_classes is None:
+        # if user_classes is None:
         #    user_classes = self.user_classes
 
         for user_class in self.user_classes:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -330,7 +330,7 @@ class Runner:
             gevent.sleep(CPU_MONITOR_INTERVAL)
 
     @abstractmethod
-    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:list=None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:Optional[List[User]]=None) -> None:
         ...
 
     def start_shape(self) -> None:
@@ -550,7 +550,7 @@ class LocalRunner(Runner):
 
         self.environment.events.spawning_complete.fire(user_count=sum(self.target_user_classes_count.values()))
 
-    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:list = None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes: Optional[List[User]] = None) -> None:
         if spawn_rate > 100:
             logger.warning(
                 "Your selected spawn rate is very high (>100), and this is known to sometimes cause issues. Do you really need to ramp up that fast?"
@@ -737,7 +737,7 @@ class MasterRunner(DistributedRunner):
             warning_emitted = True
         return warning_emitted
 
-    def start(self, user_count: int, spawn_rate: float, wait=False, user_classes:list = None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait=False, user_classes: Optional[List[User]] = None) -> None:
         self.spawning_completed = False
 
         self.target_user_count = user_count
@@ -1215,7 +1215,7 @@ class WorkerRunner(DistributedRunner):
 
         self.environment.events.user_error.add_listener(on_user_error)
 
-    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:list = None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:Optional[List[User]] = None) -> None:
         raise NotImplementedError("use start_worker")
 
     def start_worker(self, user_classes_count: Dict[str, int], **kwargs) -> None:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -494,10 +494,10 @@ class LocalRunner(Runner):
         if wait and user_count - self.user_count > spawn_rate:
             raise ValueError("wait is True but the amount of users to add is greater than the spawn rate")
 
-        if user_classes is None:
-            user_classes = self.user_classes
+        #if user_classes is None:
+        #    user_classes = self.user_classes
 
-        for user_class in user_classes:
+        for user_class in self.user_classes:
             if self.environment.host:
                 user_class.host = self.environment.host
 
@@ -756,10 +756,10 @@ class MasterRunner(DistributedRunner):
             logger.warning("You can't start a distributed test before at least one worker processes has connected")
             return
 
-        if user_classes is None:
-            user_classes = self.user_classes
+        #if user_classes is None:
+        #    user_classes = self.user_classes
 
-        for user_class in user_classes:
+        for user_class in self.user_classes:
             if self.environment.host:
                 user_class.host = self.environment.host
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -330,7 +330,7 @@ class Runner:
             gevent.sleep(CPU_MONITOR_INTERVAL)
 
     @abstractmethod
-    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:Optional[List[User]]=None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes: Optional[List[User]] = None) -> None:
         ...
 
     def start_shape(self) -> None:
@@ -1215,7 +1215,7 @@ class WorkerRunner(DistributedRunner):
 
         self.environment.events.user_error.add_listener(on_user_error)
 
-    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes:Optional[List[User]] = None) -> None:
+    def start(self, user_count: int, spawn_rate: float, wait: bool = False, user_classes: Optional[List[User]] = None) -> None:
         raise NotImplementedError("use start_worker")
 
     def start_worker(self, user_classes_count: Dict[str, int], **kwargs) -> None:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -479,7 +479,8 @@ class LocalRunner(Runner):
         :param wait: If True calls to this method will block until all users are spawned.
                      If False (the default), a greenlet that spawns the users will be
                      started and the call to this method will return immediately.
-        :param user_classes: The user classes to be dispatched
+        :param user_classes: The user classes to be dispatched, None indicates to use the classes the dispatcher was
+                             invoked with.
         """
         self.target_user_count = user_count
 
@@ -494,8 +495,6 @@ class LocalRunner(Runner):
         if wait and user_count - self.user_count > spawn_rate:
             raise ValueError("wait is True but the amount of users to add is greater than the spawn rate")
 
-        # if user_classes is None:
-        #    user_classes = self.user_classes
 
         for user_class in self.user_classes:
             if self.environment.host:
@@ -755,9 +754,6 @@ class MasterRunner(DistributedRunner):
         if not num_workers:
             logger.warning("You can't start a distributed test before at least one worker processes has connected")
             return
-
-        # if user_classes is None:
-        #    user_classes = self.user_classes
 
         for user_class in self.user_classes:
             if self.environment.host:

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Tuple, List, Type
+from typing import Optional, Tuple, List, Type, Union
 
 from . import User
 from .runners import Runner
@@ -35,7 +35,7 @@ class LoadTestShape:
         """
         return self.runner.user_count
 
-    def tick(self) -> Tuple[int, float] | Tuple[int, float, Optional[List[Type[User]]]] | None:
+    def tick(self) -> Union[Tuple[int, float], Tuple[int, float, Optional[List[Type[User]]]], None]:
         """
         Returns a tuple with 2 elements to control the running load test:
 

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,5 +1,7 @@
 import time
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
+
+from . import User
 from .runners import Runner
 
 
@@ -33,7 +35,7 @@ class LoadTestShape:
         """
         return self.runner.user_count
 
-    def tick(self) -> Optional[Tuple[int, float, any]]:
+    def tick(self) -> Optional[Tuple[int, float], Tuple[int, float, Optional[List[User]]]]:
         """
         Returns a tuple with 2 elements to control the running load test:
 

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -41,7 +41,7 @@ class LoadTestShape:
 
             user_count -- Total user count
             spawn_rate -- Number of users to start/stop per second when changing number of users
-            user_classes -- None or a List of userclasses to be spawend in it tick
+            user_classes -- None or a List of userclasses to be spawned in it tick
         If `None` is returned then the running load test will be stopped.
 
         """

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -35,7 +35,7 @@ class LoadTestShape:
         """
         return self.runner.user_count
 
-    def tick(self) -> Optional[Tuple[int, float], Tuple[int, float, Optional[List[User]]]]:
+    def tick(self) -> Tuple[int, float] | Tuple[int, float, Optional[List[User]]] | None:
         """
         Returns a tuple with 2 elements to control the running load test:
 

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -33,13 +33,13 @@ class LoadTestShape:
         """
         return self.runner.user_count
 
-    def tick(self) -> Optional[Tuple[int, float]]:
+    def tick(self) -> Optional[Tuple[int, float, any]]:
         """
         Returns a tuple with 2 elements to control the running load test:
 
             user_count -- Total user count
             spawn_rate -- Number of users to start/stop per second when changing number of users
-
+            user_classes -- None or a List of userclasses to be spawend in it tick
         If `None` is returned then the running load test will be stopped.
 
         """

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, Type
 
 from . import User
 from .runners import Runner
@@ -35,7 +35,7 @@ class LoadTestShape:
         """
         return self.runner.user_count
 
-    def tick(self) -> Tuple[int, float] | Tuple[int, float, Optional[List[User]]] | None:
+    def tick(self) -> Tuple[int, float] | Tuple[int, float, Optional[List[Type[User]]]] | None:
         """
         Returns a tuple with 2 elements to control the running load test:
 

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -12,7 +12,6 @@ _TOLERANCE = 0.025
 
 
 class TestRampUpUsersFromZero(unittest.TestCase):
-
     def test_ramp_up_users_to_3_workers_with_spawn_rate_of_0_5(self):
         """Final distribution should be {"User1": 3, "User2": 3, "User3": 3}"""
 
@@ -3634,6 +3633,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                                     user_class.fixed_count,
                                 )
 
+
 class TestRampUpDifferentUsers(unittest.TestCase):
     def test_ramp_up_different_users_for_each_dispatch(self):
         class User1(User):
@@ -3649,31 +3649,18 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         sleep_time = 0.2
 
-        user_dispatcher = UsersDispatcher(
-            worker_nodes=[worker_node1], user_classes=[User1, User2, User3]
-        )
+        user_dispatcher = UsersDispatcher(worker_nodes=[worker_node1], user_classes=[User1, User2, User3])
 
         user_dispatcher.new_dispatch(target_user_count=3, spawn_rate=3)
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 1, "User2": 1, "User3": 1}
-            }
-        )
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 1, "User2": 1, "User3": 1}})
         user_dispatcher.new_dispatch(target_user_count=4, spawn_rate=1, user_classes=[User1])
-        self.assertDictEqual(next(user_dispatcher), {
-            "1": {"User1": 2, "User2": 1, "User3": 1}
-        })
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 2, "User2": 1, "User3": 1}})
 
         user_dispatcher.new_dispatch(target_user_count=5, spawn_rate=1, user_classes=[User2])
-        self.assertDictEqual(next(user_dispatcher), {
-            "1": {"User1": 2, "User2": 2, "User3": 1}
-        })
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 2, "User2": 2, "User3": 1}})
 
         user_dispatcher.new_dispatch(target_user_count=6, spawn_rate=1, user_classes=[User3])
-        self.assertDictEqual(next(user_dispatcher), {
-            "1": {"User1": 2, "User2": 2, "User3": 2}
-        })
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 2, "User2": 2, "User3": 2}})
 
     def test_ramp_up_only_one_kind_of_user(self):
         class User1(User):
@@ -3689,17 +3676,10 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         sleep_time = 0.2
 
-        user_dispatcher = UsersDispatcher(
-            worker_nodes=[worker_node1], user_classes=[User1, User2, User3]
-        )
+        user_dispatcher = UsersDispatcher(worker_nodes=[worker_node1], user_classes=[User1, User2, User3])
 
         user_dispatcher.new_dispatch(target_user_count=10, spawn_rate=10, user_classes=[User2])
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 0, "User2": 10, "User3": 0}
-            }
-        )
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 0, "User2": 10, "User3": 0}})
 
     def test_ramp_up_first_half_user1_second_half_user2(self):
         class User1(User):
@@ -3715,25 +3695,13 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         sleep_time = 0.2
 
-        user_dispatcher = UsersDispatcher(
-            worker_nodes=[worker_node1], user_classes=[User1, User2, User3]
-        )
+        user_dispatcher = UsersDispatcher(worker_nodes=[worker_node1], user_classes=[User1, User2, User3])
 
         user_dispatcher.new_dispatch(target_user_count=10, spawn_rate=10, user_classes=[User2])
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 0, "User2": 10, "User3": 0}
-            }
-        )
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 0, "User2": 10, "User3": 0}})
 
         user_dispatcher.new_dispatch(target_user_count=40, spawn_rate=30, user_classes=[User3])
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 0, "User2": 10, "User3": 30}
-            }
-        )
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 0, "User2": 10, "User3": 30}})
 
     def test_ramp_up_first_one_user_then_all_classes(self):
         class User1(User):
@@ -3749,26 +3717,13 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         sleep_time = 0.2
 
-        user_dispatcher = UsersDispatcher(
-            worker_nodes=[worker_node1], user_classes=[User1, User2, User3]
-        )
+        user_dispatcher = UsersDispatcher(worker_nodes=[worker_node1], user_classes=[User1, User2, User3])
 
         user_dispatcher.new_dispatch(target_user_count=10, spawn_rate=10, user_classes=[User2])
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 0, "User2": 10, "User3": 0}
-            }
-        )
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 0, "User2": 10, "User3": 0}})
 
         user_dispatcher.new_dispatch(target_user_count=40, spawn_rate=30, user_classes=[User1, User2, User3])
-        self.assertDictEqual(
-            next(user_dispatcher),
-            {
-                "1": {"User1": 10, "User2": 20, "User3": 10}
-            }
-        )
-
+        self.assertDictEqual(next(user_dispatcher), {"1": {"User1": 10, "User2": 20, "User3": 10}})
 
     def test_ramp_up_different_users_each_dispatch_multiple_worker(self):
         class User1(User):
@@ -3797,7 +3752,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "1": {"User1": 3, "User2": 0, "User3": 0},
                 "2": {"User1": 0, "User2": 3, "User3": 0},
                 "3": {"User1": 0, "User2": 0, "User3": 3},
-            }
+            },
         )
 
         user_dispatcher.new_dispatch(target_user_count=12, spawn_rate=3, user_classes=[User3])
@@ -3807,7 +3762,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "1": {"User1": 3, "User2": 0, "User3": 1},
                 "2": {"User1": 0, "User2": 3, "User3": 1},
                 "3": {"User1": 0, "User2": 0, "User3": 4},
-            }
+            },
         )
 
         user_dispatcher.new_dispatch(target_user_count=15, spawn_rate=3, user_classes=[User2])
@@ -3817,7 +3772,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "1": {"User1": 3, "User2": 1, "User3": 1},
                 "2": {"User1": 0, "User2": 4, "User3": 1},
                 "3": {"User1": 0, "User2": 1, "User3": 4},
-            }
+            },
         )
 
         user_dispatcher.new_dispatch(target_user_count=18, spawn_rate=3, user_classes=[User1])
@@ -3827,7 +3782,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "1": {"User1": 4, "User2": 1, "User3": 1},
                 "2": {"User1": 1, "User2": 4, "User3": 1},
                 "3": {"User1": 1, "User2": 1, "User3": 4},
-            }
+            },
         )
 
     def test_ramp_up_one_user_class_multiple_worker(self):
@@ -3857,7 +3812,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "1": {"User1": 0, "User2": 20, "User3": 0},
                 "2": {"User1": 0, "User2": 20, "User3": 0},
                 "3": {"User1": 0, "User2": 20, "User3": 0},
-            }
+            },
         )
 
     def test_ramp_down_custom_user_classes_respect_weighting(self):
@@ -3875,54 +3830,61 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         user_dispatcher.new_dispatch(target_user_count=20, spawn_rate=20, user_classes=[User3])
         dispatched_users = next(user_dispatcher)
-        self.assertDictEqual(dispatched_users,
+        self.assertDictEqual(
+            dispatched_users,
             {
                 "1": {"User1": 0, "User2": 0, "User3": 7},
                 "2": {"User1": 0, "User2": 0, "User3": 7},
                 "3": {"User1": 0, "User2": 0, "User3": 6},
-            })
+            },
+        )
 
         user_dispatcher.new_dispatch(target_user_count=9, spawn_rate=20, user_classes=[User3])
         dispatched_users = next(user_dispatcher)
-        self.assertDictEqual(dispatched_users,
+        self.assertDictEqual(
+            dispatched_users,
             {
                 "1": {"User1": 0, "User2": 0, "User3": 3},
                 "2": {"User1": 0, "User2": 0, "User3": 3},
                 "3": {"User1": 0, "User2": 0, "User3": 3},
-            })
+            },
+        )
 
         user_dispatcher.new_dispatch(target_user_count=3, spawn_rate=20, user_classes=[User1, User2, User3])
         dispatched_users = next(user_dispatcher)
-        self.assertDictEqual(dispatched_users,
-                             {
-                                 "1": {"User1": 0, "User2": 0, "User3": 1},
-                                 "2": {"User1": 0, "User2": 0, "User3": 1},
-                                 "3": {"User1": 0, "User2": 0, "User3": 1},
-                             })
+        self.assertDictEqual(
+            dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 0, "User3": 1},
+                "2": {"User1": 0, "User2": 0, "User3": 1},
+                "3": {"User1": 0, "User2": 0, "User3": 1},
+            },
+        )
 
         user_dispatcher.new_dispatch(target_user_count=21, spawn_rate=21, user_classes=[User1, User2, User3])
         dispatched_users = next(user_dispatcher)
-        self.assertDictEqual(dispatched_users,
+        self.assertDictEqual(
+            dispatched_users,
             {
-                "1": {"User1": 0, "User2": 6, "User3": 1}, # 7
-                "2": {"User1": 0, "User2": 0, "User3": 7}, # 7
-                "3": {"User1": 6, "User2": 0, "User3": 1}, # 7
-            })
+                "1": {"User1": 0, "User2": 6, "User3": 1},  # 7
+                "2": {"User1": 0, "User2": 0, "User3": 7},  # 7
+                "3": {"User1": 6, "User2": 0, "User3": 1},  # 7
+            },
+        )
 
         user_dispatcher.new_dispatch(target_user_count=9, spawn_rate=20, user_classes=[User1, User2, User3])
         dispatched_users = next(user_dispatcher)
 
         # this is disrespecting the weighting
 
-        self.assertDictEqual(dispatched_users,
-                             {
-                                 "1": {"User1": 0, "User2": 2, "User3": 1},
-                                 "2": {"User1": 0, "User2": 0, "User3": 3},
-                                 "3": {"User1": 2, "User2": 0, "User3": 1},
-                             })
-
-
-
+        self.assertDictEqual(
+            dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 2, "User3": 1},
+                "2": {"User1": 0, "User2": 0, "User3": 3},
+                "3": {"User1": 2, "User2": 0, "User3": 1},
+            },
+        )
 
     def test_remove_worker_during_ramp_up_custom_classes(self):
         class User1(User):
@@ -3950,13 +3912,15 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         dispatched_users = next(users_dispatcher)
         delta = time.perf_counter() - ts
         self.assertTrue(0 <= delta <= _TOLERANCE, delta)
-        self.assertDictEqual(dispatched_users,
+        self.assertDictEqual(
+            dispatched_users,
             {
                 "1": {"User1": 0, "User2": 1, "User3": 0},
                 "2": {"User1": 0, "User2": 1, "User3": 0},
                 "3": {"User1": 0, "User2": 1, "User3": 0},
-            })
-        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 3, "User3": 0})
+            },
+        )
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 0, "User2": 3, "User3": 0})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 1)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 1)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 1)
@@ -3966,7 +3930,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         dispatched_users = next(users_dispatcher)
         delta = time.perf_counter() - ts
         self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
-        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 6, "User3": 0})
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 0, "User2": 6, "User3": 0})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 2)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 2)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 2)
@@ -3982,12 +3946,10 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         dispatched_users = next(users_dispatcher)
         delta = time.perf_counter() - ts
         self.assertTrue(0 <= delta <= _TOLERANCE, f"Expected re-balance dispatch to be instantaneous but got {delta}s")
-        self.assertDictEqual(dispatched_users,
-                             {
-                                 "1":{"User1": 0, "User2": 3, "User3": 0},
-                                 "3": {"User1": 0, "User2": 3, "User3": 0}
-                             })
-        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 6, "User3": 0})
+        self.assertDictEqual(
+            dispatched_users, {"1": {"User1": 0, "User2": 3, "User3": 0}, "3": {"User1": 0, "User2": 3, "User3": 0}}
+        )
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 0, "User2": 6, "User3": 0})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 3)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
 
@@ -3998,25 +3960,19 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         dispatched_users = next(users_dispatcher)
         delta = time.perf_counter() - ts
         self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
-        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 9, "User3": 0})
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 0, "User2": 9, "User3": 0})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 5)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 4)
 
-
-
         # New dispatch
-        users_dispatcher.new_dispatch(16,7,[User3])
+        users_dispatcher.new_dispatch(16, 7, [User3])
         dispatched_users = next(users_dispatcher)
-        self.assertDictEqual(dispatched_users,
-                             {
-                                 "1": {"User1": 0, "User2": 5, "User3": 3},
-                                 "3": {"User1": 0, "User2": 4, "User3": 4}
-                             })
-        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 9, "User3": 7})
+        self.assertDictEqual(
+            dispatched_users, {"1": {"User1": 0, "User2": 5, "User3": 3}, "3": {"User1": 0, "User2": 4, "User3": 4}}
+        )
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 0, "User2": 9, "User3": 7})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 8)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 8)
-
-
 
     def test_add_worker_during_ramp_up_custom_classes(self):
         class User1(User):
@@ -4096,15 +4052,13 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 4)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
 
-        #New Dispatch
+        # New Dispatch
         users_dispatcher.new_dispatch(target_user_count=18, spawn_rate=7, user_classes=[User3])
         dispatched_users = next(users_dispatcher)
         self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 11, "User2": 0, "User3": 7})
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 6)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 6)
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 6)
-
-
 
 
 def _aggregate_dispatched_users(d: Dict[str, Dict[str, int]]) -> Dict[str, int]:

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -3863,6 +3863,7 @@ class TestRampUpDifferentUsers(unittest.TestCase):
 
         user_dispatcher.new_dispatch(target_user_count=21, spawn_rate=21, user_classes=[User1, User2, User3])
         dispatched_users = next(user_dispatcher)
+        print(dispatched_users)
         self.assertDictEqual(
             dispatched_users,
             {

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -1010,6 +1010,49 @@ class TestRampDownUsersToZero(unittest.TestCase):
         delta = time.perf_counter() - ts
         self.assertTrue(0 <= delta <= _TOLERANCE, delta)
 
+    # def test_ramp_down_users_on_workers_respecting_weight(self):
+    #     class User1(User):
+    #         weight = 1
+    #
+    #     class User2(User):
+    #         weight = 1
+    #
+    #     class User3(User):
+    #         weight = 1
+    #
+    #     user_classes = [User1, User2, User3]
+    #     workers = [WorkerNode(str(i + 1)) for i in range(3)]
+    #
+    #     user_dispatcher = UsersDispatcher(worker_nodes= workers, user_classes = user_classes)
+    #     user_dispatcher.new_dispatch(target_user_count=7, spawn_rate=7)
+    #
+    #     dispatched_users = next(user_dispatcher)
+    #     self.assertDictEqual(dispatched_users,
+    #                          {
+    #                              "1": {"User1": 3, "User2": 0, "User3": 0},
+    #                              "2": {"User1": 0, "User2": 2, "User3": 0},
+    #                              "3": {"User1": 0, "User2": 0, "User3": 2}
+    #                          })
+    #
+    #     user_dispatcher.new_dispatch(target_user_count=16, spawn_rate=9)
+    #     dispatched_users = next(user_dispatcher)
+    #     self.assertDictEqual(dispatched_users,
+    #                          {
+    #                              "1": {"User1": 6, "User2": 0, "User3": 0},
+    #                              "2": {"User1": 0, "User2": 5, "User3": 0},
+    #                              "3": {"User1": 0, "User2": 0, "User3": 5}
+    #                          })
+    #
+    #     user_dispatcher.new_dispatch(target_user_count=3, spawn_rate=15)
+    #     dispatched_users = next(user_dispatcher)
+    #     self.assertDictEqual(dispatched_users,
+    #                          {
+    #                              "1": {"User1": 1, "User2": 0, "User3": 0},
+    #                              "2": {"User1": 0, "User2": 1, "User3": 0},
+    #                              "3": {"User1": 0, "User2": 0, "User3": 1}
+    #                          })
+    #
+
     def test_ramp_down_users_to_3_workers_with_spawn_rate_of_1(self):
         class User1(User):
             weight = 1
@@ -3816,6 +3859,252 @@ class TestRampUpDifferentUsers(unittest.TestCase):
                 "3": {"User1": 0, "User2": 20, "User3": 0},
             }
         )
+
+    def test_ramp_down_custom_user_classes_respect_weighting(self):
+        class User1(User):
+            weight = 1
+
+        class User2(User):
+            weight = 1
+
+        class User3(User):
+            weight = 1
+
+        worker_nodes = [WorkerNode(str(i + 1)) for i in range(3)]
+        user_dispatcher = UsersDispatcher(worker_nodes=worker_nodes, user_classes=[User1, User2, User3])
+
+        user_dispatcher.new_dispatch(target_user_count=20, spawn_rate=20, user_classes=[User3])
+        dispatched_users = next(user_dispatcher)
+        self.assertDictEqual(dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 0, "User3": 7},
+                "2": {"User1": 0, "User2": 0, "User3": 7},
+                "3": {"User1": 0, "User2": 0, "User3": 6},
+            })
+
+        user_dispatcher.new_dispatch(target_user_count=9, spawn_rate=20, user_classes=[User3])
+        dispatched_users = next(user_dispatcher)
+        self.assertDictEqual(dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 0, "User3": 3},
+                "2": {"User1": 0, "User2": 0, "User3": 3},
+                "3": {"User1": 0, "User2": 0, "User3": 3},
+            })
+
+        user_dispatcher.new_dispatch(target_user_count=3, spawn_rate=20, user_classes=[User1, User2, User3])
+        dispatched_users = next(user_dispatcher)
+        self.assertDictEqual(dispatched_users,
+                             {
+                                 "1": {"User1": 0, "User2": 0, "User3": 1},
+                                 "2": {"User1": 0, "User2": 0, "User3": 1},
+                                 "3": {"User1": 0, "User2": 0, "User3": 1},
+                             })
+
+        user_dispatcher.new_dispatch(target_user_count=21, spawn_rate=21, user_classes=[User1, User2, User3])
+        dispatched_users = next(user_dispatcher)
+        self.assertDictEqual(dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 6, "User3": 1}, # 7
+                "2": {"User1": 0, "User2": 0, "User3": 7}, # 7
+                "3": {"User1": 6, "User2": 0, "User3": 1}, # 7
+            })
+
+        user_dispatcher.new_dispatch(target_user_count=9, spawn_rate=20, user_classes=[User1, User2, User3])
+        dispatched_users = next(user_dispatcher)
+
+        # this is disrespecting the weighting
+
+        self.assertDictEqual(dispatched_users,
+                             {
+                                 "1": {"User1": 0, "User2": 2, "User3": 1},
+                                 "2": {"User1": 0, "User2": 0, "User3": 3},
+                                 "3": {"User1": 2, "User2": 0, "User3": 1},
+                             })
+
+
+
+
+    def test_remove_worker_during_ramp_up_custom_classes(self):
+        class User1(User):
+            weight = 1
+
+        class User2(User):
+            weight = 1
+
+        class User3(User):
+            weight = 1
+
+        user_classes = [User1, User2, User3]
+
+        worker_nodes = [WorkerNode(str(i + 1)) for i in range(3)]
+
+        users_dispatcher = UsersDispatcher(worker_nodes=worker_nodes, user_classes=user_classes)
+
+        sleep_time = 0.2  # Speed-up test
+
+        users_dispatcher.new_dispatch(target_user_count=9, spawn_rate=3, user_classes=[User2])
+        users_dispatcher._wait_between_dispatch = sleep_time
+
+        # Dispatch iteration 1
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(0 <= delta <= _TOLERANCE, delta)
+        self.assertDictEqual(dispatched_users,
+            {
+                "1": {"User1": 0, "User2": 1, "User3": 0},
+                "2": {"User1": 0, "User2": 1, "User3": 0},
+                "3": {"User1": 0, "User2": 1, "User3": 0},
+            })
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 3, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 1)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 1)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 1)
+
+        # Dispatch iteration 2
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 6, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 2)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 2)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 2)
+
+        self.assertFalse(users_dispatcher._rebalance)
+
+        users_dispatcher.remove_worker(worker_nodes[1])
+
+        self.assertTrue(users_dispatcher._rebalance)
+
+        # Re-balance
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(0 <= delta <= _TOLERANCE, f"Expected re-balance dispatch to be instantaneous but got {delta}s")
+        self.assertDictEqual(dispatched_users,
+                             {
+                                 "1":{"User1": 0, "User2": 3, "User3": 0},
+                                 "3": {"User1": 0, "User2": 3, "User3": 0}
+                             })
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 6, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 3)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
+
+        self.assertFalse(users_dispatcher._rebalance)
+
+        # Dispatch iteration 3
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 9, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 5)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 4)
+
+
+
+        # New dispatch
+        users_dispatcher.new_dispatch(16,7,[User3])
+        dispatched_users = next(users_dispatcher)
+        self.assertDictEqual(dispatched_users,
+                             {
+                                 "1": {"User1": 0, "User2": 5, "User3": 3},
+                                 "3": {"User1": 0, "User2": 4, "User3": 4}
+                             })
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {'User1': 0,"User2": 9, "User3": 7})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 8)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 8)
+
+
+
+    def test_add_worker_during_ramp_up_custom_classes(self):
+        class User1(User):
+            weight = 1
+
+        class User2(User):
+            weight = 1
+
+        class User3(User):
+            weight = 1
+
+        user_classes = [User1, User2, User3]
+
+        worker_nodes = [WorkerNode(str(i + 1)) for i in range(3)]
+
+        users_dispatcher = UsersDispatcher(worker_nodes=[worker_nodes[0], worker_nodes[2]], user_classes=user_classes)
+
+        sleep_time = 0.2  # Speed-up test
+
+        users_dispatcher.new_dispatch(target_user_count=11, spawn_rate=3, user_classes=[User1])
+        users_dispatcher._wait_between_dispatch = sleep_time
+
+        # Dispatch iteration 1
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(0 <= delta <= _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 3, "User2": 0, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 2)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 1)
+
+        # Dispatch iteration 2
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 6, "User2": 0, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 3)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
+
+        self.assertFalse(users_dispatcher._rebalance)
+
+        users_dispatcher.add_worker(worker_nodes[1])
+
+        self.assertTrue(users_dispatcher._rebalance)
+
+        # Re-balance
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(0 <= delta <= _TOLERANCE, f"Expected re-balance dispatch to be instantaneous but got {delta}s")
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 6, "User2": 0, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 2)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 2)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 2)
+
+        self.assertFalse(users_dispatcher._rebalance)
+
+        # Dispatch iteration 3
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 9, "User2": 0, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 3)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 3)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
+
+        # Dispatch iteration 4
+        ts = time.perf_counter()
+        dispatched_users = next(users_dispatcher)
+        delta = time.perf_counter() - ts
+        self.assertTrue(sleep_time - _TOLERANCE <= delta <= sleep_time + _TOLERANCE, delta)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 11, "User2": 0, "User3": 0})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 4)
+        # without host-based balancing the following two values would be reversed
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 4)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 3)
+
+        #New Dispatch
+        users_dispatcher.new_dispatch(target_user_count=18, spawn_rate=7, user_classes=[User3])
+        dispatched_users = next(users_dispatcher)
+        self.assertDictEqual(_aggregate_dispatched_users(dispatched_users), {"User1": 11, "User2": 0, "User3": 7})
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[0].id), 6)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[1].id), 6)
+        self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 6)
+
+
 
 
 def _aggregate_dispatched_users(d: Dict[str, Dict[str, int]]) -> Dict[str, int]:


### PR DESCRIPTION
Hey Locust Team,

I've been using locust for a while now, and really like to work with it. Still we achieved to run into some shortcomings for the project I am currently working on.

#### With this PR I would like to propose a new feature:
The possibility to create custom LoadTestShapes, where a step / tick only creates a specified set of users.

#### Why I need this feature / other maybe also need it: 
In our Testscenario we need to make sure that a certain amount of locust users is definitely present upfront. Trying to achieve this with `weighting` or `fixed_users` is possible but from my experience also mixed with a bit of luck. As we are already using `LoadTestShapes` I asked myself, whether it is possible to include the users in the stages for example.

#### How to use it:
Using this would look like this for example:
```python
stages = [
        {"duration": 60, "users": 10, "spawn_rate": 10, "user_classes": [WebsiteUserA]},
        {"duration": 100, "users": 50, "spawn_rate": 10, "user_classes": [WebsiteUserB]},
        {"duration": 180, "users": 100, "spawn_rate": 10, "user_classes": [WebsiteUserA, WebsiteUserB]},
        {"duration": 220, "users": 30, "spawn_rate": 10},
    ]
```
In this case the first step would only create users of the class `WebsiteUserA`, the second step `WebsiteUserB` and so on.
I also included a new example called `staging_user_classes.py`. 

#### Is it backwards compatible: 
Yeah, it should be. If the `"user_classes"`-entry is missing, it will use all the existing user classes as input, as it was before.

#### How it was achieved: 
I needed to adjust three files: 
- `shape.py`
- `runners.py`
- `dispatch.py`

The maybe most important change (and maybe there's an even better solution for that) was, that in every `new_dispatch()` call (this happens for each tick / step once), also a new `user_generator` is being created. But in the end there were only a few minimal changes to the code done.

I really am looking forward hearing your thought. 

Thanks a lot in advance. 

