### PR TITLE
Fix: Ask worker to reconnect if master gets a broken RPC message

### DIFF
--- a/locust/exception.py
+++ b/locust/exception.py
@@ -68,6 +68,9 @@ class RPCReceiveError(Exception):
 
     When raised from zmqrpc, client connection should be reestablished.
     """
+    def __init__(self, *args: object, addr=None) -> None:
+        super().__init__(*args)
+        self.addr = addr
 
 
 class AuthCredentialsError(ValueError):

--- a/locust/exception.py
+++ b/locust/exception.py
@@ -68,6 +68,7 @@ class RPCReceiveError(Exception):
 
     When raised from zmqrpc, client connection should be reestablished.
     """
+
     def __init__(self, *args: object, addr=None) -> None:
         super().__init__(*args)
         self.addr = addr

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -49,7 +49,7 @@ class BaseSocket:
         try:
             msg = Message.unserialize(data[1])
         except (UnicodeDecodeError, msgerr.ExtraData) as e:
-            raise RPCReceiveError(f"ZMQ interrupted or corrupted message from {addr}") from e
+            raise RPCReceiveError("ZMQ interrupted or corrupted message", addr=addr) from e
         return addr, msg
 
     def close(self, linger=None):

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -49,7 +49,7 @@ class BaseSocket:
         try:
             msg = Message.unserialize(data[1])
         except (UnicodeDecodeError, msgerr.ExtraData) as e:
-            raise RPCReceiveError("ZMQ interrupted or corrupted message") from e
+            raise RPCReceiveError(f"ZMQ interrupted or corrupted message from {addr}") from e
         return addr, msg
 
     def close(self, linger=None):

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -989,7 +989,9 @@ class MasterRunner(DistributedRunner):
                 client_id, msg = self.server.recv_from_client()
             except RPCReceiveError as e:
                 # TODO: Add proper reconnect if https://github.com/zeromq/pyzmq/issues/1809 fixed
-                logger.error(f"Unrecognized message detected: {e}")
+                addr = e.addr
+                message = f'{e}' if not addr else f'{e} from {addr}'
+                logger.error(f"Unrecognized message detected: {message}")
                 continue
             except RPCSendError as e:
                 logger.error(f"Error sending reconnect message to worker: {e}. Will reset RPC server.")

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -994,8 +994,8 @@ class MasterRunner(DistributedRunner):
                     logger.error(f"RPCError when receiving from client: {e}. Will reset client {client_id}.")
                     try:
                         self.server.send_to_client(Message("reconnect", None, client_id))
-                    except Exception as e:
-                        logger.error(f"Error sending reconnect message to worker: {e}. Will reset RPC server.")
+                    except Exception as error:
+                        logger.error(f"Error sending reconnect message to worker: {error}. Will reset RPC server.")
                         self.connection_broken = True
                         gevent.sleep(FALLBACK_INTERVAL)
                         continue

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3078,7 +3078,7 @@ class TestMasterRunner(LocustRunnerTestCase):
 
     def test_unknown_host_sends_message_to_master(self):
         """
-        Validate master ignores message that is.
+        Validate master ignores message that is sent from unknown host
         """
 
         class TestUser(User):


### PR DESCRIPTION
#2260

Follow up - restore reconnect when client_id is known