### PR TITLE
Get_stats function added

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,24 +784,12 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 
 def print_stats(stats: RequestStats, current=True) -> None:
-    name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
-    console_logger.info(
-        ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
-        % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
-    )
-    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
-    console_logger.info(separator)
-    for key in sorted(stats.entries.keys()):
-        r = stats.entries[key]
-        console_logger.info(r.to_string(current=current))
-    console_logger.info(separator)
-    console_logger.info(stats.total.to_string(current=current))
-    console_logger.info("")
+    console_logger.info(get_stats(stats,current))
 
-def get_stats(stats: stats.RequestStats, current=True) -> str:
+def get_stats(stats: RequestStats, current=True) -> str:
     """
-        Stats will be returned as string.
-        This can be used for sending the result to user defined handlers (for ex: Reportportal)
+    Stats will be returned as string.
+    This can be used for sending the result to user defined handlers (for ex: Reportportal)
     """
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     stat_summary = (

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -798,6 +798,25 @@ def print_stats(stats: RequestStats, current=True) -> None:
     console_logger.info(stats.total.to_string(current=current))
     console_logger.info("")
 
+def get_stats(stats: stats.RequestStats, current=True) -> str:
+    """
+        Stats will be returned as string.
+        This can be used for sending the result to user defined handlers (for ex: Reportportal)
+    """
+    name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
+    stat_summary = (
+        "%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s"
+    ) % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
+    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
+    stat_summary += separator
+    for key in sorted(stats.entries.keys()):
+        r = stats.entries[key]
+        stat_summary += r.to_string(current=current)
+    stat_summary += separator
+    stat_summary += stats.total.to_string(current=current)
+    stat_summary += ""
+
+    return stat_summary
 
 def print_percentile_stats(stats: RequestStats) -> None:
     console_logger.info("Response time percentiles (approximated)")

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,7 +1,6 @@
-from abc import abstractmethod
 import datetime
+from gc import get_stats
 import hashlib
-from tempfile import NamedTemporaryFile
 import time
 from collections import namedtuple, OrderedDict
 from copy import copy
@@ -10,39 +9,11 @@ import os
 import csv
 import signal
 import gevent
-
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    NoReturn,
-    Tuple,
-    List,
-    Union,
-    Optional,
-    OrderedDict as OrderedDictType,
-    Callable,
-    TypeVar,
-    cast,
-)
-
-# @TODO: typing.Protocol is in python >= 3.8
-try:
-    from typing import Protocol, TypedDict
-except ImportError:
-    from typing_extensions import Protocol, TypedDict  # type: ignore
-
-from types import FrameType
+from typing import Dict, Tuple
 
 from .exception import CatchResponseError
-from .event import Events
 
 import logging
-
-if TYPE_CHECKING:
-    from .runners import Runner
-    from .env import Environment
 
 console_logger = logging.getLogger("locust.stats_logger")
 
@@ -55,46 +26,7 @@ except OSError:  # not a real terminal
 STATS_AUTORESIZE = True  # overwrite this if you dont want auto resize while running
 
 
-class CSVWriter(Protocol):
-    @abstractmethod
-    def writerow(self, columns: Iterable[Union[str, int, float]]) -> None:
-        ...
-
-
-class StatsBaseDict(TypedDict):
-    name: str
-    method: str
-
-
-class StatsEntryDict(StatsBaseDict):
-    last_request_timestamp: Optional[float]
-    start_time: float
-    num_requests: int
-    num_none_requests: int
-    num_failures: int
-    total_response_time: int
-    max_response_time: int
-    min_response_time: Optional[int]
-    total_content_length: int
-    response_times: Dict[int, int]
-    num_reqs_per_sec: Dict[int, int]
-    num_fail_per_sec: Dict[int, int]
-
-
-class StatsErrorDict(StatsBaseDict):
-    error: str
-    occurrences: int
-
-
-class StatsHolder(Protocol):
-    name: str
-    method: str
-
-
-S = TypeVar("S", bound=StatsHolder)
-
-
-def resize_handler(signum: int, frame: Optional[FrameType]):
+def resize_handler(signum, frame):
     global STATS_NAME_WIDTH
     if STATS_AUTORESIZE:
         try:
