### PR TITLE
Fix setuptools deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,7 @@ classifiers =
     Topic :: System :: Distributed Computing
 
 [options]
-packages = find:
-include_package_data = true
+packages = find_namespace:
 zip_safe = false
 python_requires = >= 3.7
 install_requires =
@@ -52,9 +51,16 @@ install_requires =
     pywin32;platform_system=='Windows'
 
 [options.packages.find]
+include = locust*
 exclude =
     examples
     tests
+
+[options.package_data]
+locust.static = 
+    **/*
+locust.templates = 
+    **/*
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = locust
-license_file = LICENSE
+license_files = LICENSE
 url = https://locust.io/
 project_urls = 
     Documentation = https://docs.locust.io/


### PR DESCRIPTION
Fix for #2279

Change packages directive in setup.cfg to use find_namespace: and add [opptions.package_data] for including HTML templates and static files.

This fixes a SetuptoolsDeprecationWarning when running setup.py build.