### PR TITLE
stats summary refactoring

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -791,7 +791,7 @@ def print_stats(stats: RequestStats, current=True) -> None:
 
 def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
     """
-        stats summary will be returned as string
+        stats summary will be returned as list of string
     """
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     summary = list()
@@ -817,7 +817,7 @@ def print_percentile_stats(stats: RequestStats) -> None:
 
 def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
     """
-        Percentile stats summary will be returned as string
+        Percentile stats summary will be returned as list of string
     """
     summary = []
     summary.append("Response time percentiles (approximated)")

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,14 +784,15 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 
 def print_stats(stats: RequestStats, current=True) -> None:
-    stat_summary = get_stats_summary(stats,current)
+    stat_summary = get_stats_summary(stats, current)
     for summary in stat_summary:
         console_logger.info(summary)
     console_logger.info("")
 
+
 def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
     """
-        stats summary will be returned as list of string
+    stats summary will be returned as list of string
     """
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     summary = list()
@@ -815,9 +816,10 @@ def print_percentile_stats(stats: RequestStats) -> None:
         console_logger.info(summary)
     console_logger.info("")
 
+
 def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
     """
-        Percentile stats summary will be returned as list of string
+    Percentile stats summary will be returned as list of string
     """
     summary = []
     summary.append("Response time percentiles (approximated)")
@@ -847,15 +849,12 @@ def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
 def print_error_report(stats: RequestStats) -> None:
     if not len(stats.errors):
         return
-    stat_summary=get_error_report_summary(stats)
+    stat_summary = get_error_report_summary(stats)
     for summary in stat_summary:
         console_logger.info(summary)
-    console_logger.info("")
+
 
 def get_error_report_summary(stats) -> List[str]:
-    """ 
-        Get error report summary as list of string
-    """
     summary = []
     summary.append("Error report")
     summary.append("%-18s %-100s" % ("# occurrences", "Error"))
@@ -864,6 +863,7 @@ def get_error_report_summary(stats) -> List[str]:
     for error in stats.errors.values():
         summary.append("%-18i %-100s" % (error.occurrences, error.to_name()))
     summary.append(separator)
+    summary.append("")
     return summary
 
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,7 +784,7 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 
 def print_stats(stats: RequestStats, current=True) -> None:
-    name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
+    # name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
     # console_logger.info(
     #     ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
     #     % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
@@ -800,6 +800,7 @@ def print_stats(stats: RequestStats, current=True) -> None:
     stat_summary = get_stats_summary(stats,current)
     for summary in stat_summary:
         console_logger.info(summary)
