### PR TITLE
Add conditional monkeypatching for threads (see issue #2250)

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -8,7 +8,8 @@ if os.getenv("LOCUST_PLAYWRIGHT", False):
 
 from gevent import monkey
 
-monkey.patch_all()
+if not monkey.is_module_patched('thread'):
+    monkey.patch_thread()
 
 from ._version import version as __version__
 from .user.sequential_taskset import SequentialTaskSet

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -8,8 +8,8 @@ if os.getenv("LOCUST_PLAYWRIGHT", False):
 
 from gevent import monkey
 
-if not monkey.is_module_patched('thread'):
-    monkey.patch_thread()
+if monkey.is_module_patched("ssl"):
+    monkey.patch_all(ssl=False)
 
 from ._version import version as __version__
 from .user.sequential_taskset import SequentialTaskSet


### PR DESCRIPTION
Mass monkeypatching via `monkey.patch_all()` in some setups did lead to double patching and [incompatibilities](https://github.com/locustio/locust/issues/2250) e.g. with `boto3` modules, hence there was a [proposition](https://github.com/locustio/locust/issues/2250#issuecomment-1315065631) to patch only the `thread` module if it wasn't patched yet.