@@ -137,7 +69,7 @@ class RequestStatsAdditionError(Exception):
     pass
 
 
-def get_readable_percentiles(percentile_list: List[float]) -> List[str]:
+def get_readable_percentiles(percentile_list):
     """
     Converts a list of percentiles from 0-1 fraction to 0%-100% view for using in console & csv reporting
     :param percentile_list: The list of percentiles in range 0-1
@@ -149,7 +81,7 @@ def get_readable_percentiles(percentile_list: List[float]) -> List[str]:
     ]
 
 
-def calculate_response_time_percentile(response_times: Dict[int, int], num_requests: int, percent: float) -> int:
+def calculate_response_time_percentile(response_times, num_requests, percent):
     """
     Get the response time that a certain number of percent of the requests
     finished within. Arguments:
@@ -170,7 +102,7 @@ def calculate_response_time_percentile(response_times: Dict[int, int], num_reque
     return 0
 
 
-def diff_response_time_dicts(latest: Dict[int, int], old: Dict[int, int]) -> Dict[int, int]:
+def diff_response_time_dicts(latest, old):
     """
     Returns the delta between two {response_times:request_count} dicts.
 
@@ -224,11 +156,11 @@ class RequestStats:
     def start_time(self):
         return self.total.start_time
 
-    def log_request(self, method: str, name: str, response_time: int, content_length: int) -> None:
+    def log_request(self, method, name, response_time, content_length):
         self.total.log(response_time, content_length)
         self.get(name, method).log(response_time, content_length)
 
-    def log_error(self, method: str, name: str, error: Optional[Union[Exception, str]]) -> None:
+    def log_error(self, method, name, error):
         self.total.log_error(error)
         self.get(name, method).log_error(error)
 
@@ -240,7 +172,7 @@ class RequestStats:
             self.errors[key] = entry
         entry.occurred()
 
-    def get(self, name: str, method: str) -> "StatsEntry":
+    def get(self, name, method):
         """
         Retrieve a StatsEntry instance by name and method
         """
@@ -250,7 +182,7 @@ class RequestStats:
             self.entries[(name, method)] = entry
         return entry
 
-    def reset_all(self) -> None:
+    def reset_all(self):
         """
         Go through all stats entries and reset them to zero
         """
@@ -260,24 +192,24 @@ class RequestStats:
             r.reset()
         self.history = []
 
-    def clear_all(self) -> None:
+    def clear_all(self):
         """
         Remove all stats entries and errors
         """
-        self.total = StatsEntry(self, "Aggregated", "", use_response_times_cache=self.use_response_times_cache)
+        self.total = StatsEntry(self, "Aggregated", None, use_response_times_cache=self.use_response_times_cache)
         self.entries = {}
         self.errors = {}
         self.history = []
 
-    def serialize_stats(self) -> List["StatsEntryDict"]:
+    def serialize_stats(self):
         return [
             self.entries[key].get_stripped_report()
             for key in self.entries.keys()
             if not (self.entries[key].num_requests == 0 and self.entries[key].num_failures == 0)
         ]
 
-    def serialize_errors(self) -> Dict[str, "StatsErrorDict"]:
-        return {k: e.serialize() for k, e in self.errors.items()}
+    def serialize_errors(self):
+        return {k: e.to_dict() for k, e in self.errors.items()}
 
 
 class StatsEntry:
@@ -285,7 +217,7 @@ class StatsEntry:
     Represents a single stats entry (name and method)
     """
 
-    def __init__(self, stats: Optional[RequestStats], name: str, method: str, use_response_times_cache: bool = False):
+    def __init__(self, stats: RequestStats, name: str, method: str, use_response_times_cache=False):
         self.stats = stats
         self.name = name
         """ Name (URL) of this stats entry """
@@ -298,17 +230,17 @@ class StatsEntry:
         We can use this dict to calculate the *current*  median response time, as well as other response
         time percentiles.
         """
-        self.num_requests: int = 0
+        self.num_requests = 0
         """ The number of requests made """
-        self.num_none_requests: int = 0
+        self.num_none_requests = 0
         """ The number of requests made with a None response time (typically async requests) """
-        self.num_failures: int = 0
+        self.num_failures = 0
         """ Number of failed request """
-        self.total_response_time: int = 0
+        self.total_response_time = 0
         """ Total sum of the response times """
-        self.min_response_time: Optional[int] = None
+        self.min_response_time = None
         """ Minimum response time """
-        self.max_response_time: int = 0
+        self.max_response_time = 0
         """ Maximum response time """
         self.num_reqs_per_sec: Dict[int, int] = {}
         """ A {second => request_count} dict that holds the number of requests made per second """
@@ -324,16 +256,16 @@ class StatsEntry:
 
         This dict is used to calculate the median and percentile response times.
         """
-        self.response_times_cache: Optional[OrderedDictType[int, CachedResponseTimes]] = None
+        self.response_times_cache = None
         """
         If use_response_times_cache is set to True, this will be a {timestamp => CachedResponseTimes()}
         OrderedDict that holds a copy of the response_times dict for each of the last 20 seconds.
         """
-        self.total_content_length: int = 0
+        self.total_content_length = 0
         """ The sum of the content length of all the requests for this entry """
-        self.start_time: float = 0.0
+        self.start_time = 0.0
         """ Time of the first request for this entry """
-        self.last_request_timestamp: Optional[float] = None
+        self.last_request_timestamp = None
         """ Time of the last request for this entry """
         self.reset()
 
@@ -354,7 +286,7 @@ class StatsEntry:
             self.response_times_cache = OrderedDict()
             self._cache_response_times(int(time.time()))
 
-    def log(self, response_time: int, content_length: int) -> None:
+    def log(self, response_time, content_length):
         # get the time
         current_time = time.time()
         t = int(current_time)
@@ -370,12 +302,12 @@ class StatsEntry:
         # increase total content-length
         self.total_content_length += content_length
 
-    def _log_time_of_request(self, current_time: float) -> None:
+    def _log_time_of_request(self, current_time):
         t = int(current_time)
         self.num_reqs_per_sec[t] = self.num_reqs_per_sec.setdefault(t, 0) + 1
         self.last_request_timestamp = current_time
 
-    def _log_response_time(self, response_time: int) -> None:
+    def _log_response_time(self, response_time):
         if response_time is None:
             self.num_none_requests += 1
             return
@@ -404,13 +336,13 @@ class StatsEntry:
         self.response_times.setdefault(rounded_response_time, 0)
         self.response_times[rounded_response_time] += 1
 
-    def log_error(self, error: Optional[Union[Exception, str]]) -> None:
+    def log_error(self, error):
         self.num_failures += 1
         t = int(time.time())
         self.num_fail_per_sec[t] = self.num_fail_per_sec.setdefault(t, 0) + 1
 
     @property
-    def fail_ratio(self) -> float:
+    def fail_ratio(self):
         try:
             return float(self.num_failures) / self.num_requests
         except ZeroDivisionError:
@@ -420,14 +352,14 @@ class StatsEntry:
                 return 0.0
 
     @property
-    def avg_response_time(self) -> float:
+    def avg_response_time(self):
         try:
             return float(self.total_response_time) / (self.num_requests - self.num_none_requests)
         except ZeroDivisionError:
-            return 0.0
+            return 0
 
     @property
-    def median_response_time(self) -> int:
+    def median_response_time(self):
         if not self.response_times:
             return 0
         median = median_from_dict(self.num_requests - self.num_none_requests, self.response_times) or 0
@@ -438,18 +370,18 @@ class StatsEntry:
         # have one (or very few) really slow requests
         if median > self.max_response_time:
             median = self.max_response_time
-        elif self.min_response_time is not None and median < self.min_response_time:
+        elif median < self.min_response_time:
             median = self.min_response_time
 
         return median
 
     @property
-    def current_rps(self) -> float:
-        if self.stats is None or self.stats.last_request_timestamp is None:
+    def current_rps(self):
+        if self.stats.last_request_timestamp is None:
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
-        reqs: List[Union[int, float]] = [
+        reqs = [
             self.num_reqs_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp) - 2)
         ]
         return avg(reqs)
