### PR TITLE
Enable download of (aggregated) history from web

### DIFF
--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -232,7 +232,9 @@
                 <div style="margin-top:20px;">
                     <a href="./stats/requests/csv">Download request statistics CSV</a><br>
                     {% if stats_history_enabled %}
-                        <a href="./stats/requests_full_history/csv">Download full request statistics history CSV</a><br>
+                        <a href="./stats/requests_history/csv">Download full request statistics history CSV</a><br>
+                    {% else %}
+                        <a href="./stats/requests_history/csv">Download request statistics history CSV</a><br>
                     {% endif %}
                     <a href="./stats/failures/csv">Download failures CSV</a><br>
                     <a href="./exceptions/csv">Download exceptions CSV</a><br>

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -231,10 +231,8 @@
             <div style="display:none;">
                 <div style="margin-top:20px;">
                     <a href="./stats/requests/csv">Download request statistics CSV</a><br>
-                    {% if stats_history_enabled %}
-                        <a href="./stats/requests_history/csv">Download full request statistics history CSV</a><br>
-                    {% else %}
-                        <a href="./stats/requests_history/csv">Download request statistics history CSV</a><br>
+                    {% if stats_csv_enabled %}
+                        <a href="./stats/requests_history/csv">Download {{'full' if stats_history_enabled else ''}} request statistics history CSV</a><br>
                     {% endif %}
                     <a href="./stats/failures/csv">Download failures CSV</a><br>
                     <a href="./exceptions/csv">Download exceptions CSV</a><br>

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -1043,7 +1043,7 @@ class TestWebUIFullHistory(LocustTestCase, _HeaderCheckMixin):
         self.stats_csv_writer.stats_history_flush()
         gevent.kill(greenlet)
 
-        response = requests.get("http://127.0.0.1:%i/stats/requests_full_history/csv" % self.web_port)
+        response = requests.get("http://127.0.0.1:%i/stats/requests_history/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
         self._check_csv_headers(response.headers, "requests_full_history")
         self.assertIn("Content-Length", response.headers)

--- a/locust/web.py
+++ b/locust/web.py
@@ -31,7 +31,6 @@ from flask_cors import CORS
 if TYPE_CHECKING:
     from .env import Environment
 
-
 logger = logging.getLogger(__name__)
 greenlet_exception_handler = greenlet_exception_logger(logger)
 
@@ -70,16 +69,16 @@ class WebUI:
     extending index.html."""
 
     def __init__(
-        self,
-        environment: "Environment",
-        host: str,
-        port: int,
-        auth_credentials: Optional[str] = None,
-        tls_cert: Optional[str] = None,
-        tls_key: Optional[str] = None,
-        stats_csv_writer: Optional[StatsCSV] = None,
-        delayed_start=False,
-        userclass_picker_is_active=False,
+            self,
+            environment: "Environment",
+            host: str,
+            port: int,
+            auth_credentials: Optional[str] = None,
+            tls_cert: Optional[str] = None,
+            tls_key: Optional[str] = None,
+            stats_csv_writer: Optional[StatsCSV] = None,
+            delayed_start=False,
+            userclass_picker_is_active=False,
     ):
         """
         Create WebUI instance and start running the web server in a separate greenlet (self.greenlet)
@@ -300,23 +299,24 @@ class WebUI:
             self.stats_csv_writer.requests_csv(writer)
             return _download_csv_response(data.getvalue(), "requests")
 
-        @app.route("/stats/requests_full_history/csv")
+        @app.route("/stats/requests_history/csv")
         @self.auth_required_if_enabled
         def request_stats_full_history_csv() -> Response:
             options = self.environment.parsed_options
-            if options and options.stats_history_enabled and isinstance(self.stats_csv_writer, StatsCSVFileWriter):
+            if options and isinstance(self.stats_csv_writer, StatsCSVFileWriter):
                 return send_file(
                     os.path.abspath(self.stats_csv_writer.stats_history_file_name()),
                     mimetype="text/csv",
                     as_attachment=True,
-                    download_name=_download_csv_suggest_file_name("requests_full_history"),
+                    download_name=_download_csv_suggest_file_name(
+                        "requests_full_history" if options.stats_history_enabled else "requests_history"),
                     etag=True,
                     max_age=0,
                     conditional=True,
                     last_modified=None,
                 )
 
-            return make_response("Error: Server was not started with option to generate full history.", 404)
+            return make_response("Error: Server was not started with option to generate CSV history '--csv'.", 404)
 
         @app.route("/stats/failures/csv")
         @self.auth_required_if_enabled

--- a/locust/web.py
+++ b/locust/web.py
@@ -69,16 +69,16 @@ class WebUI:
     extending index.html."""
 
     def __init__(
-            self,
-            environment: "Environment",
-            host: str,
-            port: int,
-            auth_credentials: Optional[str] = None,
-            tls_cert: Optional[str] = None,
-            tls_key: Optional[str] = None,
-            stats_csv_writer: Optional[StatsCSV] = None,
-            delayed_start=False,
-            userclass_picker_is_active=False,
+        self,
+        environment: "Environment",
+        host: str,
+        port: int,
+        auth_credentials: Optional[str] = None,
+        tls_cert: Optional[str] = None,
+        tls_key: Optional[str] = None,
+        stats_csv_writer: Optional[StatsCSV] = None,
+        delayed_start=False,
+        userclass_picker_is_active=False,
     ):
         """
         Create WebUI instance and start running the web server in a separate greenlet (self.greenlet)
@@ -550,6 +550,7 @@ class WebUI:
             "worker_count": worker_count,
             "is_shape": self.environment.shape_class and not self.userclass_picker_is_active,
             "stats_history_enabled": options and options.stats_history_enabled,
+            "stats_csv_enabled": isinstance(self.stats_csv_writer, StatsCSVFileWriter),
             "tasks": dumps({}),
             "extra_options": extra_options,
             "show_userclass_picker": self.userclass_picker_is_active,


### PR DESCRIPTION
## Description
Enable downloading of CSV with aggregated history through the web ui.
Currently the web ui allows for downloading following data:
- request statistics csv
- failures csv
- exceptions csv
- report html
- full history csv when enabled in configuration `--csv-full-history`

## Changes
Allow the download of the aggregated history csv in the web ui when `--csv` is enabled but not `--csv-full-history`.