### PR TITLE
Prevent Download as PNG text from getting cut off

### DIFF
--- a/locust/static/chart.js
+++ b/locust/static/chart.js
@@ -97,7 +97,12 @@
                     feature: {
                         saveAsImage: {
                             name: this.title.replace(/\s+/g, '_').toLowerCase() + '_' + Date.parse(new Date()) / 1000,
-                            title: "Download as PNG"
+                            title: "Download as PNG",
+                            emphasis: {
+                                iconStyle: {
+                                    textPosition: "left"
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Resolves https://github.com/locustio/locust/issues/2307.

This prevents the "Download as PNG" text, which displays when hovering over the download icon, from getting cut off.
This is achieved by placing the label to the left of the icon instead of below the icon.

Before:
<img width="1440" alt="Screen Shot 2023-02-26 at 2 44 36 PM" src="https://user-images.githubusercontent.com/55810428/221436931-f21e027a-2395-483a-a4f6-0367ba9a91fd.png">

After:
<img width="1440" alt="Screen Shot 2023-02-26 at 3 17 56 PM" src="https://user-images.githubusercontent.com/55810428/221436942-c6bcfdbe-113f-4873-a61e-ed22942263a4.png">
