### PR TITLE
docs (#2188):  Add Locust Kubernetes Operator

### DIFF
--- a/docs/running-in-docker.rst
+++ b/docs/running-in-docker.rst
@@ -39,10 +39,21 @@ official Locust docker image as a base image::
 
 
 Running a distributed load test on Kubernetes
-=============================================
+==============================================
 
-The easiest way to run Locust on Kubernetes is to use a `Helm chart <https://helm.sh/>`_.
+HELM
+*****
+
+One of the ways to run Locust on Kubernetes is to use a `Helm chart <https://helm.sh/>`_.
 
 There is a good helm chart here: `github.com/deliveryhero/helm-charts <https://github.com/deliveryhero/helm-charts/tree/master/stable/locust>`_.
 
-Note: this Helm chart is a separate project, and not supported by Locust maintainers.
+Note: this Helm chart is a separate project, and not supported by Locust maintainers. 
+
+Kubernetes Operator
+*******************
+Another way to run Locust on Kubernetes is to use the `Locust Kubernetes Operator <https://abdelrhmanhamouda.github.io/locust-k8s-operator/>`_.
+
+The Locust Operator is designed to unlock easy, seamless & effortless distributed performance testing in the cloud.
+
+Note: the Locust Kubernetes Operator is a separate project and is not supported by Locust maintainers. 


### PR DESCRIPTION
locustio/locust#2188 

- Update `Running a distributed load test on Kubernetes` docs section to include Locust Kubernetes Operator. 
- Small reformat of the section to clearly list all possibilities (HELM & Operator)  in a structured manner.