### PR TITLE
Fix parsed options user classes when using class picker

### DIFF
--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -369,8 +369,15 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
             def t(self):
                 pass
 
+        class User2(User):
+            wait_time = constant(1)
+
+            @task
+            def t(self):
+                pass
+
         self.environment.web_ui.userclass_picker_is_active = True
-        self.environment.available_user_classes = {"User1": User1}
+        self.environment.available_user_classes = {"User1": User1, "User2": User2}
 
         response = requests.post(
             "http://127.0.0.1:%i/swarm" % self.web_port,

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -356,6 +356,41 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         response = requests.get("http://127.0.0.1:%i/stop" % self.web_port)
         self.assertEqual(response.json()["message"], "Test stopped")
 
+    def test_swarm_doesnt_update_parsed_options_when_userclass_specified(self):
+        """
+        This test validates that environment.parsed_options.user_classes isn't overwritten
+        when /swarm is hit with 'user_classes' in the data.
+        """
+
+        class User1(User):
+            wait_time = constant(1)
+
+            @task
+            def t(self):
+                pass
+
+        self.environment.web_ui.userclass_picker_is_active = True
+        self.environment.available_user_classes = {"User1": User1}
+
+        response = requests.post(
+            "http://127.0.0.1:%i/swarm" % self.web_port,
+            data={
+                "user_count": 5,
+                "spawn_rate": 5,
+                "host": "https://localhost",
+                "user_classes": ["User1"],
+            },
+        )
+        self.assertListEqual(["User1"], response.json()["user_classes"])
+
+        # stop
+        gevent.sleep(1)
+        response = requests.get("http://127.0.0.1:%i/stop" % self.web_port)
+        self.assertEqual(response.json()["message"], "Test stopped")
+
+        # Checking parsed_options.user_classes remains empty
+        self.assertListEqual(self.environment.parsed_options.user_classes, [])
+
     def test_swarm_defaults_to_all_available_userclasses_when_userclass_picker_is_active_and_no_userclass_in_payload(
         self,
     ):

--- a/locust/web.py
+++ b/locust/web.py
@@ -195,6 +195,9 @@ class WebUI:
                 elif key == "host":
                     # Replace < > to guard against XSS
                     environment.host = str(request.form["host"]).replace("<", "").replace(">", "")
+                elif key == "user_classes":
+                    # Avoiding overriding environment.parsed_options.user_classes
+                    pass
                 elif key in parsed_options_dict:
                     # update the value in environment.parsed_options, but dont change the type.
                     # This won't work for parameters that are None

--- a/locust/web.py
+++ b/locust/web.py
@@ -196,8 +196,8 @@ class WebUI:
                     # Replace < > to guard against XSS
                     environment.host = str(request.form["host"]).replace("<", "").replace(">", "")
                 elif key == "user_classes":
-                    # Avoiding overriding environment.parsed_options.user_classes
-                    pass
+                    # Set environment.parsed_options.user_classes to the selected user_classes
+                    parsed_options_dict[key] = request.form.getlist("user_classes")
                 elif key in parsed_options_dict:
                     # update the value in environment.parsed_options, but dont change the type.
                     # This won't work for parameters that are None


### PR DESCRIPTION
Fix for https://github.com/locustio/locust/issues/2192

When `user_classes` is in the `/swarm` payload, `swarm` will update `environment.parsed_options.user_classes` to include the selected user_classes