### PR TITLE
Delete the `CustomMessageListener` class for type consistency

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -27,7 +27,8 @@ from typing import (
     Tuple,
     Type,
     Any,
-    cast, Callable,
+    cast,
+    Callable,
 )
 from uuid import uuid4
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -93,12 +93,6 @@ class ExceptionDict(TypedDict):
     nodes: Set[str]
 
 
-class CustomMessageListener(Protocol):
-    @abstractmethod
-    def __call__(self, environment: "Environment", msg: Message) -> None:
-        ...
-
-
 class Runner:
     """
     Orchestrates the load test by starting and stopping the users.
@@ -130,7 +124,7 @@ class Runner:
         self.target_user_classes_count: Dict[str, int] = {}
         # target_user_count is set before the ramp-up/ramp-down occurs.
         self.target_user_count: int = 0
-        self.custom_messages: Dict[str, CustomMessageListener] = {}
+        self.custom_messages: Dict[str, any] = {}
 
         self._users_dispatcher: Optional[UsersDispatcher] = None
 
@@ -432,7 +426,7 @@ class Runner:
         row["nodes"].add(node_id)
         self.exceptions[key] = row
 
-    def register_message(self, msg_type: str, listener: CustomMessageListener) -> None:
+    def register_message(self, msg_type: str, listener) -> None:
         """
         Register a listener for a custom message from another node
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -27,7 +27,7 @@ from typing import (
     Tuple,
     Type,
     Any,
-    cast,
+    cast, Callable,
 )
 from uuid import uuid4
 
@@ -124,7 +124,7 @@ class Runner:
         self.target_user_classes_count: Dict[str, int] = {}
         # target_user_count is set before the ramp-up/ramp-down occurs.
         self.target_user_count: int = 0
-        self.custom_messages: Dict[str, any] = {}
+        self.custom_messages: Dict[str, Callable] = {}
 
         self._users_dispatcher: Optional[UsersDispatcher] = None
 
@@ -426,7 +426,7 @@ class Runner:
         row["nodes"].add(node_id)
         self.exceptions[key] = row
 
-    def register_message(self, msg_type: str, listener) -> None:
+    def register_message(self, msg_type: str, listener: Callable) -> None:
         """
         Register a listener for a custom message from another node
 


### PR DESCRIPTION
This PR is the conclusion of #2208. 
It deletes the `CustomMessageListener` class for type consistency and adds `Callable` type hint instead.