### PR TITLE
Handling zmq corrupted message

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -988,14 +988,9 @@ class MasterRunner(DistributedRunner):
             try:
                 client_id, msg = self.server.recv_from_client()
             except RPCReceiveError as e:
-                logger.error(f"RPCError when receiving from client: {e}. Will reset client {client_id}.")
-                try:
-                    self.server.send_to_client(Message("reconnect", None, client_id))
-                except Exception as e:
-                    logger.error(f"Error sending reconnect message to worker: {e}. Will reset RPC server.")
-                    self.connection_broken = True
-                    gevent.sleep(FALLBACK_INTERVAL)
-                    continue
+                # TODO: Add proper reconnect if https://github.com/zeromq/pyzmq/issues/1809 fixed
+                logger.error(f"Unrecognized message detected: {e}")
+                continue
             except RPCSendError as e:
                 logger.error(f"Error sending reconnect message to worker: {e}. Will reset RPC server.")
                 self.connection_broken = True

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3040,7 +3040,7 @@ class TestMasterRunner(LocustRunnerTestCase):
             master.start(10, 10)
             sleep(0.1)
             server.mocked_send(Message("stats", BAD_MESSAGE, "zeh_fake_client1"))
-            self.assertEqual(3, len(server.outbox))
+            self.assertEqual(2, len(server.outbox))
 
 
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3043,7 +3043,6 @@ class TestMasterRunner(LocustRunnerTestCase):
             self.assertEqual(2, len(server.outbox))
 
 
-
 class TestWorkerRunner(LocustTestCase):
     def setUp(self):
         super().setUp()

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3040,12 +3040,8 @@ class TestMasterRunner(LocustRunnerTestCase):
             master.start(10, 10)
             sleep(0.1)
             server.mocked_send(Message("stats", BAD_MESSAGE, "zeh_fake_client1"))
-            self.assertEqual(4, len(server.outbox))
+            self.assertEqual(3, len(server.outbox))
 
-            # Expected message order in outbox: ack, spawn, reconnect, ack
-            self.assertEqual(
-                "reconnect", server.outbox[2][1].type, "Master didn't send worker reconnect message when expected."
-            )
 
 
 class TestWorkerRunner(LocustTestCase):


### PR DESCRIPTION
#2260 
Disable reconnect