@@ -490,7 +422,7 @@ class StatsEntry:
         except ZeroDivisionError:
             return 0
 
-    def extend(self, other: "StatsEntry") -> None:
+    def extend(self, other):
         """
         Extend the data from the current StatsEntry with the stats from another
         StatsEntry instance.
@@ -504,17 +436,18 @@ class StatsEntry:
         elif other.last_request_timestamp is not None:
             self.last_request_timestamp = other.last_request_timestamp
         self.start_time = min(self.start_time, other.start_time)
-        self.num_requests += other.num_requests
-        self.num_none_requests += other.num_none_requests
-        self.num_failures += other.num_failures
-        self.total_response_time += other.total_response_time
+
+        self.num_requests = self.num_requests + other.num_requests
+        self.num_none_requests = self.num_none_requests + other.num_none_requests
+        self.num_failures = self.num_failures + other.num_failures
+        self.total_response_time = self.total_response_time + other.total_response_time
         self.max_response_time = max(self.max_response_time, other.max_response_time)
         if self.min_response_time is not None and other.min_response_time is not None:
             self.min_response_time = min(self.min_response_time, other.min_response_time)
         elif other.min_response_time is not None:
             # this means self.min_response_time is None, so we can safely replace it
             self.min_response_time = other.min_response_time
-        self.total_content_length += other.total_content_length
+        self.total_content_length = self.total_content_length + other.total_content_length
 
         for key in other.response_times:
             self.response_times[key] = self.response_times.get(key, 0) + other.response_times[key]
@@ -530,27 +463,49 @@ class StatsEntry:
             # lag behind a second or two, but since StatsEntry.current_response_time_percentile()
             # (which is what the response times cache is used for) uses an approximation of the
             # last 10 seconds anyway, it should be fine to ignore this.
-            last_time = int(self.last_request_timestamp) if self.last_request_timestamp else None
+            last_time = self.last_request_timestamp and int(self.last_request_timestamp) or None
             if last_time and last_time > (old_last_request_timestamp and int(old_last_request_timestamp) or 0):
                 self._cache_response_times(last_time)
 
-    def serialize(self) -> StatsEntryDict:
-        return cast(StatsEntryDict, {key: getattr(self, key, None) for key in StatsEntryDict.__annotations__.keys()})
+    def serialize(self):
+        return {
+            "name": self.name,
+            "method": self.method,
+            "last_request_timestamp": self.last_request_timestamp,
+            "start_time": self.start_time,
+            "num_requests": self.num_requests,
+            "num_none_requests": self.num_none_requests,
+            "num_failures": self.num_failures,
+            "total_response_time": self.total_response_time,
+            "max_response_time": self.max_response_time,
+            "min_response_time": self.min_response_time,
+            "total_content_length": self.total_content_length,
+            "response_times": self.response_times,
+            "num_reqs_per_sec": self.num_reqs_per_sec,
+            "num_fail_per_sec": self.num_fail_per_sec,
+        }
 
     @classmethod
-    def unserialize(cls, data: StatsEntryDict) -> "StatsEntry":
-        """Return the unserialzed version of the specified dict"""
+    def unserialize(cls, data):
         obj = cls(None, data["name"], data["method"])
-        valid_keys = StatsEntryDict.__annotations__.keys()
-
-        for key, value in data.items():
-            if key in ["name", "method"] or key not in valid_keys:
-                continue
-
-            setattr(obj, key, value)
+        for key in [
+            "last_request_timestamp",
+            "start_time",
+            "num_requests",
+            "num_none_requests",
+            "num_failures",
+            "total_response_time",
+            "max_response_time",
+            "min_response_time",
+            "total_content_length",
+            "response_times",
+            "num_reqs_per_sec",
+            "num_fail_per_sec",
+        ]:
+            setattr(obj, key, data[key])
         return obj
 
-    def get_stripped_report(self) -> StatsEntryDict:
+    def get_stripped_report(self):
         """
         Return the serialized version of this StatsEntry, and then clear the current stats.
         """
@@ -558,7 +513,7 @@ class StatsEntry:
         self.reset()
         return report
 
-    def to_string(self, current=True) -> str:
+    def to_string(self, current=True):
         """
         Return the stats as a string suitable for console output. If current is True, it'll show
         the RPS and failure rate for the last 10 seconds. If it's false, it'll show the total stats
