### PR TITLE
Fix CustomMessageListener class, and update example and documentation

### DIFF
--- a/docs/running-distributed.rst
+++ b/docs/running-distributed.rst
@@ -88,15 +88,17 @@ order to coordinate data. This can be easily accomplished with custom messages u
 .. code-block:: python
 
     from locust import events
-    from locust.runners import MasterRunner, WorkerRunner
+    from locust.runners import MasterRunner, WorkerRunner, CustomMessageListener
 
     # Fired when the worker receives a message of type 'test_users'
+    @CustomMessageListener
     def setup_test_users(environment, msg, **kwargs):
         for user in msg.data:
             print(f"User {user['name']} received")
         environment.runner.send_message('acknowledge_users', f"Thanks for the {len(msg.data)} users!")
 
     # Fired when the master receives a message of type 'acknowledge_users'
+    @CustomMessageListener
     def on_acknowledge(msg, **kwargs):
         print(msg.data)
 

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -1,15 +1,17 @@
 from locust import HttpUser, task, events, between
-from locust.runners import MasterRunner, WorkerRunner
+from locust.runners import MasterRunner, WorkerRunner, CustomMessageListener
 
 usernames = []
 
 
+@CustomMessageListener
 def setup_test_users(environment, msg, **kwargs):
     # Fired when the worker receives a message of type 'test_users'
     usernames.extend(map(lambda u: u["name"], msg.data))
     environment.runner.send_message("acknowledge_users", f"Thanks for the {len(msg.data)} users!")
 
 
+@CustomMessageListener
 def on_acknowledge(msg, **kwargs):
     # Fired when the master receives a message of type 'acknowledge_users'
     print(msg.data)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -93,10 +93,12 @@ class ExceptionDict(TypedDict):
     nodes: Set[str]
 
 
-class CustomMessageListener(Protocol):
-    @abstractmethod
+class CustomMessageListener:
+    def __init__(self, f):
+        self.f = f
+
     def __call__(self, environment: "Environment", msg: Message) -> None:
-        ...
+        self.f(environment=environment, msg=msg)
 
 
 class Runner:


### PR DESCRIPTION
This is an implementation of the changes mentioned in #2195 which therefore can be closed. 

#### Content of the PR
In previous commits there was the `CustomMessageListener` class implemented, to add type hinting to the message listeners.
This PR is fixing the bug of not being able to utilise this typehinting class. It makes sure to enable users to use the `@CustomMessageListener` decorator for their listener functions, while still being backwards compatible. 

#### Changes made
In `runners.py`
```python 
class CustomMessageListener(Protocol):
    @abstractmethod
    def __call__(self, environment: "Environment", msg: Message) -> None:
```
to
```
class CustomMessageListener:
    def __init__(self, f):
        self.f = f  # Store the function

    def __call__(self, environment: "Environment", msg: Message) -> None:
        self.f(environment=environment, msg=msg)
```

#### Additional Changes:
Updated the `custom_messages.py` example and the `running-distributed.rst` documentation file.