### PR TITLE
Second fix for --class-picker resetting user_count on edits

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -184,10 +184,6 @@ class WebUI:
                 else:
                     self._update_shape_class(form_data_shape_class_name)
 
-                # Setting user dispatchers to None so that the runners recreate the
-                # UserDistpatcher with the appropriate user classes
-                self._reset_users_dispatcher()
-
             parsed_options_dict = vars(environment.parsed_options) if environment.parsed_options else {}
             run_time = None
             for key, value in request.form.items():
@@ -583,6 +579,3 @@ class WebUI:
 
     def _stop_runners(self):
         self.environment.runner.stop()
-
-    def _reset_users_dispatcher(self):
-        self.environment.runner._users_dispatcher = None


### PR DESCRIPTION
Second fix for https://github.com/locustio/locust/issues/2204.

As it turns out, the `_reset_users_dispatcher` method isn't necessary. It was originally used for resetting the runners when `user_classes` is in the `/swarm` payload, since I was seeing issues if I didn't do this when originally developing the class picker. My guess is that I updated `_update_user_classes` at some point during that feature and it was the actual fix for the errors I was seeing.

<img width="1695" alt="Screen Shot 2022-09-20 at 8 56 37 AM" src="https://user-images.githubusercontent.com/19849309/191264883-bfdc913e-cff7-4da9-9bea-a284566ff0ad.png">