@@ -589,10 +544,10 @@ class StatsEntry:
             fail_per_sec or 0,
         )
 
-    def __str__(self) -> str:
+    def __str__(self):
         return self.to_string(current=True)
 
-    def get_response_time_percentile(self, percent: float) -> int:
+    def get_response_time_percentile(self, percent):
         """
         Get the response time that a certain number of percent of the requests
         finished within.
@@ -601,7 +556,7 @@ class StatsEntry:
         """
         return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
 
-    def get_current_response_time_percentile(self, percent: float) -> Optional[int]:
+    def get_current_response_time_percentile(self, percent):
         """
         Calculate the *current* response time for a certain percentile. We use a sliding
         window of (approximately) the last 10 seconds (specified by CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
@@ -619,18 +574,17 @@ class StatsEntry:
         # when trying to fetch the cached response_times. We construct this list in such a way
         # that it's ordered by preference by starting to add t-10, then t-11, t-9, t-12, t-8,
         # and so on
-        acceptable_timestamps: List[int] = []
+        acceptable_timestamps = []
         acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
         for i in range(1, 9):
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW - i)
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + i)
 
-        cached: Optional[CachedResponseTimes] = None
-        if self.response_times_cache is not None:
-            for ts in acceptable_timestamps:
-                if ts in self.response_times_cache:
-                    cached = self.response_times_cache[ts]
-                    break
+        cached = None
+        for ts in acceptable_timestamps:
+            if ts in self.response_times_cache:
+                cached = self.response_times_cache[ts]
+                break
 
         if cached:
             # If we found an acceptable cached response times, we'll calculate a new response
@@ -645,7 +599,7 @@ class StatsEntry:
         # if time was not in response times cache window
         return None
 
-    def percentile(self) -> str:
+    def percentile(self):
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
 
@@ -657,10 +611,7 @@ class StatsEntry:
             + (self.num_requests,)
         )
 
-    def _cache_response_times(self, t: int) -> None:
-        if self.response_times_cache is None:
-            self.response_times_cache = OrderedDict()
-
+    def _cache_response_times(self, t):
         self.response_times_cache[t] = CachedResponseTimes(
             response_times=copy(self.response_times),
             num_requests=self.num_requests,
@@ -674,19 +625,19 @@ class StatsEntry:
 
         if len(self.response_times_cache) > cache_size:
             # only keep the latest 20 response_times dicts
-            for _ in range(len(self.response_times_cache) - cache_size):
+            for i in range(len(self.response_times_cache) - cache_size):
                 self.response_times_cache.popitem(last=False)
 
 
 class StatsError:
-    def __init__(self, method: str, name: str, error: Optional[Union[Exception, str]], occurrences: int = 0):
+    def __init__(self, method, name, error, occurrences=0):
         self.method = method
         self.name = name
         self.error = error
         self.occurrences = occurrences
 
     @classmethod
-    def parse_error(cls, error: Optional[Union[Exception, str]]) -> str:
+    def parse_error(cls, error):
         string_error = repr(error)
         target = "object at 0x"
         target_index = string_error.find(target)
@@ -700,14 +651,14 @@ class StatsError:
         return string_error.replace(hex_address, "0x....")
 
     @classmethod
-    def create_key(cls, method: str, name: str, error: Optional[Union[Exception, str]]) -> str:
+    def create_key(cls, method, name, error):
         key = f"{method}.{name}.{StatsError.parse_error(error)!r}"
-        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return hashlib.md5(key.encode("utf-8")).hexdigest()
 
-    def occurred(self) -> None:
+    def occurred(self):
         self.occurrences += 1
 
-    def to_name(self) -> str:
+    def to_name(self):
         error = self.error
         if isinstance(error, CatchResponseError):
             # standalone
@@ -722,27 +673,24 @@ class StatsError:
 
         return f"{self.method} {self.name}: {unwrapped_error}"
 
-    def serialize(self) -> StatsErrorDict:
-        def _getattr(obj: "StatsError", key: str, default: Optional[Any]) -> Optional[Any]:
-            value = getattr(obj, key, default)
-
-            if key in ["error"]:
-                value = StatsError.parse_error(value)
-
-            return value
-
-        return cast(StatsErrorDict, {key: _getattr(self, key, None) for key in StatsErrorDict.__annotations__.keys()})
+    def to_dict(self):
+        return {
+            "method": self.method,
+            "name": self.name,
+            "error": StatsError.parse_error(self.error),
+            "occurrences": self.occurrences,
+        }
 
     @classmethod
-    def unserialize(cls, data: StatsErrorDict) -> "StatsError":
+    def from_dict(cls, data):
         return cls(data["method"], data["name"], data["error"], data["occurrences"])
 
 
-def avg(values: List[Union[float, int]]) -> float:
+def avg(values):
     return sum(values, 0.0) / max(len(values), 1)
 
 
-def median_from_dict(total: int, count: Dict[int, int]) -> int:
+def median_from_dict(total, count):
     """
     total is the number of requests made
     count is a dict {response_time: count}
