### PR TITLE
Allow to change worker id pattern

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -12,6 +12,7 @@ version = locust.__version__
 
 
 DEFAULT_CONFIG_FILES = ["~/.locust.conf", "locust.conf"]
+WORKER_ID_PATTERN = "%(hostname)s_%(uuid)s"
 
 
 class LocustArgumentParser(configargparse.ArgumentParser):
@@ -437,6 +438,14 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         help="The port to connect to that is used by the locust master for distributed load testing. Only used when running with --worker. Defaults to 5557.",
         env_var="LOCUST_MASTER_NODE_PORT",
         metavar="MASTER_NODE_PORT",
+    )
+    worker_group.add_argument(
+        "--worker-id-pattern",
+        type=str,
+        default=WORKER_ID_PATTERN,
+        help="Pattern of worker ID. Only used when running with --worker. Defaults to %(default)s. Variables to use: hostname, uuid",
+        env_var="LOCUST_WORKER_ID_PATTERN",
+        metavar="WORKER_ID_PATTERN",
     )
 
     tag_group = parser.add_argument_group(

--- a/locust/env.py
+++ b/locust/env.py
@@ -10,6 +10,7 @@ from typing import (
 
 from configargparse import Namespace
 
+from .argument_parser import WORKER_ID_PATTERN
 from .event import Events
 from .exception import RunnerAlreadyExistsError
 from .stats import RequestStats, StatsCSV
@@ -140,12 +141,15 @@ class Environment:
             master_bind_port=master_bind_port,
         )
 
-    def create_worker_runner(self, master_host: str, master_port: int) -> WorkerRunner:
+    def create_worker_runner(
+        self, master_host: str, master_port: int, worker_id_pattern: str = WORKER_ID_PATTERN
+    ) -> WorkerRunner:
         """
         Create a :class:`WorkerRunner <locust.runners.WorkerRunner>` instance for this Environment
 
         :param master_host: Host/IP of a running master node
         :param master_port: Port on master node to connect to
+        :param worker_id_pattern: Pattern of worker ID
         """
         # Create a new RequestStats with use_response_times_cache set to False to save some memory
         # and CPU cycles, since the response_times_cache is not needed for Worker nodes
@@ -154,6 +158,7 @@ class Environment:
             WorkerRunner,
             master_host=master_host,
             master_port=master_port,
+            worker_id_pattern=worker_id_pattern,
         )
 
     def create_web_ui(

--- a/locust/main.py
+++ b/locust/main.py
@@ -220,7 +220,9 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         )
     elif options.worker:
         try:
-            runner = environment.create_worker_runner(options.master_host, options.master_port)
+            runner = environment.create_worker_runner(
+                options.master_host, options.master_port, options.worker_id_pattern
+            )
             logger.debug("Connected to locust master: %s:%s", options.master_host, options.master_port)
         except OSError as e:
             logger.error("Failed to connect to the Locust master: %s", e)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1164,7 +1164,7 @@ class WorkerRunner(DistributedRunner):
     # the worker index is set on ACK, if master provided it (masters <= 2.10.2 do not provide it)
     worker_index = -1
 
-    def __init__(self, environment: "Environment", master_host: str, master_port: int) -> None:
+    def __init__(self, environment: "Environment", master_host: str, master_port: int, worker_id_pattern: str) -> None:
         """
         :param environment: Environment instance
         :param master_host: Host/IP to use for connection to the master
@@ -1175,7 +1175,7 @@ class WorkerRunner(DistributedRunner):
         self.connected = False
         self.connection_event = Event()
         self.worker_state = STATE_INIT
-        self.client_id = socket.gethostname() + "_" + uuid4().hex
+        self.client_id = worker_id_pattern % {"hostname": socket.gethostname(), "uuid": uuid4().hex}
         self.master_host = master_host
         self.master_port = master_port
         self.worker_cpu_warning_emitted = False

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -19,7 +19,7 @@ from locust import (
     runners,
     __version__,
 )
-from locust.argument_parser import parse_options
+from locust.argument_parser import parse_options, WORKER_ID_PATTERN
 from locust.env import Environment
 from locust.exception import RPCError, StopUser, RPCReceiveError
 from locust.main import create_environment
@@ -3116,7 +3116,7 @@ class TestWorkerRunner(LocustTestCase):
             environment = self.environment
         user_classes = user_classes or []
         environment.user_classes = user_classes
-        return WorkerRunner(environment, master_host="localhost", master_port=5557)
+        return WorkerRunner(environment, master_host="localhost", master_port=5557, worker_id_pattern=WORKER_ID_PATTERN)
 
     def test_worker_stop_timeout(self):
         class MyTestUser(User):


### PR DESCRIPTION
At that moment, worker ID equals to pattern:
**HOSTNAME_UUID**
for example:
**locust-worker-5f754b69b5-vsjs8_9fe2c4e93f654fdbb24c02b15259716c**

When we use locust in Kubernetes, each worker runs in a separate pod with a unique hostname (it's guaranteed by k8s).
If a worker suddenly restarts inside a pod, the new worker ID will be generated, because there is a new uuid created.
It's not convenient - master becomes a bit crazy and sees the worker with the old ID as missing and with the new ID as running simultaneously. Why is it a new worker, if it's actually the same?
In Kubernetes, it's better to use hostname only for worker ID, so, these changes make it possible to generate any convenient worker id based on pattern and autofill variables.
