### PR TITLE
Stats in json to stdout

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -492,7 +492,7 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         "--json",
         default=False,
         action="store_true",
-        help="Prints the final stats in JSON format to stdout. Usefull for parsing the results in other programs/scripts."
+        help="Prints the final stats in JSON format to stdout. Usefull for parsing the results in other programs/scripts.",
     )
 
     log_group = parser.add_argument_group("Logging options")

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -488,6 +488,12 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         help="Store HTML report to file path specified",
         env_var="LOCUST_HTML",
     )
+    stats_group.add_argument(
+        "--json",
+        default=False,
+        action="store_true",
+        help="Prints the final stats in JSON format to stdout. Usefull for parsing the results in other programs/scripts."
+    )
 
     log_group = parser.add_argument_group("Logging options")
     log_group.add_argument(

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -492,7 +492,7 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         "--json",
         default=False,
         action="store_true",
-        help="Prints the final stats in JSON format to stdout. Usefull for parsing the results in other programs/scripts.",
+        help="Prints the final stats in JSON format to stdout. Useful for parsing the results in other programs/scripts. Use together with --headless and --skip-log for an output only with the json data.",
     )
 
     log_group = parser.add_argument_group("Logging options")

--- a/locust/log.py
+++ b/locust/log.py
@@ -32,6 +32,11 @@ def setup_logging(loglevel, logfile=None):
                 "class": "logging.StreamHandler",
                 "formatter": "plain",
             },
+            "console_plain_stdout": {
+                "class": "logging.StreamHandler",
+                "formatter": "plain",
+                "stream": "ext://sys.stdout",
+            },
         },
         "loggers": {
             "locust": {
@@ -45,7 +50,7 @@ def setup_logging(loglevel, logfile=None):
                 "propagate": False,
             },
             "locust.stats_logger.json": {
-                "handlers": ["console_plain"],
+                "handlers": ["console_plain_stdout"],
                 "level": "INFO",
                 "propagate": False,
             },

--- a/locust/log.py
+++ b/locust/log.py
@@ -44,6 +44,11 @@ def setup_logging(loglevel, logfile=None):
                 "level": "INFO",
                 "propagate": False,
             },
+            "locust.stats_logger.json": {
+                "handlers": ["console_plain"],
+                "level": "INFO",
+                "propagate": False,
+            },
         },
         "root": {
             "handlers": ["console"],

--- a/locust/log.py
+++ b/locust/log.py
@@ -32,11 +32,6 @@ def setup_logging(loglevel, logfile=None):
                 "class": "logging.StreamHandler",
                 "formatter": "plain",
             },