@@ -753,17 +701,15 @@ def median_from_dict(total: int, count: Dict[int, int]) -> int:
             return k
         pos -= count[k]
 
-    return k
 
-
-def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats) -> None:
-    def on_report_to_master(client_id: str, data: Dict[str, Any]) -> None:
+def setup_distributed_stats_event_listeners(events, stats):
+    def on_report_to_master(client_id, data):
         data["stats"] = stats.serialize_stats()
         data["stats_total"] = stats.total.get_stripped_report()
         data["errors"] = stats.serialize_errors()
         stats.errors = {}
 
-    def on_worker_report(client_id: str, data: Dict[str, Any]) -> None:
+    def on_worker_report(client_id, data):
         for stats_data in data["stats"]:
             entry = StatsEntry.unserialize(stats_data)
             request_key = (entry.name, entry.method)
@@ -773,7 +719,7 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
         for error_key, error in data["errors"].items():
             if error_key not in stats.errors:
-                stats.errors[error_key] = StatsError.unserialize(error)
+                stats.errors[error_key] = StatsError.from_dict(error)
             else:
                 stats.errors[error_key].occurrences += error["occurrences"]
 
@@ -783,8 +729,9 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
     events.worker_report.add_listener(on_worker_report)
 
 
-def print_stats(stats: RequestStats, current=True) -> None:
-    console_logger.info(get_stats(stats,current))
+def print_stats(stats, current=True):
+    console_logger.info(get_stats(stats, current))
+
 
 def get_stats(stats: RequestStats, current=True) -> str:
     """
@@ -806,32 +753,41 @@ def get_stats(stats: RequestStats, current=True) -> str:
 
     return stat_summary
 
-def print_percentile_stats(stats: RequestStats) -> None:
-    console_logger.info("Response time percentiles (approximated)")
+
+def print_percentile_stats(stats):
+    console_logger.info(get_percentile_stats(stats))
+
+
+def get_percentile_stats(stats: RequestStats):
+    stat_summary = "Response time percentiles (approximated)"
+    stat_summary += "\n"
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
-    console_logger.info(
-        (
-            f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
-            f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
-        )
-        % headers
-    )
+    stat_summary += (
+        f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
+        f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
+    ) % headers
     separator = (
         f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
     )[:-1]
-    console_logger.info(separator)
+    stat_summary += "\n"
+    stat_summary += separator
+    stat_summary += "\n"
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
         if r.response_times:
-            console_logger.info(r.percentile())
-    console_logger.info(separator)
+            stat_summary += r.percentile()
+            stat_summary += "\n"
+    stat_summary += separator
+    stat_summary += "\n"
 
     if stats.total.response_times:
-        console_logger.info(stats.total.percentile())
-    console_logger.info("")
+        stat_summary += stats.total.percentile()
+    stat_summary += ""
+
+    return stat_summary
 
 
-def print_error_report(stats: RequestStats) -> None:
+def print_error_report(stats):
     if not len(stats.errors):
         return
     console_logger.info("Error report")
@@ -844,8 +800,8 @@ def print_error_report(stats: RequestStats) -> None:
     console_logger.info("")
 
 
-def stats_printer(stats: RequestStats) -> Callable[[], None]:
-    def stats_printer_func() -> None:
+def stats_printer(stats):
+    def stats_printer_func():
         while True:
             print_stats(stats)
             gevent.sleep(CONSOLE_STATS_INTERVAL_SEC)
@@ -853,11 +809,11 @@ def stats_printer(stats: RequestStats) -> Callable[[], None]:
     return stats_printer_func
 
 
-def sort_stats(stats: Dict[Any, S]) -> List[S]:
+def sort_stats(stats):
     return [stats[key] for key in sorted(stats.keys())]
 
 
-def stats_history(runner: "Runner") -> None:
+def stats_history(runner):
     """Save current stats info to history for charts of report."""
     while True:
         stats = runner.stats
@@ -879,7 +835,8 @@ def stats_history(runner: "Runner") -> None:
 class StatsCSV:
     """Write statistics to csv_writer stream."""
 
-    def __init__(self, environment: "Environment", percentiles_to_report: List[float]) -> None:
+    def __init__(self, environment, percentiles_to_report):
+        super().__init__()
         self.environment = environment
         self.percentiles_to_report = percentiles_to_report
 
@@ -913,7 +870,7 @@ class StatsCSV:
             "Nodes",
         ]
 
-    def _percentile_fields(self, stats_entry: StatsEntry, use_current: bool = False) -> Union[List[str], List[int]]:
+    def _percentile_fields(self, stats_entry, use_current=False):
         if not stats_entry.num_requests:
             return self.percentiles_na
         elif use_current:
@@ -921,12 +878,12 @@ class StatsCSV:
         else:
             return [int(stats_entry.get_response_time_percentile(x) or 0) for x in self.percentiles_to_report]
 
-    def requests_csv(self, csv_writer: CSVWriter) -> None:
+    def requests_csv(self, csv_writer):
         """Write requests csv with header and data rows."""
         csv_writer.writerow(self.requests_csv_columns)
         self._requests_data_rows(csv_writer)
 
-    def _requests_data_rows(self, csv_writer: CSVWriter) -> None:
+    def _requests_data_rows(self, csv_writer):
         """Write requests csv data row, excluding header."""
         stats = self.environment.stats
         for stats_entry in chain(sort_stats(stats.entries), [stats.total]):
@@ -949,29 +906,26 @@ class StatsCSV:
                 )
             )
 
-    def failures_csv(self, csv_writer: CSVWriter) -> None:
+    def failures_csv(self, csv_writer):
         csv_writer.writerow(self.failures_columns)
         self._failures_data_rows(csv_writer)
 
-    def _failures_data_rows(self, csv_writer: CSVWriter) -> None:
+    def _failures_data_rows(self, csv_writer):
         for stats_error in sort_stats(self.environment.stats.errors):
             csv_writer.writerow(
                 [
                     stats_error.method,
                     stats_error.name,
-                    StatsError.parse_error(stats_error.error),
+                    stats_error.error,
                     stats_error.occurrences,
                 ]
             )
 
-    def exceptions_csv(self, csv_writer: CSVWriter) -> None:
+    def exceptions_csv(self, csv_writer):
         csv_writer.writerow(self.exceptions_columns)
         self._exceptions_data_rows(csv_writer)
 
-    def _exceptions_data_rows(self, csv_writer: CSVWriter) -> None:
-        if self.environment.runner is None:
-            return
-
+    def _exceptions_data_rows(self, csv_writer):
         for exc in self.environment.runner.exceptions.values():
             csv_writer.writerow([exc["count"], exc["msg"], exc["traceback"], ", ".join(exc["nodes"])])
 
@@ -979,13 +933,7 @@ class StatsCSV:
 class StatsCSVFileWriter(StatsCSV):
     """Write statistics to to CSV files"""
 
-    def __init__(
-        self,
-        environment: "Environment",
-        percentiles_to_report: List[float],
-        base_filepath: str,
-        full_history: bool = False,
-    ):
+    def __init__(self, environment, percentiles_to_report, base_filepath, full_history=False):
         super().__init__(environment, percentiles_to_report)
         self.base_filepath = base_filepath
         self.full_history = full_history
@@ -998,11 +946,11 @@ class StatsCSVFileWriter(StatsCSV):
 
         self.failures_csv_filehandle = open(self.base_filepath + "_failures.csv", "w")
         self.failures_csv_writer = csv.writer(self.failures_csv_filehandle)
-        self.failures_csv_data_start: int = 0
+        self.failures_csv_data_start = 0
 
         self.exceptions_csv_filehandle = open(self.base_filepath + "_exceptions.csv", "w")
         self.exceptions_csv_writer = csv.writer(self.exceptions_csv_filehandle)
-        self.exceptions_csv_data_start: int = 0
+        self.exceptions_csv_data_start = 0
 
         self.stats_history_csv_columns = [
             "Timestamp",
@@ -1021,10 +969,10 @@ class StatsCSVFileWriter(StatsCSV):
             "Total Average Content Size",
         ]
 
-    def __call__(self) -> None:
+    def __call__(self):
         self.stats_writer()
 
-    def stats_writer(self) -> NoReturn:
+    def stats_writer(self):
         """Writes all the csv files for the locust run."""
 
         # Write header row for all files and save position for non-append files
@@ -1040,7 +988,7 @@ class StatsCSVFileWriter(StatsCSV):
         self.exceptions_csv_data_start = self.exceptions_csv_filehandle.tell()
 
         # Continuously write date rows for all files
-        last_flush_time: float = 0.0
+        last_flush_time = 0
         while True:
             now = time.time()
 
@@ -1067,7 +1015,7 @@ class StatsCSVFileWriter(StatsCSV):
 
             gevent.sleep(CSV_STATS_INTERVAL_SEC)
 
-    def _stats_history_data_rows(self, csv_writer: CSVWriter, now: float) -> None:
+    def _stats_history_data_rows(self, csv_writer, now):
         """
         Write CSV rows with the *current* stats. By default only includes the
         Aggregated stats entry, but if self.full_history is set to True, a row for each entry will
