### PR TITLE
Fix: Enhance typing of the tasks attribute in the User class

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -245,6 +245,8 @@ class Environment:
             u.weight = 1
             user_tasks: List[TaskSet | Callable] = []
             tasks_frontier = u.tasks
+            isinstance(tasks_frontier, list)
+
             while len(tasks_frontier) != 0:
                 t = tasks_frontier.pop()
                 if isinstance(t, TaskHolder):

--- a/locust/env.py
+++ b/locust/env.py
@@ -256,7 +256,7 @@ class Environment:
                         user_tasks.append(t)
                 else:
                     raise ValueError("Unrecognized task type in user")
-            u.tasks = user_tasks
+            u.tasks = user_tasks  # type: ignore
 
     def _validate_user_class_name_uniqueness(self):
         # Validate there's no class with the same name but in different modules

--- a/locust/env.py
+++ b/locust/env.py
@@ -245,7 +245,7 @@ class Environment:
             u.weight = 1
             user_tasks: List[TaskSet | Callable] = []
             tasks_frontier = u.tasks
-            isinstance(tasks_frontier, list)
+            assert isinstance(tasks_frontier, list)
 
             while len(tasks_frontier) != 0:
                 t = tasks_frontier.pop()

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 from gevent import GreenletExit, greenlet
 from gevent.pool import Group
@@ -84,7 +84,7 @@ class User(metaclass=UserMeta):
     Method that returns the time between the execution of locust tasks in milliseconds
     """
 
-    tasks: List[TaskSet | Callable] = []
+    tasks: List[TaskSet | Callable] | dict[Callable, int] | Tuple = []
     """
     Collection of python callables and/or TaskSet classes that the Locust user(s) will run.
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -84,7 +84,7 @@ class User(metaclass=UserMeta):
     Method that returns the time between the execution of locust tasks in milliseconds
     """
 
-    tasks: List[TaskSet | Callable] | dict[Callable, int] | Tuple = []
+    tasks: List[TaskSet | Callable | Tuple] | dict[Callable, int] = []
     """
     Collection of python callables and/or TaskSet classes that the Locust user(s) will run.
 


### PR DESCRIPTION
#### Description
This PR fixes a minor typing issue in the `User` class, it is related to the issue #2256.

#### The change
The code is changed from: 
```python
from
    tasks: List[TaskSet | Callable]  = []
to
    tasks: List[TaskSet | Callable | Tuple]  | dict[Callable, int] = []
```