-            "console_plain_stdout": {
-                "class": "logging.StreamHandler",
-                "formatter": "plain",
-                "stream": "ext://sys.stdout",
-            },
         },
         "loggers": {
             "locust": {
@@ -46,11 +41,6 @@ def setup_logging(loglevel, logfile=None):
             },
             "locust.stats_logger": {
                 "handlers": ["console_plain"],
-                "level": "INFO",
-                "propagate": False,
-            },
-            "locust.stats_logger.json": {
-                "handlers": ["console_plain_stdout"],
                 "level": "INFO",
                 "propagate": False,
             },

--- a/locust/main.py
+++ b/locust/main.py
@@ -13,7 +13,14 @@ from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
 from .log import setup_logging, greenlet_exception_logger
 from . import stats
-from .stats import print_error_report, print_percentile_stats, print_stats, print_stats_json, stats_printer, stats_history
+from .stats import (
+    print_error_report,
+    print_percentile_stats,
+    print_stats,
+    print_stats_json,
+    stats_printer,
+    stats_history,
+)
 from .stats import StatsCSV, StatsCSVFileWriter
 from .user.inspectuser import print_task_ratio, print_task_ratio_json
 from .util.timespan import parse_timespan
@@ -246,7 +253,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         for key in logging.Logger.manager.loggerDict:
             if key != "locust.stats_logger.json":
                 logging.getLogger(key).setLevel(logging.ERROR)
-    
 
     # start Web UI
     if not options.headless and not options.worker:

--- a/locust/main.py
+++ b/locust/main.py
@@ -13,7 +13,7 @@ from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
 from .log import setup_logging, greenlet_exception_logger
 from . import stats
-from .stats import print_error_report, print_percentile_stats, print_stats, stats_printer, stats_history
+from .stats import print_error_report, print_percentile_stats, print_stats, print_stats_json, stats_printer, stats_history
 from .stats import StatsCSV, StatsCSVFileWriter
 from .user.inspectuser import print_task_ratio, print_task_ratio_json
 from .util.timespan import parse_timespan
@@ -435,8 +435,9 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         logger.debug("Cleaning up runner...")
         if runner is not None:
             runner.quit()
-
-        if not isinstance(runner, locust.runners.WorkerRunner):
+        if options.json:
+            print_stats_json(runner.stats)
+        elif not isinstance(runner, locust.runners.WorkerRunner):
             print_stats(runner.stats, current=False)
             print_percentile_stats(runner.stats)
             print_error_report(runner.stats)

--- a/locust/main.py
+++ b/locust/main.py
@@ -241,6 +241,13 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     else:
         stats_csv_writer = StatsCSV(environment, stats.PERCENTILES_TO_REPORT)
 
+    if options.json:
+        # disable all logging to stdout
+        for key in logging.Logger.manager.loggerDict:
+            if key != "locust.stats_logger.json":
+                logging.getLogger(key).setLevel(logging.ERROR)
+    
+
     # start Web UI
     if not options.headless and not options.worker:
         # spawn web greenlet

--- a/locust/main.py
+++ b/locust/main.py
@@ -248,12 +248,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     else:
         stats_csv_writer = StatsCSV(environment, stats.PERCENTILES_TO_REPORT)
 
-    if options.json:
-        # disable all logging to stdout
-        for key in logging.Logger.manager.loggerDict:
-            if key != "locust.stats_logger.json":
-                logging.getLogger(key).setLevel(logging.ERROR)
-
     # start Web UI
     if not options.headless and not options.worker:
         # spawn web greenlet

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import abstractmethod
 import datetime
 import hashlib
+import json
 from tempfile import NamedTemporaryFile
 import time
 from collections import namedtuple, OrderedDict
@@ -786,6 +787,9 @@ def print_stats(stats: RequestStats, current=True) -> None:
         console_logger.info(line)
     console_logger.info("")
 
+def print_stats_json(stats: RequestStats) -> None:
+    json_logger = logging.getLogger("locust.stats_logger.json")
+    json_logger.info(json.dumps(stats.serialize_stats(), indent=4))
 
 def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
     """

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -789,8 +789,7 @@ def print_stats(stats: RequestStats, current=True) -> None:
 
 
 def print_stats_json(stats: RequestStats) -> None:
-    json_logger = logging.getLogger("locust.stats_logger.json")
-    json_logger.info(json.dumps(stats.serialize_stats(), indent=4))
+    print(json.dumps(stats.serialize_stats(), indent=4))
 
 
 def get_stats_summary(stats: RequestStats, current=True) -> List[str]:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -787,9 +787,11 @@ def print_stats(stats: RequestStats, current=True) -> None:
         console_logger.info(line)
     console_logger.info("")
 
+
 def print_stats_json(stats: RequestStats) -> None:
     json_logger = logging.getLogger("locust.stats_logger.json")
     json_logger.info(json.dumps(stats.serialize_stats(), indent=4))
+
 
 def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
     """

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1416,15 +1416,7 @@ class SecondUser(HttpUser):
         )
         with mock_locustfile(content=LOCUSTFILE_CONTENT) as mocked:
             proc = subprocess.Popen(
-                [
-                    "locust",
-                    "-f",
-                    mocked.file_path,
-                    "--headless",
-                    "-t",
-                    "5s",
-                    "--json"
-                ],
+                ["locust", "-f", mocked.file_path, "--headless", "-t", "5s", "--json"],
                 stderr=DEVNULL,
                 stdout=PIPE,
                 text=True,
@@ -1436,6 +1428,61 @@ class SecondUser(HttpUser):
             except json.JSONDecodeError:
                 self.fail(f"Trying to parse {stdout} as json failed")
             self.assertEqual(0, proc.returncode)
+
+    def test_json_schema(self):
+        LOCUSTFILE_CONTENT = textwrap.dedent(
+            """
+            from locust import HttpUser, task, constant
+
+            class QuickstartUser(HttpUser):
+                wait_time = constant(1)
+
+                @task
+                def hello_world(self):
+                    self.client.get("/")
+
+            """
+        )
+        with mock_locustfile(content=LOCUSTFILE_CONTENT) as mocked:
+            proc = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--host",
+                    "http://google.com",
+                    "--headless",
+                    "-u",
+                    "1",
+                    "-t",
+                    "2s",
+                    "--json",
+                ],
+                stderr=DEVNULL,
+                stdout=PIPE,
+                text=True,
+            )
+            stdout, stderr = proc.communicate()
+
+            try:
+                data = json.loads(stdout)
+            except json.JSONDecodeError:
+                self.fail(f"Trying to parse {stdout} as json failed")
+
+            self.assertEqual(0, proc.returncode)
+
+            result = data[0]
+            self.assertEqual(float, type(result["last_request_timestamp"]))
+            self.assertEqual(float, type(result["start_time"]))
+            self.assertEqual(int, type(result["num_requests"]))
+            self.assertEqual(int, type(result["num_none_requests"]))
+            self.assertEqual(float, type(result["total_response_time"]))
+            self.assertEqual(float, type(result["max_response_time"]))
+            self.assertEqual(float, type(result["min_response_time"]))
+            self.assertEqual(int, type(result["total_content_length"]))
+            self.assertEqual(dict, type(result["response_times"]))
+            self.assertEqual(dict, type(result["num_reqs_per_sec"]))
+            self.assertEqual(dict, type(result["num_fail_per_sec"]))
 
     def test_worker_indexes(self):
         content = """


### PR DESCRIPTION
I extended the cli with a `--json` argument. This argument prints the result of a run in json, after a run is finished. It blocks other INFO logs, so it's easy to interoperable with other programs. Below is an example with `jq`

```shell
❯ python -m locust -f examples/locustfile.py --host http://localhost:80 --headless -u 10 -t 4s --json
[
    {
        "name": "/",
        "method": "GET",
        "last_request_timestamp": 1670363796.9102132,
        "start_time": 1670363793.665749,
        "num_requests": 8,
        "num_none_requests": 0,
        "num_failures": 0,
        "total_response_time": 61.882097012130544,
        "max_response_time": 18.852641980629414,
        "min_response_time": 3.2629000197630376,
        "total_content_length": 4920,
        "response_times": {
            "19": 1,
            "9": 1,
            "4": 3,
            "10": 1,
            "3": 1,
            "8": 1
        },
        "num_reqs_per_sec": {
            "1670363793": 1,
            "1670363794": 2,
            "1670363795": 1,
            "1670363796": 4
        },
        "num_fail_per_sec": {}
    }
]
```
```shell
❯ python -m locust -f examples/locustfile.py --host http://localhost:80 --headless -u 10 -t 4s --json | jq .[0].response_times
{
  "11": 2,
  "10": 1,
  "4": 4,
  "9": 1
}
```
Locust: 2.13.2.dev11
Python: 3.10.8