@@ -1078,7 +1026,7 @@ class StatsCSVFileWriter(StatsCSV):
 
         stats = self.environment.stats
         timestamp = int(now)
-        stats_entries: List[StatsEntry] = []
+        stats_entries = []
         if self.full_history:
             stats_entries = sort_stats(stats.entries)
 
@@ -1087,7 +1035,7 @@ class StatsCSVFileWriter(StatsCSV):
                 chain(
                     (
                         timestamp,
-                        self.environment.runner.user_count if self.environment.runner is not None else 0,
+                        self.environment.runner.user_count,
                         stats_entry.method or "",
                         stats_entry.name,
                         f"{stats_entry.current_rps:2f}",
@@ -1106,23 +1054,23 @@ class StatsCSVFileWriter(StatsCSV):
                 )
             )
 
-    def requests_flush(self) -> None:
+    def requests_flush(self):
         self.requests_csv_filehandle.flush()
 
-    def stats_history_flush(self) -> None:
+    def stats_history_flush(self):
         self.stats_history_csv_filehandle.flush()
 
-    def failures_flush(self) -> None:
+    def failures_flush(self):
         self.failures_csv_filehandle.flush()
 
-    def exceptions_flush(self) -> None:
+    def exceptions_flush(self):
         self.exceptions_csv_filehandle.flush()
 
