### PR TITLE
add events when initialize Environment

### DIFF
--- a/examples/use_as_lib.py
+++ b/examples/use_as_lib.py
@@ -1,5 +1,5 @@
 import gevent
-from locust import HttpUser, task
+from locust import HttpUser, task, events
 from locust.env import Environment
 from locust.stats import stats_printer, stats_history
 from locust.log import setup_logging
@@ -16,7 +16,7 @@ class MyUser(HttpUser):
 
 
 # setup Environment and Runner
-env = Environment(user_classes=[MyUser])
+env = Environment(user_classes=[MyUser], events=events)
 runner = env.create_local_runner()
 
 # start a WebUI instance


### PR DESCRIPTION
Add events when initialize `Environment(user_classes=[MyUser], events=events)`, otherwise the event codes in the example(as following) won't work

```python
# ...
env.events.init.fire(environment=env, runner=runner, web_ui=web_ui)
```