### PR TITLE
Add IPv6 support for zmq connections

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -4,6 +4,7 @@ from locust.util.exception_handler import retry
 from locust.exception import RPCError, RPCSendError, RPCReceiveError
 import zmq.error as zmqerr
 import msgpack.exceptions as msgerr
+import socket
 
 
 class BaseSocket:
@@ -13,7 +14,8 @@ class BaseSocket:
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-        self.socket.setsockopt(zmq.IPV6, 1)
+        if socket.has_ipv6:
+            self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()
     def send(self, msg):

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -13,6 +13,7 @@ class BaseSocket:
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+        self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()
     def send(self, msg):


### PR DESCRIPTION
This is a small fix to allow distributed testing in a IPv6 only network like fly.io.