+    console_logger.info("")
 
 def get_stats_summary(stats: RequestStats, current=True) -> str:
     """
@@ -818,67 +819,62 @@ def get_stats_summary(stats: RequestStats, current=True) -> str:
         summary.append(r.to_string(current=current))
     summary.append(separator)
     summary.append(stats.total.to_string(current=current))
-    # summary.append("")
     return summary
 
 
 def print_percentile_stats(stats: RequestStats) -> None:
-    console_logger.info("Response time percentiles (approximated)")
-    headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
-    console_logger.info(
-        (
-            f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
-            f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
-        )
-        % headers
-    )
-    separator = (
-        f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
-    )[:-1]
-    console_logger.info(separator)
-    for key in sorted(stats.entries.keys()):
-        r = stats.entries[key]
-        if r.response_times:
-            console_logger.info(r.percentile())
-    console_logger.info(separator)
+    # console_logger.info("Response time percentiles (approximated)")
+    # headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
+    # console_logger.info(
+    #     (
+    #         f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
+    #         f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
+    #     )
+    #     % headers
+    # )
+    # separator = (
+    #     f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
+    # )[:-1]
+    # console_logger.info(separator)
+    # for key in sorted(stats.entries.keys()):
+    #     r = stats.entries[key]
+    #     if r.response_times:
+    #         console_logger.info(r.percentile())
+    # console_logger.info(separator)
 
-    if stats.total.response_times:
-        console_logger.info(stats.total.percentile())
+    # if stats.total.response_times:
+    #     console_logger.info(stats.total.percentile())
+    stat_summary = get_percentile_stats_summary(stats)
+    for summary in stat_summary:
+        console_logger.info(summary)
     console_logger.info("")
 
 def get_percentile_stats_summary(stats: RequestStats) -> str:
     """
         Percentile stats summary will be returned as string
     """
-    summary =("Response time percentiles (approximated)")
-    summary += ("\n")
+    summary = []
+    summary.append("Response time percentiles (approximated)")
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
-    summary += (
+    summary.append(
         (
             f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
             f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
         )
         % headers
     )
-    summary += ("\n")
     separator = (
         f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
     )[:-1]
-    summary +=(separator)
-    summary += ("\n")
+    summary.append(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
         if r.response_times:
-            summary+=(r.percentile())
-            summary += ("\n")
-    summary += (separator)
-    summary += ("\n")
+            summary.append(r.percentile())
+    summary.append(separator)
 
     if stats.total.response_times:
-        summary += (stats.total.percentile())
-        summary += ("\n")
-    summary += ("")
-    summary += ("\n")
+        summary.append(stats.total.percentile())
     return summary
 
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,19 +784,6 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 
 def print_stats(stats: RequestStats, current=True) -> None:
-    # name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
-    # console_logger.info(
-    #     ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
-    #     % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
-    # )
-    # separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
-    # console_logger.info(separator)
-    # for key in sorted(stats.entries.keys()):
-    #     r = stats.entries[key]
-    #     console_logger.info(r.to_string(current=current))
-    # console_logger.info(separator)
-    # console_logger.info(stats.total.to_string(current=current))
-    # console_logger.info("")
     stat_summary = get_stats_summary(stats,current)
     for summary in stat_summary:
         console_logger.info(summary)
@@ -823,27 +810,6 @@ def get_stats_summary(stats: RequestStats, current=True) -> str:
 
 
 def print_percentile_stats(stats: RequestStats) -> None:
-    # console_logger.info("Response time percentiles (approximated)")
-    # headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
-    # console_logger.info(
-    #     (
-    #         f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
-    #         f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
-    #     )
-    #     % headers
-    # )
-    # separator = (
-    #     f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
-    # )[:-1]
-    # console_logger.info(separator)
-    # for key in sorted(stats.entries.keys()):
-    #     r = stats.entries[key]
-    #     if r.response_times:
-    #         console_logger.info(r.percentile())
-    # console_logger.info(separator)
-
-    # if stats.total.response_times:
-    #     console_logger.info(stats.total.percentile())
     stat_summary = get_percentile_stats_summary(stats)
     for summary in stat_summary:
         console_logger.info(summary)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -785,36 +785,40 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 def print_stats(stats: RequestStats, current=True) -> None:
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
-    console_logger.info(
-        ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
-        % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
-    )
-    separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
-    console_logger.info(separator)
-    for key in sorted(stats.entries.keys()):
-        r = stats.entries[key]
-        console_logger.info(r.to_string(current=current))
-    console_logger.info(separator)
-    console_logger.info(stats.total.to_string(current=current))
-    console_logger.info("")
+    # console_logger.info(
+    #     ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
+    #     % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
+    # )
+    # separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
+    # console_logger.info(separator)
+    # for key in sorted(stats.entries.keys()):
+    #     r = stats.entries[key]
+    #     console_logger.info(r.to_string(current=current))
+    # console_logger.info(separator)
+    # console_logger.info(stats.total.to_string(current=current))
+    # console_logger.info("")
+    stat_summary = get_stats_summary(stats,current)
+    for summary in stat_summary:
+        console_logger.info(summary)
 
 def get_stats_summary(stats: RequestStats, current=True) -> str:
     """
         stats summary will be returned as string
     """
     name_column_width = (STATS_NAME_WIDTH - STATS_TYPE_WIDTH) + 4  # saved characters by compacting other columns
-    summary = (
+    summary = list()
+    summary.append(
         ("%-" + str(STATS_TYPE_WIDTH) + "s %-" + str(name_column_width) + "s %7s %12s |%7s %7s %7s%7s | %7s %11s")
         % ("Type", "Name", "# reqs", "# fails", "Avg", "Min", "Max", "Med", "req/s", "failures/s")
     )
     separator = f'{"-" * STATS_TYPE_WIDTH}|{"-" * (name_column_width)}|{"-" * 7}|{"-" * 13}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 7}|{"-" * 8}|{"-" * 11}'
-    summary += (separator)
+    summary.append(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
-        summary += (r.to_string(current=current))
-    summary += (separator)
-    summary += (stats.total.to_string(current=current))
-    summary += ("")
+        summary.append(r.to_string(current=current))
+    summary.append(separator)
+    summary.append(stats.total.to_string(current=current))
+    # summary.append("")
     return summary
 
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -802,7 +802,7 @@ def print_stats(stats: RequestStats, current=True) -> None:
 def print_percentile_stats(stats: RequestStats) -> None:
     console_logger.info(get_percentile_stats_summary(stats))
 
-def get_percentile_stats_summary(stats: RequestStats) -> None:
+def get_percentile_stats_summary(stats: RequestStats) -> str:
     summary =("Response time percentiles (approximated)")
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
     summary += (

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -784,9 +784,8 @@ def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats)
 
 
 def print_stats(stats: RequestStats, current=True) -> None:
-    stat_summary = get_stats_summary(stats, current)
-    for summary in stat_summary:
-        console_logger.info(summary)
+    for line in get_stats_summary(stats, current):
+        console_logger.info(line)
     console_logger.info("")
 
 
@@ -811,9 +810,8 @@ def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
 
 
 def print_percentile_stats(stats: RequestStats) -> None:
-    stat_summary = get_percentile_stats_summary(stats)
-    for summary in stat_summary:
-        console_logger.info(summary)
+    for line in get_percentile_stats_summary(stats):
+        console_logger.info(line)
     console_logger.info("")
 
 
@@ -821,8 +819,7 @@ def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
     """
     Percentile stats summary will be returned as list of string
     """
-    summary = []
-    summary.append("Response time percentiles (approximated)")
+    summary = ["Response time percentiles (approximated)"]
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
     summary.append(
         (
@@ -849,14 +846,12 @@ def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
 def print_error_report(stats: RequestStats) -> None:
     if not len(stats.errors):
         return
-    stat_summary = get_error_report_summary(stats)
-    for summary in stat_summary:
-        console_logger.info(summary)
+    for line in get_error_report_summary(stats):
+        console_logger.info(line)
 
 
 def get_error_report_summary(stats) -> List[str]:
-    summary = []
-    summary.append("Error report")
+    summary = ["Error report"]
     summary.append("%-18s %-100s" % ("# occurrences", "Error"))
     separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}'
     summary.append(separator)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -847,14 +847,24 @@ def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
 def print_error_report(stats: RequestStats) -> None:
     if not len(stats.errors):
         return
-    console_logger.info("Error report")
-    console_logger.info("%-18s %-100s" % ("# occurrences", "Error"))
-    separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}'
-    console_logger.info(separator)
-    for error in stats.errors.values():
-        console_logger.info("%-18i %-100s" % (error.occurrences, error.to_name()))
-    console_logger.info(separator)
+    stat_summary=get_error_report_summary(stats)
+    for summary in stat_summary:
+        console_logger.info(summary)
     console_logger.info("")
+
+def get_error_report_summary(stats) -> List[str]:
+    """ 
+        Get error report summary as list of string
+    """
+    summary = []
+    summary.append("Error report")
+    summary.append("%-18s %-100s" % ("# occurrences", "Error"))
+    separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}'
+    summary.append(separator)
+    for error in stats.errors.values():
+        summary.append("%-18i %-100s" % (error.occurrences, error.to_name()))
+    summary.append(separator)
+    return summary
 
 
 def stats_printer(stats: RequestStats) -> Callable[[], None]:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -800,9 +800,12 @@ def print_stats(stats: RequestStats, current=True) -> None:
 
 
 def print_percentile_stats(stats: RequestStats) -> None:
-    console_logger.info("Response time percentiles (approximated)")
+    console_logger.info(get_percentile_stats_summary(stats))
+
+def get_percentile_stats_summary(stats: RequestStats) -> None:
+    summary =("Response time percentiles (approximated)")
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
-    console_logger.info(
+    summary += (
         (
             f"%-{str(STATS_TYPE_WIDTH)}s %-{str(STATS_NAME_WIDTH)}s %8s "
             f"{' '.join(['%6s'] * len(PERCENTILES_TO_REPORT))}"
@@ -812,16 +815,17 @@ def print_percentile_stats(stats: RequestStats) -> None:
     separator = (
         f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
     )[:-1]
-    console_logger.info(separator)
+    summary +=(separator)
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
         if r.response_times:
-            console_logger.info(r.percentile())
-    console_logger.info(separator)
+            summary+=(r.percentile())
+    summary += (separator)
 
     if stats.total.response_times:
-        console_logger.info(stats.total.percentile())
-    console_logger.info("")
+        summary += (stats.total.percentile())
+    summary += ("")
+    return summary
 
 
 def print_error_report(stats: RequestStats) -> None:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -804,6 +804,7 @@ def print_percentile_stats(stats: RequestStats) -> None:
 
 def get_percentile_stats_summary(stats: RequestStats) -> str:
     summary =("Response time percentiles (approximated)")
+    summary += ("\n")
     headers = ("Type", "Name") + tuple(get_readable_percentiles(PERCENTILES_TO_REPORT)) + ("# reqs",)
     summary += (
         (
@@ -812,19 +813,25 @@ def get_percentile_stats_summary(stats: RequestStats) -> str:
         )
         % headers
     )
+    summary += ("\n")
     separator = (
         f'{"-" * STATS_TYPE_WIDTH}|{"-" * STATS_NAME_WIDTH}|{"-" * 8}|{("-" * 6 + "|") * len(PERCENTILES_TO_REPORT)}'
     )[:-1]
     summary +=(separator)
+    summary += ("\n")
     for key in sorted(stats.entries.keys()):
         r = stats.entries[key]
         if r.response_times:
             summary+=(r.percentile())
+            summary += ("\n")
     summary += (separator)
+    summary += ("\n")
 
     if stats.total.response_times:
         summary += (stats.total.percentile())
+        summary += ("\n")
     summary += ("")
+    summary += ("\n")
     return summary
 
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -789,7 +789,7 @@ def print_stats(stats: RequestStats, current=True) -> None:
         console_logger.info(summary)
     console_logger.info("")
 
-def get_stats_summary(stats: RequestStats, current=True) -> str:
+def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
     """
         stats summary will be returned as string
     """
@@ -815,7 +815,7 @@ def print_percentile_stats(stats: RequestStats) -> None:
         console_logger.info(summary)
     console_logger.info("")
 
-def get_percentile_stats_summary(stats: RequestStats) -> str:
+def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
     """
         Percentile stats summary will be returned as string
     """


### PR DESCRIPTION
Added get_stats_summary and get_percentile_stats_summary . This will return the stats as string , So that the string can be used in other places. I am using this to record it in Reportportal.
currently print_stats and print_percentile_stats functions are directly record the result into console_logger. But these functions return the same results into string so that it can be used by other log handler