### PR TITLE
fix: docs describing running without web UI had improper flag -f. Cor…

### DIFF
--- a/docs/retrieving-stats.rst
+++ b/docs/retrieving-stats.rst
@@ -6,16 +6,16 @@ You may wish to consume your Locust results via a CSV file. In this case, there 
 
 First, when running Locust with the web UI, you can retrieve CSV files under the Download Data tab. 
 
-Secondly, you can run Locust with a flag which will periodically save three CSV files. This is particularly useful
+Secondly, you can run Locust with a flag which will periodically save four CSV files. This is particularly useful
 if you plan on running Locust in an automated way with the ``--headless`` flag:
 
 .. code-block:: console
 
     $ locust -f examples/basic.py --csv=example --headless -t10m
 
-The files will be named ``example_stats.csv``, ``example_failures.csv`` and ``example_history.csv``
+The files will be named ``example_stats.csv``, ``example_failures.csv``, ``example_exceptions.csv`` and ``example_stats_history.csv``
 (when using ``--csv=example``). The first two files will contain the stats and failures for the whole 
-test run, with a row for every stats entry (URL endpoint) and an aggregated row. The ``example_history.csv`` 
+test run, with a row for every stats entry (URL endpoint) and an aggregated row. The ``example_stats_history.csv`` 
 will get new rows with the *current* (10 seconds sliding window) stats appended during the whole test run. 
 By default only the Aggregate row is appended regularly to the history stats, but if Locust is started with 
 the ``--csv-full-history`` flag, a row for each stats entry (and the Aggregate) is appended every time 

--- a/docs/running-without-web-ui.rst
+++ b/docs/running-without-web-ui.rst
@@ -32,8 +32,8 @@ To specify the run time for a test, use ``-t/--run-time``:
 
 .. code-block:: console
 
-    $ locust -f --headless -u 100 --run-time 1h30m
-    $ locust -f --headless -u 100 --run-time 60 # default unit is seconds
+    $ locust --headless -u 100 --run-time 1h30m
+    $ locust --headless -u 100 --run-time 60 # default unit is seconds
 
 Locust will shut down once the time is up. Time is calculated from the start of the test (not from when ramp up has finished).
 


### PR DESCRIPTION
Docs describing running in headless mode had dangling `-f` flag which caused error
Actually there are 4 CSV files generated in headless mode.