-    def close_files(self) -> None:
+    def close_files(self):
         self.requests_csv_filehandle.close()
         self.stats_history_csv_filehandle.close()
         self.failures_csv_filehandle.close()
         self.exceptions_csv_filehandle.close()
 
-    def stats_history_file_name(self) -> str:
+    def stats_history_file_name(self):
         return self.base_filepath + "_stats_history.csv"

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -730,10 +730,10 @@ def setup_distributed_stats_event_listeners(events, stats):
 
 
 def print_stats(stats, current=True):
-    console_logger.info(get_stats(stats, current))
+    console_logger.info(get_stats_summary(stats, current))
 
 
-def get_stats(stats: RequestStats, current=True) -> str:
+def get_stats_summary(stats: RequestStats, current=True) -> str:
     """
     Stats will be returned as string.
     This can be used for sending the result to user defined handlers (for ex: Reportportal)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -744,10 +744,13 @@ def get_stats(stats: RequestStats, current=True) -> str:
     ) % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
     separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
     stat_summary += separator
+    stat_summary += "\n"
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
         stat_summary += r.to_string(current=current)
+        stat_summary += "\n"
     stat_summary += separator
+    stat_summary += "\n"
     stat_summary += stats.total.to_string(current=current)
     stat_summary += ""
 


### PR DESCRIPTION
This function will be useful if user want stats in string. Print_stats directly print in console. This function will return the stats as string which can be used to pass it to other handler like Reportportal

It is refactored out of print_stats.
Also get_percentile_stats is refactored from print_percentile_stats. If some one wants the string summary rather than display in console_logger they can call these