### PR TITLE
Fix / Custom Messages and update examples/docs

### DIFF
--- a/docs/running-distributed.rst
+++ b/docs/running-distributed.rst
@@ -88,24 +88,26 @@ order to coordinate data. This can be easily accomplished with custom messages u
 .. code-block:: python
 
     from locust import events
-    from locust.runners import MasterRunner, WorkerRunner
+    from locust.runners import MasterRunner, WorkerRunner, CustomMessageListener
 
     # Fired when the worker receives a message of type 'test_users'
-    def setup_test_users(environment, msg, **kwargs):
-        for user in msg.data:
-            print(f"User {user['name']} received")
-        environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
+    class SetupTestUsers(CustomMessageListener):
+        def __call__(self, environment, msg, **kwargs):
+            for user in msg.data:
+                print(f"User {user['name']} received")
+            environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
 
     # Fired when the master receives a message of type 'acknowledge_users'
-    def on_acknowledge(msg, **kwargs):
-        print(msg.data)
+    class OnAcknowledge(CustomMessageListener):
+        def __call__(super, msg, **kwargs):
+            print(msg.data)
 
     @events.init.add_listener
     def on_locust_init(environment, **_kwargs):
         if not isinstance(environment.runner, MasterRunner):
-            environment.runner.register_message('test_users', setup_test_users)
+            environment.runner.register_message('test_users', SetupTestUsers)
         if not isinstance(environment.runner, WorkerRunner):
-            environment.runner.register_message('acknowledge_users', on_acknowledge)
+            environment.runner.register_message('acknowledge_users', OnAcknowledge)
 
     @events.test_start.add_listener
     def on_test_start(environment, **_kwargs):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -581,7 +581,7 @@ class LocalRunner(Runner):
         """
         logger.debug(f"Running locally: sending {msg_type} message to self")
         if msg_type in self.custom_messages:
-            listener = self.custom_messages[msg_type]
+            listener = self.custom_messages[msg_type]()
             msg = Message(msg_type, data, "local")
             listener(environment=self.environment, msg=msg)
         else:
@@ -1115,7 +1115,8 @@ class MasterRunner(DistributedRunner):
                 logger.debug(
                     f"Received {msg.type} message from worker {msg.node_id} (index {self.get_worker_index(msg.node_id)})"
                 )
-                self.custom_messages[msg.type](environment=self.environment, msg=msg)
+                listener = self.custom_messages[msg.type]()
+                listener(environment=self.environment, msg=msg)
             else:
                 logger.warning(
                     f"Unknown message type received from worker {msg.node_id} (index {self.get_worker_index(msg.node_id)}): {msg.type}"
@@ -1355,7 +1356,8 @@ class WorkerRunner(DistributedRunner):
                 self.reset_connection()
             elif msg.type in self.custom_messages:
                 logger.debug(f"Received {msg.type} message from master")
-                self.custom_messages[msg.type](environment=self.environment, msg=msg)
+                listener = self.custom_messages[msg.type]()
+                listener(environment=self.environment, msg=msg)
             else:
                 logger.warning(f"Unknown message type received: {msg.type}")
 


### PR DESCRIPTION
#### Background
I was trying to implement the new locust version, running into a few errors.
In our implementation we rely on the messaging feature, when I saw that when registering a message a class ´CustomMessageListener` is now expected I tried to change my code accordingly. 

#### The Error
Beforehand it worked, but after these changes it didn't. 
After some research if found out that using a class with a `__call__` method, still needs proper instantiating.

#### Solution
Therefore I changed the runner code from
```python
self.custom_messages[message_type](environment=self.environment, msg=msg)
```
to
```python
listener = self.custom_messages[msg.type]()
listener(environment=self.environment, msg=msg)
```
and it worked as expected.

I also updated the examples and the documentation to the latest state regarding this feature.

Happy to hear your comments / ideas / input.  Thanks a lot in advance. 

Best Sam