### PR TITLE
Add PERCENTILES_TO_CHART param in stats.py to make the Response Time Chart configurable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -201,4 +201,6 @@ The list of statistics parameters that can be modified is:
 +-------------------------------------------+--------------------------------------------------------------------------------------+
 | PERCENTILES_TO_REPORT                     | The list of response time percentiles to be calculated & reported                    |
 +-------------------------------------------+--------------------------------------------------------------------------------------+
+| PERCENTILES_TO_CHART                      | The list of response time percentiles for response time chart                        |
++-------------------------------------------+--------------------------------------------------------------------------------------+
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -292,15 +292,10 @@ def setup_parser_arguments(parser):
     )
 
     parser.add_argument(
-        "--percentile1",
-        dest='percentile1',
-        env_var="PERCENTILE_1",
-    )
-
-    parser.add_argument(
-        "--percentile2",
-        dest='percentile2',
-        env_var="PERCENTILE_2",
+        "--percentiles",
+        dest='percentiles',
+        default='0.95,0.5',
+        env_var="PERCENTILES",
     )
 
     web_ui_group = parser.add_argument_group("Web UI options")

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -293,8 +293,8 @@ def setup_parser_arguments(parser):
 
     parser.add_argument(
         "--percentiles",
-        dest='percentiles',
-        default='0.95,0.5',
+        dest="percentiles",
+        default="0.95,0.5",
         env_var="PERCENTILES",
     )
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -291,13 +291,6 @@ def setup_parser_arguments(parser):
         help="Show list of possible User classes and exit",
     )
 
-    parser.add_argument(
-        "--percentiles",
-        dest="percentiles",
-        default="0.95,0.5",
-        env_var="PERCENTILES",
-    )
-
     web_ui_group = parser.add_argument_group("Web UI options")
     web_ui_group.add_argument(
         "--web-host",

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -291,6 +291,18 @@ def setup_parser_arguments(parser):
         help="Show list of possible User classes and exit",
     )
 
+    parser.add_argument(
+        "--percentile1",
+        dest='percentile1',
+        env_var="PERCENTILE_1",
+    )
+
+    parser.add_argument(
+        "--percentile2",
+        dest='percentile2',
+        env_var="PERCENTILE_2",
+    )
+
     web_ui_group = parser.add_argument_group("Web UI options")
     web_ui_group.add_argument(
         "--web-host",

--- a/locust/html.py
+++ b/locust/html.py
@@ -4,6 +4,7 @@ import pathlib
 import datetime
 from itertools import chain
 from .stats import sort_stats
+from . import stats as stats_module
 from .user.inspectuser import get_ratio
 from html import escape
 from json import dumps
@@ -75,7 +76,6 @@ def get_html_report(environment, show_download_link=True):
         "per_class": get_ratio(environment.user_classes, user_spawned, False),
         "total": get_ratio(environment.user_classes, user_spawned, True),
     }
-    from .stats import PERCENTILES_TO_CHART
 
     res = render_template(
         "report.html",
@@ -95,8 +95,8 @@ def get_html_report(environment, show_download_link=True):
         show_download_link=show_download_link,
         locustfile=environment.locustfile,
         tasks=dumps(task_data),
-        percentile1=PERCENTILES_TO_CHART[0],
-        percentile2=PERCENTILES_TO_CHART[1],
+        percentile1=stats_module.PERCENTILES_TO_CHART[0],
+        percentile2=stats_module.PERCENTILES_TO_CHART[1],
     )
 
     return res

--- a/locust/html.py
+++ b/locust/html.py
@@ -8,6 +8,7 @@ from .user.inspectuser import get_ratio
 from html import escape
 from json import dumps
 from .runners import MasterRunner, STATE_STOPPED, STATE_STOPPING
+from .stats import PERCENTILES_TO_CHART
 
 
 def render_template(file, **kwargs):
@@ -94,12 +95,8 @@ def get_html_report(environment, show_download_link=True):
         show_download_link=show_download_link,
         locustfile=environment.locustfile,
         tasks=dumps(task_data),
-        percentile1=options.percentiles.split(",")[0]
-        if options and options.percentiles and len(options.percentiles.split(",")) >= 1
-        else 0.95,
-        percentile2=options.percentiles.split(",")[1]
-        if options and options.percentiles and len(options.percentiles.split(",")) >= 2
-        else 0.5,
+        percentile1=PERCENTILES_TO_CHART[0],
+        percentile2=PERCENTILES_TO_CHART[1],
     )
 
     return res

--- a/locust/html.py
+++ b/locust/html.py
@@ -94,8 +94,8 @@ def get_html_report(environment, show_download_link=True):
         show_download_link=show_download_link,
         locustfile=environment.locustfile,
         tasks=dumps(task_data),
-        percentile1=options.percentile1 if options.percentile1 else 0.95,
-        percentile2=options.percentile2 if options.percentile2 else 0.5,
+        percentile1=options.percentiles.split(',')[0] if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95,
+        percentile2=options.percentiles.split(',')[1] if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5,
     )
 
     return res

--- a/locust/html.py
+++ b/locust/html.py
@@ -19,7 +19,7 @@ def render_template(file, **kwargs):
 
 def get_html_report(environment, show_download_link=True):
     stats = environment.runner.stats
-
+    options = environment.parsed_options
     start_ts = stats.start_time
     start_time = datetime.datetime.utcfromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M:%S")
 
@@ -94,6 +94,8 @@ def get_html_report(environment, show_download_link=True):
         show_download_link=show_download_link,
         locustfile=environment.locustfile,
         tasks=dumps(task_data),
+        percentile1=options.percentile1 if options.percentile1 else 0.95,
+        percentile2=options.percentile2 if options.percentile2 else 0.5,
     )
 
     return res

--- a/locust/html.py
+++ b/locust/html.py
@@ -20,7 +20,7 @@ def render_template(file, **kwargs):
 
 def get_html_report(environment, show_download_link=True):
     stats = environment.runner.stats
-    options = environment.parsed_options
+
     start_ts = stats.start_time
     start_time = datetime.datetime.utcfromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M:%S")
 

--- a/locust/html.py
+++ b/locust/html.py
@@ -94,8 +94,12 @@ def get_html_report(environment, show_download_link=True):
         show_download_link=show_download_link,
         locustfile=environment.locustfile,
         tasks=dumps(task_data),
-        percentile1=options.percentiles.split(',')[0] if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95,
-        percentile2=options.percentiles.split(',')[1] if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5,
+        percentile1=options.percentiles.split(",")[0]
+        if options and options.percentiles and len(options.percentiles.split(",")) >= 1
+        else 0.95,
+        percentile2=options.percentiles.split(",")[1]
+        if options and options.percentiles and len(options.percentiles.split(",")) >= 2
+        else 0.5,
     )
 
     return res

--- a/locust/html.py
+++ b/locust/html.py
@@ -8,7 +8,6 @@ from .user.inspectuser import get_ratio
 from html import escape
 from json import dumps
 from .runners import MasterRunner, STATE_STOPPED, STATE_STOPPING
-from .stats import PERCENTILES_TO_CHART
 
 
 def render_template(file, **kwargs):
@@ -76,6 +75,7 @@ def get_html_report(environment, show_download_link=True):
         "per_class": get_ratio(environment.user_classes, user_spawned, False),
         "total": get_ratio(environment.user_classes, user_spawned, True),
     }
+    from .stats import PERCENTILES_TO_CHART
 
     res = render_template(
         "report.html",

--- a/locust/main.py
+++ b/locust/main.py
@@ -110,13 +110,29 @@ def main():
         sys.stderr.write("The --slave/--expect-slaves parameters have been renamed --worker/--expect-workers\n")
         sys.exit(1)
 
-    if options.percentile1 and (float(options.percentile1) < 0 or float(options.percentile1) >1):
-        sys.stderr.write("The --percentile1/--percentile2 parameters need to be between 0 to 1. Eg : 0.95 \n")
-        sys.exit(1)
+    def isfloat(parameter):
+        if not parameter.isdecimal():
+            try:
+                float(parameter)
+                return True
+            except ValueError:
+                return False
+        else:
+            return False
 
-    if options.percentile2 and (float(options.percentile2) < 0 or float(options.percentile2) >1):
-        sys.stderr.write("The --percentile1/--percentile2 parameters need to be between 0 to 1. Eg : 0.95 \n")
-        sys.exit(1)
+    if options.percentiles:
+
+        if any([not isfloat(percentile) for percentile in options.percentiles.split(',')]):
+            sys.stderr.write("The --percentiles parameter need to be float.  Eg 0.95 \n")
+            sys.exit(1)
+
+        if any((0 > float(pecentile) or 1 < float(pecentile)) for pecentile in options.percentiles.split(',')):
+            sys.stderr.write("The --percentiles parameter need to be value between. 0 <= percentile <= 1 Eg 0.95 \n")
+            sys.exit(1)
+
+        if len(options.percentiles.split(',')) >= 3:
+            sys.stderr.write("The --percentiles parameter can be specified up tp 2 parameters by comma separators. Eg 0.95,0.5   \n")
+            sys.exit(1)
 
     if options.autoquit != -1 and not options.autostart:
         sys.stderr.write("--autoquit is only meaningful in combination with --autostart\n")
@@ -188,6 +204,8 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
     # create locust Environment
     locustfile_path = None if not locustfile else os.path.basename(locustfile)
+
+
     environment = create_environment(
         user_classes,
         options,
@@ -482,3 +500,4 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     except Exception:
         raise
     shutdown()
+

--- a/locust/main.py
+++ b/locust/main.py
@@ -100,6 +100,24 @@ def main():
             user_classes[key] = value
             available_user_classes[key] = value
 
+    if len(stats.PERCENTILES_TO_CHART) > 2:
+        sys.stderr.write("stats.PERCENTILES_TO_CHART parameter can be specified up tp 2 parameters \n")
+        sys.exit(1)
+
+    def is_valid_percentile(parameter):
+        try:
+            if 0 < float(parameter) < 1:
+                return True
+            return False
+        except ValueError:
+            return False
+
+    for percentile in stats.PERCENTILES_TO_CHART:
+        if not is_valid_percentile(percentile):
+            sys.stderr.write(
+                "stats.PERCENTILES_TO_CHART parameter need to be float and value between. 0 <= percentile <= 1 Eg 0.95\n"
+            )
+            sys.exit(1)
     # parse all command line options
     options = parse_options()
 
@@ -109,31 +127,6 @@ def main():
     if options.slave or options.expect_slaves:
         sys.stderr.write("The --slave/--expect-slaves parameters have been renamed --worker/--expect-workers\n")
         sys.exit(1)
-
-    def isfloat(parameter):
-        if not parameter.isdecimal():
-            try:
-                float(parameter)
-                return True
-            except ValueError:
-                return False
-        else:
-            return False
-
-    if options.percentiles:
-        if any([not isfloat(percentile) for percentile in options.percentiles.split(",")]):
-            sys.stderr.write("The --percentiles parameter need to be float.  Eg 0.95 \n")
-            sys.exit(1)
-
-        if any((0 > float(pecentile) or 1 < float(pecentile)) for pecentile in options.percentiles.split(",")):
-            sys.stderr.write("The --percentiles parameter need to be value between. 0 <= percentile <= 1 Eg 0.95 \n")
-            sys.exit(1)
-
-        if len(options.percentiles.split(",")) >= 3:
-            sys.stderr.write(
-                "The --percentiles parameter can be specified up tp 2 parameters by comma separators. Eg 0.95,0.5   \n"
-            )
-            sys.exit(1)
 
     if options.autoquit != -1 and not options.autostart:
         sys.stderr.write("--autoquit is only meaningful in combination with --autostart\n")

--- a/locust/main.py
+++ b/locust/main.py
@@ -121,17 +121,18 @@ def main():
             return False
 
     if options.percentiles:
-
-        if any([not isfloat(percentile) for percentile in options.percentiles.split(',')]):
+        if any([not isfloat(percentile) for percentile in options.percentiles.split(",")]):
             sys.stderr.write("The --percentiles parameter need to be float.  Eg 0.95 \n")
             sys.exit(1)
 
-        if any((0 > float(pecentile) or 1 < float(pecentile)) for pecentile in options.percentiles.split(',')):
+        if any((0 > float(pecentile) or 1 < float(pecentile)) for pecentile in options.percentiles.split(",")):
             sys.stderr.write("The --percentiles parameter need to be value between. 0 <= percentile <= 1 Eg 0.95 \n")
             sys.exit(1)
 
-        if len(options.percentiles.split(',')) >= 3:
-            sys.stderr.write("The --percentiles parameter can be specified up tp 2 parameters by comma separators. Eg 0.95,0.5   \n")
+        if len(options.percentiles.split(",")) >= 3:
+            sys.stderr.write(
+                "The --percentiles parameter can be specified up tp 2 parameters by comma separators. Eg 0.95,0.5   \n"
+            )
             sys.exit(1)
 
     if options.autoquit != -1 and not options.autostart:
@@ -184,7 +185,6 @@ def main():
         user_classes = list(user_classes.values())
 
     if os.name != "nt" and not options.master:
-
         try:
             import resource
 
@@ -204,7 +204,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
     # create locust Environment
     locustfile_path = None if not locustfile else os.path.basename(locustfile)
-
 
     environment = create_environment(
         user_classes,
@@ -500,4 +499,3 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     except Exception:
         raise
     shutdown()
-

--- a/locust/main.py
+++ b/locust/main.py
@@ -101,7 +101,7 @@ def main():
             available_user_classes[key] = value
 
     if len(stats.PERCENTILES_TO_CHART) > 2:
-        sys.stderr.write("stats.PERCENTILES_TO_CHART parameter can be specified up tp 2 parameters \n")
+        logging.error("stats.PERCENTILES_TO_CHART parameter can be specified up tp 2 parameters \n")
         sys.exit(1)
 
     def is_valid_percentile(parameter):
@@ -114,8 +114,8 @@ def main():
 
     for percentile in stats.PERCENTILES_TO_CHART:
         if not is_valid_percentile(percentile):
-            sys.stderr.write(
-                "stats.PERCENTILES_TO_CHART parameter need to be float and value between. 0 <= percentile <= 1 Eg 0.95\n"
+            logging.error(
+                "stats.PERCENTILES_TO_CHART parameter need to be float and value between. 0 < percentile < 1 Eg 0.95\n"
             )
             sys.exit(1)
     # parse all command line options

--- a/locust/main.py
+++ b/locust/main.py
@@ -100,8 +100,10 @@ def main():
             user_classes[key] = value
             available_user_classes[key] = value
 
-    if len(stats.PERCENTILES_TO_CHART) > 2:
-        logging.error("stats.PERCENTILES_TO_CHART parameter can be specified up tp 2 parameters \n")
+    from .stats import PERCENTILES_TO_CHART
+
+    if len(PERCENTILES_TO_CHART) != 2:
+        logging.error("stats.PERCENTILES_TO_CHART parameter should be 2 parameters \n")
         sys.exit(1)
 
     def is_valid_percentile(parameter):
@@ -112,7 +114,7 @@ def main():
         except ValueError:
             return False
 
-    for percentile in stats.PERCENTILES_TO_CHART:
+    for percentile in PERCENTILES_TO_CHART:
         if not is_valid_percentile(percentile):
             logging.error(
                 "stats.PERCENTILES_TO_CHART parameter need to be float and value between. 0 < percentile < 1 Eg 0.95\n"

--- a/locust/main.py
+++ b/locust/main.py
@@ -100,9 +100,7 @@ def main():
             user_classes[key] = value
             available_user_classes[key] = value
 
-    from .stats import PERCENTILES_TO_CHART
-
-    if len(PERCENTILES_TO_CHART) != 2:
+    if len(stats.PERCENTILES_TO_CHART) != 2:
         logging.error("stats.PERCENTILES_TO_CHART parameter should be 2 parameters \n")
         sys.exit(1)
 
@@ -114,7 +112,7 @@ def main():
         except ValueError:
             return False
 
-    for percentile in PERCENTILES_TO_CHART:
+    for percentile in stats.PERCENTILES_TO_CHART:
         if not is_valid_percentile(percentile):
             logging.error(
                 "stats.PERCENTILES_TO_CHART parameter need to be float and value between. 0 < percentile < 1 Eg 0.95\n"

--- a/locust/main.py
+++ b/locust/main.py
@@ -110,6 +110,14 @@ def main():
         sys.stderr.write("The --slave/--expect-slaves parameters have been renamed --worker/--expect-workers\n")
         sys.exit(1)
 
+    if options.percentile1 and (float(options.percentile1) < 0 or float(options.percentile1) >1):
+        sys.stderr.write("The --percentile1/--percentile2 parameters need to be between 0 to 1. Eg : 0.95 \n")
+        sys.exit(1)
+
+    if options.percentile2 and (float(options.percentile2) < 0 or float(options.percentile2) >1):
+        sys.stderr.write("The --percentile1/--percentile2 parameters need to be between 0 to 1. Eg : 0.95 \n")
+        sys.exit(1)
+
     if options.autoquit != -1 and not options.autostart:
         sys.stderr.write("--autoquit is only meaningful in combination with --autostart\n")
         sys.exit(1)

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -219,8 +219,8 @@ function update_stats_charts(){
         responseTimeChart.chart.setOption({
             xAxis: {data: stats_history["time"]},
             series: [
-                {data: stats_history["response_time_percentile_50"], markLine: createMarkLine()},
-                {data: stats_history["response_time_percentile_95"]},
+                {data: stats_history["response_time_percentile_2"], markLine: createMarkLine()},
+                {data: stats_history["response_time_percentile_1"]},
             ]
         });
 
@@ -264,8 +264,8 @@ function updateStats() {
                     stats_history["user_count"].push({"value": null});
                     stats_history["current_rps"].push({"value": null});
                     stats_history["current_fail_per_sec"].push({"value": null});
-                    stats_history["response_time_percentile_50"].push({"value": null});
-                    stats_history["response_time_percentile_95"].push({"value": null});
+                    stats_history["response_time_percentile_2"].push({"value": null});
+                    stats_history["response_time_percentile_1"].push({"value": null});
                 }
 
                 // update stats chart to ensure the stop spacing appears as part 
@@ -301,8 +301,8 @@ function updateStats() {
             stats_history["user_count"].push({"value": report.user_count});
             stats_history["current_rps"].push({"value": total.current_rps, "users": report.user_count});
             stats_history["current_fail_per_sec"].push({"value": total.current_fail_per_sec, "users": report.user_count});
-            stats_history["response_time_percentile_50"].push({"value": report.current_response_time_percentile_50, "users": report.user_count});
-            stats_history["response_time_percentile_95"].push({"value": report.current_response_time_percentile_95, "users": report.user_count});
+            stats_history["response_time_percentile_2"].push({"value": report.current_response_time_percentile_50, "users": report.user_count});
+            stats_history["response_time_percentile_1"].push({"value": report.current_response_time_percentile_95, "users": report.user_count});
             update_stats_charts();
 
         } catch(i){

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -235,7 +235,7 @@ function update_stats_charts(){
 
 // init charts
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
+var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile2 * 100).toString() + "% percentile" , (percentile1 * 100).toString() + "% percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 charts.push(rpsChart, responseTimeChart, usersChart);
 echarts.connect([rpsChart.chart,responseTimeChart.chart,usersChart.chart])

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -235,7 +235,7 @@ function update_stats_charts(){
 
 // init charts
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1 * 100).toString() + "% percentile" , (percentile2 * 100).toString() + "% percentile"], "ms");
+var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1 * 100).toString() + "th percentile" , (percentile2 * 100).toString() + "th percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 charts.push(rpsChart, responseTimeChart, usersChart);
 echarts.connect([rpsChart.chart,responseTimeChart.chart,usersChart.chart])

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -301,8 +301,8 @@ function updateStats() {
             stats_history["user_count"].push({"value": report.user_count});
             stats_history["current_rps"].push({"value": total.current_rps, "users": report.user_count});
             stats_history["current_fail_per_sec"].push({"value": total.current_fail_per_sec, "users": report.user_count});
-            stats_history["response_time_percentile_2"].push({"value": report.current_response_time_percentile_50, "users": report.user_count});
-            stats_history["response_time_percentile_1"].push({"value": report.current_response_time_percentile_95, "users": report.user_count});
+            stats_history["response_time_percentile_2"].push({"value": report.current_response_time_percentile_2, "users": report.user_count});
+            stats_history["response_time_percentile_1"].push({"value": report.current_response_time_percentile_1, "users": report.user_count});
             update_stats_charts();
 
         } catch(i){

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -219,8 +219,8 @@ function update_stats_charts(){
         responseTimeChart.chart.setOption({
             xAxis: {data: stats_history["time"]},
             series: [
-                {data: stats_history["response_time_percentile_2"], markLine: createMarkLine()},
-                {data: stats_history["response_time_percentile_1"]},
+                {data: stats_history["response_time_percentile_1"], markLine: createMarkLine()},
+                {data: stats_history["response_time_percentile_2"]},
             ]
         });
 
@@ -235,7 +235,7 @@ function update_stats_charts(){
 
 // init charts
 var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile2 * 100).toString() + "% percentile" , (percentile1 * 100).toString() + "% percentile"], "ms");
+var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1 * 100).toString() + "% percentile" , (percentile2 * 100).toString() + "% percentile"], "ms");
 var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 charts.push(rpsChart, responseTimeChart, usersChart);
 echarts.connect([rpsChart.chart,responseTimeChart.chart,usersChart.chart])
@@ -264,8 +264,8 @@ function updateStats() {
                     stats_history["user_count"].push({"value": null});
                     stats_history["current_rps"].push({"value": null});
                     stats_history["current_fail_per_sec"].push({"value": null});
-                    stats_history["response_time_percentile_2"].push({"value": null});
                     stats_history["response_time_percentile_1"].push({"value": null});
+                    stats_history["response_time_percentile_2"].push({"value": null});
                 }
 
                 // update stats chart to ensure the stop spacing appears as part 
@@ -301,8 +301,8 @@ function updateStats() {
             stats_history["user_count"].push({"value": report.user_count});
             stats_history["current_rps"].push({"value": total.current_rps, "users": report.user_count});
             stats_history["current_fail_per_sec"].push({"value": total.current_fail_per_sec, "users": report.user_count});
-            stats_history["response_time_percentile_2"].push({"value": report.current_response_time_percentile_2, "users": report.user_count});
             stats_history["response_time_percentile_1"].push({"value": report.current_response_time_percentile_1, "users": report.user_count});
+            stats_history["response_time_percentile_2"].push({"value": report.current_response_time_percentile_2, "users": report.user_count});
             update_stats_charts();
 
         } catch(i){

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -884,8 +884,12 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
-            percentile1 = runner.environment.parsed_options.percentile1 if runner.environment.parsed_options.percentile1 else 0.95
-            percentile2 = runner.environment.parsed_options.percentile2 if runner.environment.parsed_options.percentile2 else 0.5
+            percentile1 = runner.environment.parsed_options.percentiles.split(',')[0] \
+                if runner.environment.parsed_options and runner.environment.parsed_options.percentiles and \
+                   len(runner.environment.parsed_options.percentiles.split(',')) >= 1 else 0.95
+            percentile2 = runner.environment.parsed_options.percentiles.split(',')[1] \
+                if runner.environment.parsed_options and runner.environment.parsed_options.percentiles and \
+                   len(runner.environment.parsed_options.percentiles.split(',')) >= 2 else 0.5
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -884,12 +884,14 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
+            percentile1 = runner.environment.parsed_options.percentile1 if runner.environment.parsed_options.percentile1 else 0.95
+            percentile2 = runner.environment.parsed_options.percentile2 if runner.environment.parsed_options.percentile2 else 0.5
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,
                 "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-                "response_time_percentile_95": stats.total.get_current_response_time_percentile(0.95) or 0,
-                "response_time_percentile_50": stats.total.get_current_response_time_percentile(0.5) or 0,
+                "response_time_percentile_95": stats.total.get_current_response_time_percentile(float(percentile1)) or 0,
+                "response_time_percentile_50": stats.total.get_current_response_time_percentile(float(percentile2)) or 0,
                 "user_count": runner.user_count or 0,
             }
             stats.history.append(r)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -886,7 +886,6 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
-
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -133,6 +133,8 @@ CachedResponseTimes = namedtuple("CachedResponseTimes", ["response_times", "num_
 
 PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 0.9999, 1.0]
 
+PERCENTILES_TO_CHART = [0.95, 0.50]
+
 
 class RequestStatsAdditionError(Exception):
     pass
@@ -884,27 +886,13 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
-            percentile1 = (
-                runner.environment.parsed_options.percentiles.split(",")[0]
-                if runner.environment.parsed_options
-                and runner.environment.parsed_options.percentiles
-                and len(runner.environment.parsed_options.percentiles.split(",")) >= 1
-                else 0.95
-            )
-            percentile2 = (
-                runner.environment.parsed_options.percentiles.split(",")[1]
-                if runner.environment.parsed_options
-                and runner.environment.parsed_options.percentiles
-                and len(runner.environment.parsed_options.percentiles.split(",")) >= 2
-                else 0.5
-            )
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,
                 "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-                "response_time_percentile_95": stats.total.get_current_response_time_percentile(float(percentile1))
+                "response_time_percentile_95": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[0])
                 or 0,
-                "response_time_percentile_50": stats.total.get_current_response_time_percentile(float(percentile2))
+                "response_time_percentile_50": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[1])
                 or 0,
                 "user_count": runner.user_count or 0,
             }

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -886,13 +886,14 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
+
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,
                 "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-                "response_time_percentile_95": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[0])
+                "response_time_percentile_1": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[0])
                 or 0,
-                "response_time_percentile_50": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[1])
+                "response_time_percentile_2": stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[1])
                 or 0,
                 "user_count": runner.user_count or 0,
             }

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -884,18 +884,28 @@ def stats_history(runner: "Runner") -> None:
         if not stats.total.use_response_times_cache:
             break
         if runner.state != "stopped":
-            percentile1 = runner.environment.parsed_options.percentiles.split(',')[0] \
-                if runner.environment.parsed_options and runner.environment.parsed_options.percentiles and \
-                   len(runner.environment.parsed_options.percentiles.split(',')) >= 1 else 0.95
-            percentile2 = runner.environment.parsed_options.percentiles.split(',')[1] \
-                if runner.environment.parsed_options and runner.environment.parsed_options.percentiles and \
-                   len(runner.environment.parsed_options.percentiles.split(',')) >= 2 else 0.5
+            percentile1 = (
+                runner.environment.parsed_options.percentiles.split(",")[0]
+                if runner.environment.parsed_options
+                and runner.environment.parsed_options.percentiles
+                and len(runner.environment.parsed_options.percentiles.split(",")) >= 1
+                else 0.95
+            )
+            percentile2 = (
+                runner.environment.parsed_options.percentiles.split(",")[1]
+                if runner.environment.parsed_options
+                and runner.environment.parsed_options.percentiles
+                and len(runner.environment.parsed_options.percentiles.split(",")) >= 2
+                else 0.5
+            )
             r = {
                 "time": datetime.datetime.now(tz=datetime.timezone.utc).strftime("%H:%M:%S"),
                 "current_rps": stats.total.current_rps or 0,
                 "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-                "response_time_percentile_95": stats.total.get_current_response_time_percentile(float(percentile1)) or 0,
-                "response_time_percentile_50": stats.total.get_current_response_time_percentile(float(percentile2)) or 0,
+                "response_time_percentile_95": stats.total.get_current_response_time_percentile(float(percentile1))
+                or 0,
+                "response_time_percentile_50": stats.total.get_current_response_time_percentile(float(percentile2))
+                or 0,
                 "user_count": runner.user_count or 0,
             }
             stats.history.append(r)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -133,7 +133,7 @@ CachedResponseTimes = namedtuple("CachedResponseTimes", ["response_times", "num_
 
 PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 0.9999, 1.0]
 
-PERCENTILES_TO_CHART = [0.95, 0.50]
+PERCENTILES_TO_CHART = [0.50, 0.95]
 
 
 class RequestStatsAdditionError(Exception):

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -357,6 +357,8 @@
         ]]>
     </script>
     <script type="text/javascript">
+        var percentile1 = {{ percentile1|tojson }};
+        var percentile2 = {{ percentile2|tojson }};
         {% include 'stats_data.html' %}
     </script>
     <script type="text/javascript" src="./static/chart.js?v={{ version }}"></script>

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -201,7 +201,7 @@
         var percentile1 = {{ percentile1|tojson }}
         var percentile2 = {{ percentile2|tojson }}
         var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1*100).toString() + "% percentile" , (percentile2*100).toString() + "% percentile"], "ms");
+        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1*100).toString() + "th percentile" , (percentile2*100).toString() + "th percentile"], "ms");
         var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
         if(stats_history["time"].length > 0){

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -216,8 +216,8 @@
             responseTimeChart.chart.setOption({
                 xAxis: {data: stats_history["time"]},
                 series: [
-                    {data: stats_history["response_time_percentile_50"]},
-                    {data: stats_history["response_time_percentile_95"]},
+                    {data: stats_history["response_time_percentile_2"]},
+                    {data: stats_history["response_time_percentile_1"]},
                 ]
             });
 

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -201,7 +201,7 @@
         var percentile1 = {{ percentile1|tojson }}
         var percentile2 = {{ percentile2|tojson }}
         var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile2*100).toString() + "% percentile" , (percentile1*100).toString() + "% percentile"], "ms");
+        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile1*100).toString() + "% percentile" , (percentile2*100).toString() + "% percentile"], "ms");
         var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
         if(stats_history["time"].length > 0){
@@ -216,8 +216,8 @@
             responseTimeChart.chart.setOption({
                 xAxis: {data: stats_history["time"]},
                 series: [
-                    {data: stats_history["response_time_percentile_2"]},
                     {data: stats_history["response_time_percentile_1"]},
+                    {data: stats_history["response_time_percentile_2"]},
                 ]
             });
 

--- a/locust/templates/report.html
+++ b/locust/templates/report.html
@@ -198,8 +198,10 @@
 
     <script>
         {% include 'stats_data.html' %}
+        var percentile1 = {{ percentile1|tojson }}
+        var percentile2 = {{ percentile2|tojson }}
         var rpsChart = new LocustLineChart($(".charts-container"), "Total Requests per Second", ["RPS", "Failures/s"], "reqs/s", ['#00ca5a', '#ff6d6d']);
-        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", ["Median Response Time", "95% percentile"], "ms");
+        var responseTimeChart = new LocustLineChart($(".charts-container"), "Response Times (ms)", [(percentile2*100).toString() + "% percentile" , (percentile1*100).toString() + "% percentile"], "ms");
         var usersChart = new LocustLineChart($(".charts-container"), "Number of Users", ["Users"], "users");
 
         if(stats_history["time"].length > 0){

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -1,10 +1,10 @@
-{% set time_data = [] %}{% set user_count_data = [] %}{% set current_rps_data = [] %}{% set current_fail_per_sec_data = [] %}{% set response_time_percentile_50_data = [] %}{% set response_time_percentile_95_data = [] %}{% for r in history %}{% do time_data.append(r.time) %}{% do user_count_data.append({"value": r.user_count}) %}{% do current_rps_data.append({"value": r.current_rps, "users": r.user_count}) %}{% do current_fail_per_sec_data.append({"value": r.current_fail_per_sec, "users": r.user_count}) %}{% do response_time_percentile_50_data.append({"value": r.response_time_percentile_2, "users": r.user_count}) %}{% do response_time_percentile_95_data.append({"value": r.response_time_percentile_1, "users": r.user_count}) %}{% endfor %}
+{% set time_data = [] %}{% set user_count_data = [] %}{% set current_rps_data = [] %}{% set current_fail_per_sec_data = [] %}{% set response_time_percentile_2_data = [] %}{% set response_time_percentile_1_data = [] %}{% for r in history %}{% do time_data.append(r.time) %}{% do user_count_data.append({"value": r.user_count}) %}{% do current_rps_data.append({"value": r.current_rps, "users": r.user_count}) %}{% do current_fail_per_sec_data.append({"value": r.current_fail_per_sec, "users": r.user_count}) %}{% do response_time_percentile_2_data.append({"value": r.response_time_percentile_2, "users": r.user_count}) %}{% do response_time_percentile_1_data.append({"value": r.response_time_percentile_1, "users": r.user_count}) %}{% endfor %}
 var stats_history = {
     "time": {{ time_data | tojson }}.map(server_time => new Date(new Date().setUTCHours(...(server_time.split(":")))).toLocaleTimeString()),
     "user_count": {{ user_count_data | tojson }},
     "current_rps": {{ current_rps_data | tojson }},
     "current_fail_per_sec": {{ current_fail_per_sec_data | tojson }},
-    "response_time_percentile_2": {{ response_time_percentile_50_data | tojson }},
-    "response_time_percentile_1": {{ response_time_percentile_95_data | tojson }},
+    "response_time_percentile_2": {{ response_time_percentile_2_data | tojson }},
+    "response_time_percentile_1": {{ response_time_percentile_1_data | tojson }},
     "markers": [],
 };

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -4,7 +4,7 @@ var stats_history = {
     "user_count": {{ user_count_data | tojson }},
     "current_rps": {{ current_rps_data | tojson }},
     "current_fail_per_sec": {{ current_fail_per_sec_data | tojson }},
-    "response_time_percentile_2": {{ response_time_percentile_2_data | tojson }},
     "response_time_percentile_1": {{ response_time_percentile_1_data | tojson }},
+    "response_time_percentile_2": {{ response_time_percentile_2_data | tojson }},
     "markers": [],
 };

--- a/locust/templates/stats_data.html
+++ b/locust/templates/stats_data.html
@@ -1,10 +1,10 @@
-{% set time_data = [] %}{% set user_count_data = [] %}{% set current_rps_data = [] %}{% set current_fail_per_sec_data = [] %}{% set response_time_percentile_50_data = [] %}{% set response_time_percentile_95_data = [] %}{% for r in history %}{% do time_data.append(r.time) %}{% do user_count_data.append({"value": r.user_count}) %}{% do current_rps_data.append({"value": r.current_rps, "users": r.user_count}) %}{% do current_fail_per_sec_data.append({"value": r.current_fail_per_sec, "users": r.user_count}) %}{% do response_time_percentile_50_data.append({"value": r.response_time_percentile_50, "users": r.user_count}) %}{% do response_time_percentile_95_data.append({"value": r.response_time_percentile_95, "users": r.user_count}) %}{% endfor %}
+{% set time_data = [] %}{% set user_count_data = [] %}{% set current_rps_data = [] %}{% set current_fail_per_sec_data = [] %}{% set response_time_percentile_50_data = [] %}{% set response_time_percentile_95_data = [] %}{% for r in history %}{% do time_data.append(r.time) %}{% do user_count_data.append({"value": r.user_count}) %}{% do current_rps_data.append({"value": r.current_rps, "users": r.user_count}) %}{% do current_fail_per_sec_data.append({"value": r.current_fail_per_sec, "users": r.user_count}) %}{% do response_time_percentile_50_data.append({"value": r.response_time_percentile_2, "users": r.user_count}) %}{% do response_time_percentile_95_data.append({"value": r.response_time_percentile_1, "users": r.user_count}) %}{% endfor %}
 var stats_history = {
     "time": {{ time_data | tojson }}.map(server_time => new Date(new Date().setUTCHours(...(server_time.split(":")))).toLocaleTimeString()),
     "user_count": {{ user_count_data | tojson }},
     "current_rps": {{ current_rps_data | tojson }},
     "current_fail_per_sec": {{ current_fail_per_sec_data | tojson }},
-    "response_time_percentile_50": {{ response_time_percentile_50_data | tojson }},
-    "response_time_percentile_95": {{ response_time_percentile_95_data | tojson }},
+    "response_time_percentile_2": {{ response_time_percentile_50_data | tojson }},
+    "response_time_percentile_1": {{ response_time_percentile_95_data | tojson }},
     "markers": [],
 };

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -193,6 +193,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             self.assertEqual(0, proc.returncode)
 
     def test_percentile_parameter(self):
+        port = get_free_tcp_port()
         with temporary_file(
             content=textwrap.dedent(
                 """
@@ -208,11 +209,18 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
         """
             )
         ) as file_path:
-            proc = subprocess.Popen(["locust", "-f", file_path], stdout=PIPE, stderr=PIPE, text=True)
+            proc = subprocess.Popen(
+                ["locust", "-f", file_path, "--web-port", str(port), "--autostart"], stdout=PIPE, stderr=PIPE, text=True
+            )
             gevent.sleep(1)
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             self.assertIn("Starting web interface at", stderr)
+            try:
+                response = requests.get(f"http://0.0.0.0:{port}/")
+                self.assertEqual(200, response.status_code)
+            except Exception:
+                pass
 
     def test_invalid_percentile_parameter(self):
         with temporary_file(
@@ -229,11 +237,12 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
         """
             )
         ) as file_path:
-            proc = subprocess.Popen(["locust", "-f", file_path], stdout=PIPE, stderr=PIPE, text=True)
+            proc = subprocess.Popen(["locust", "-f", file_path, "--autostart"], stdout=PIPE, stderr=PIPE, text=True)
             gevent.sleep(1)
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             self.assertIn("parameter need to be float and value between. 0 < percentile < 1 Eg 0.95", stderr)
+            self.assertEqual(1, proc.returncode)
 
     def test_webserver_multiple_locustfiles(self):
         with mock_locustfile(content=MOCK_LOCUSTFILE_CONTENT_A) as mocked1:

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -293,7 +293,6 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             self.assertIn('Spawning additional {"UserSubclass": 1} ({"UserSubclass": 0} already running)...', stderr)
             self.assertEqual(0, proc.returncode)
 
-
     def test_invalid_stop_timeout_string(self):
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
@@ -1138,7 +1137,6 @@ class MyUser(HttpUser):
             self.assertEqual(1, proc.returncode)
 
     def test_invalid_percentilesrange_options(self):
-
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
                 [
@@ -1159,7 +1157,6 @@ class MyUser(HttpUser):
             self.assertIn("The --percentiles parameter need to be value between", stderr)
 
     def test_invalid_num_percentiles_params_options(self):
-
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
                 [
@@ -1177,11 +1174,9 @@ class MyUser(HttpUser):
             )
 
             stdout, stderr = proc.communicate()
-            self.assertIn("The --percentiles parameter can be specified up tp 2 parameters by comma separators",
-                          stderr)
+            self.assertIn("The --percentiles parameter can be specified up tp 2 parameters by comma separators", stderr)
 
     def test_invalid_percentiles_options(self):
-
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
                 [
@@ -1608,6 +1603,3 @@ class AnyUser(HttpUser):
             for i in range(2):
                 if found[i] != i:
                     raise Exception(f"expected index {i} but got", found[i])
-
-
-

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -2,7 +2,7 @@ import json
 import os
 import platform
 
-import pty
+#import pty
 import signal
 import subprocess
 import textwrap
@@ -213,14 +213,11 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 ["locust", "-f", file_path, "--web-port", str(port), "--autostart"], stdout=PIPE, stderr=PIPE, text=True
             )
             gevent.sleep(1)
+            response = requests.get(f"http://localhost:{port}/")
+            self.assertEqual(200, response.status_code)
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             self.assertIn("Starting web interface at", stderr)
-            try:
-                response = requests.get(f"http://0.0.0.0:{port}/")
-                self.assertEqual(200, response.status_code)
-            except Exception:
-                pass
 
     def test_invalid_percentile_parameter(self):
         with temporary_file(
@@ -239,7 +236,6 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
         ) as file_path:
             proc = subprocess.Popen(["locust", "-f", file_path, "--autostart"], stdout=PIPE, stderr=PIPE, text=True)
             gevent.sleep(1)
-            proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             self.assertIn("parameter need to be float and value between. 0 < percentile < 1 Eg 0.95", stderr)
             self.assertEqual(1, proc.returncode)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -2,7 +2,7 @@ import json
 import os
 import platform
 
-# import pty
+import pty
 import signal
 import subprocess
 import textwrap

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -2,7 +2,7 @@ import json
 import os
 import platform
 
-#import pty
+import pty
 import signal
 import subprocess
 import textwrap

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1,7 +1,8 @@
 import json
 import os
 import platform
-#import pty
+
+# import pty
 import signal
 import subprocess
 import textwrap
@@ -198,7 +199,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             from locust import User, task, constant, events
             from locust.stats import PERCENTILES_TO_CHART
             PERCENTILES_TO_CHART[0] = 0.9
-            PERCENTILES_TO_CHART[0] = 0.4
+            PERCENTILES_TO_CHART[1] = 0.4
             class TestUser(User):
                 wait_time = constant(3)
                 @task
@@ -233,7 +234,6 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
             self.assertIn("parameter need to be float and value between. 0 < percentile < 1 Eg 0.95", stderr)
-
 
     def test_webserver_multiple_locustfiles(self):
         with mock_locustfile(content=MOCK_LOCUSTFILE_CONTENT_A) as mocked1:

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1136,66 +1136,6 @@ class MyUser(HttpUser):
             self.assertIn("No tasks defined on MyUser", stderr)
             self.assertEqual(1, proc.returncode)
 
-    def test_invalid_percentilesrange_options(self):
-        with mock_locustfile() as mocked:
-            proc = subprocess.Popen(
-                [
-                    "locust",
-                    "-f",
-                    mocked.file_path,
-                    "--host",
-                    "https://test.com/",
-                    "--percentiles",
-                    "1.2",
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-
-            stdout, stderr = proc.communicate()
-            self.assertIn("The --percentiles parameter need to be value between", stderr)
-
-    def test_invalid_num_percentiles_params_options(self):
-        with mock_locustfile() as mocked:
-            proc = subprocess.Popen(
-                [
-                    "locust",
-                    "-f",
-                    mocked.file_path,
-                    "--host",
-                    "https://test.com/",
-                    "--percentiles",
-                    "0.1,0.2,0.3",
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-
-            stdout, stderr = proc.communicate()
-            self.assertIn("The --percentiles parameter can be specified up tp 2 parameters by comma separators", stderr)
-
-    def test_invalid_percentiles_options(self):
-        with mock_locustfile() as mocked:
-            proc = subprocess.Popen(
-                [
-                    "locust",
-                    "-f",
-                    mocked.file_path,
-                    "--host",
-                    "https://test.com/",
-                    "--percentiles",
-                    "98",
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-
-            stdout, stderr = proc.communicate()
-            self.assertIn("The --percentiles parameter need to be float.", stderr)
-
 
 class DistributedIntegrationTests(ProcessIntegrationTest):
     def test_expect_workers(self):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -293,6 +293,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             self.assertIn('Spawning additional {"UserSubclass": 1} ({"UserSubclass": 0} already running)...', stderr)
             self.assertEqual(0, proc.returncode)
 
+
     def test_invalid_stop_timeout_string(self):
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
@@ -1136,6 +1137,70 @@ class MyUser(HttpUser):
             self.assertIn("No tasks defined on MyUser", stderr)
             self.assertEqual(1, proc.returncode)
 
+    def test_invalid_percentilesrange_options(self):
+
+        with mock_locustfile() as mocked:
+            proc = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--host",
+                    "https://test.com/",
+                    "--percentiles",
+                    "1.2",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+
+            stdout, stderr = proc.communicate()
+            self.assertIn("The --percentiles parameter need to be value between", stderr)
+
+    def test_invalid_num_percentiles_params_options(self):
+
+        with mock_locustfile() as mocked:
+            proc = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--host",
+                    "https://test.com/",
+                    "--percentiles",
+                    "0.1,0.2,0.3",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+
+            stdout, stderr = proc.communicate()
+            self.assertIn("The --percentiles parameter can be specified up tp 2 parameters by comma separators",
+                          stderr)
+
+    def test_invalid_percentiles_options(self):
+
+        with mock_locustfile() as mocked:
+            proc = subprocess.Popen(
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--host",
+                    "https://test.com/",
+                    "--percentiles",
+                    "98",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+
+            stdout, stderr = proc.communicate()
+            self.assertIn("The --percentiles parameter need to be float.", stderr)
+
 
 class DistributedIntegrationTests(ProcessIntegrationTest):
     def test_expect_workers(self):
@@ -1543,3 +1608,6 @@ class AnyUser(HttpUser):
             for i in range(2):
                 if found[i] != i:
                     raise Exception(f"expected index {i} but got", found[i])
+
+
+

--- a/locust/web.py
+++ b/locust/web.py
@@ -333,12 +333,17 @@ class WebUI:
             stats: List[Dict[str, Any]] = []
             errors: List[StatsErrorDict] = []
             options = self.environment.parsed_options
-            percentile1 = options.percentiles.split(',')[0] \
-                if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95
-            percentile2 = options.percentiles.split(',')[1] \
-                if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5
+            percentile1 = (
+                options.percentiles.split(",")[0]
+                if options and options.percentiles and len(options.percentiles.split(",")) >= 1
+                else 0.95
+            )
+            percentile2 = (
+                options.percentiles.split(",")[1]
+                if options and options.percentiles and len(options.percentiles.split(",")) >= 2
+                else 0.5
+            )
             if environment.runner is None:
-
                 report = {
                     "stats": stats,
                     "errors": errors,
@@ -541,9 +546,16 @@ class WebUI:
         if self.environment.available_shape_classes:
             available_shape_classes += sorted(self.environment.available_shape_classes.keys())
 
-        percentile1 = options.percentiles.split(',')[0] if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95
-        percentile2 = options.percentiles.split(',')[1] if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5
-
+        percentile1 = (
+            options.percentiles.split(",")[0]
+            if options and options.percentiles and len(options.percentiles.split(",")) >= 1
+            else 0.95
+        )
+        percentile2 = (
+            options.percentiles.split(",")[1]
+            if options and options.percentiles and len(options.percentiles.split(",")) >= 2
+            else 0.5
+        )
 
         self.template_args = {
             "locustfile": self.environment.locustfile,

--- a/locust/web.py
+++ b/locust/web.py
@@ -21,7 +21,7 @@ from .runners import MasterRunner, STATE_RUNNING, STATE_MISSING
 from .log import greenlet_exception_logger
 from .stats import StatsCSVFileWriter, StatsErrorDict, sort_stats
 from . import stats as stats_module, __version__ as version, argument_parser
-from .stats import StatsCSV, PERCENTILES_TO_CHART
+from .stats import StatsCSV
 from .user.inspectuser import get_ratio
 from .util.cache import memoize
 from .util.rounding import proper_round
@@ -384,7 +384,7 @@ class WebUI:
                 truncated_stats += [stats[-1]]
 
             report = {"stats": truncated_stats, "errors": errors[:500]}
-
+            from .stats import PERCENTILES_TO_CHART
             if stats:
                 report["total_rps"] = stats[len(stats) - 1]["current_rps"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
@@ -536,6 +536,8 @@ class WebUI:
         available_shape_classes = ["Default"]
         if self.environment.available_shape_classes:
             available_shape_classes += sorted(self.environment.available_shape_classes.keys())
+
+        from .stats import PERCENTILES_TO_CHART
 
         self.template_args = {
             "locustfile": self.environment.locustfile,

--- a/locust/web.py
+++ b/locust/web.py
@@ -332,8 +332,13 @@ class WebUI:
         def request_stats() -> Response:
             stats: List[Dict[str, Any]] = []
             errors: List[StatsErrorDict] = []
-
+            options = self.environment.parsed_options
+            if not options.percentile1:
+                options.percentile1 = '0.95'
+            if not options.percentile2:
+                options.percentile2 = '0.5'
             if environment.runner is None:
+
                 report = {
                     "stats": stats,
                     "errors": errors,
@@ -389,10 +394,10 @@ class WebUI:
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
                 report[
                     "current_response_time_percentile_95"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(0.95)
+                ] = environment.runner.stats.total.get_current_response_time_percentile(float(options.percentile1))
                 report[
                     "current_response_time_percentile_50"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(0.5)
+                ] = environment.runner.stats.total.get_current_response_time_percentile(float(options.percentile2))
 
             if isinstance(environment.runner, MasterRunner):
                 workers = []
@@ -555,6 +560,8 @@ class WebUI:
             "show_userclass_picker": self.userclass_picker_is_active,
             "available_user_classes": available_user_classes,
             "available_shape_classes": available_shape_classes,
+            "percentile1": options.percentile1 if options.percentile1 else 0.95,
+            "percentile2": options.percentile2 if options.percentile2 else 0.5,
         }
 
     def _update_shape_class(self, shape_class_name):

--- a/locust/web.py
+++ b/locust/web.py
@@ -333,10 +333,10 @@ class WebUI:
             stats: List[Dict[str, Any]] = []
             errors: List[StatsErrorDict] = []
             options = self.environment.parsed_options
-            if not options.percentile1:
-                options.percentile1 = '0.95'
-            if not options.percentile2:
-                options.percentile2 = '0.5'
+            percentile1 = options.percentiles.split(',')[0] \
+                if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95
+            percentile2 = options.percentiles.split(',')[1] \
+                if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5
             if environment.runner is None:
 
                 report = {
@@ -394,10 +394,10 @@ class WebUI:
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
                 report[
                     "current_response_time_percentile_95"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(float(options.percentile1))
+                ] = environment.runner.stats.total.get_current_response_time_percentile(float(percentile1))
                 report[
                     "current_response_time_percentile_50"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(float(options.percentile2))
+                ] = environment.runner.stats.total.get_current_response_time_percentile(float(percentile2))
 
             if isinstance(environment.runner, MasterRunner):
                 workers = []
@@ -541,6 +541,10 @@ class WebUI:
         if self.environment.available_shape_classes:
             available_shape_classes += sorted(self.environment.available_shape_classes.keys())
 
+        percentile1 = options.percentiles.split(',')[0] if options and options.percentiles and len(options.percentiles.split(',')) >= 1 else 0.95
+        percentile2 = options.percentiles.split(',')[1] if options and options.percentiles and len(options.percentiles.split(',')) >= 2 else 0.5
+
+
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,
@@ -560,8 +564,8 @@ class WebUI:
             "show_userclass_picker": self.userclass_picker_is_active,
             "available_user_classes": available_user_classes,
             "available_shape_classes": available_shape_classes,
-            "percentile1": options.percentile1 if options.percentile1 else 0.95,
-            "percentile2": options.percentile2 if options.percentile2 else 0.5,
+            "percentile1": percentile1,
+            "percentile2": percentile2,
         }
 
     def _update_shape_class(self, shape_class_name):

--- a/locust/web.py
+++ b/locust/web.py
@@ -384,17 +384,20 @@ class WebUI:
                 truncated_stats += [stats[-1]]
 
             report = {"stats": truncated_stats, "errors": errors[:500]}
-            from .stats import PERCENTILES_TO_CHART
 
             if stats:
                 report["total_rps"] = stats[len(stats) - 1]["current_rps"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
                 report[
                     "current_response_time_percentile_1"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[0])
+                ] = environment.runner.stats.total.get_current_response_time_percentile(
+                    stats_module.PERCENTILES_TO_CHART[0]
+                )
                 report[
                     "current_response_time_percentile_2"
-                ] = environment.runner.stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[1])
+                ] = environment.runner.stats.total.get_current_response_time_percentile(
+                    stats_module.PERCENTILES_TO_CHART[1]
+                )
 
             if isinstance(environment.runner, MasterRunner):
                 workers = []
@@ -538,9 +541,6 @@ class WebUI:
         if self.environment.available_shape_classes:
             available_shape_classes += sorted(self.environment.available_shape_classes.keys())
 
-        from .stats import PERCENTILES_TO_CHART
-
-        # print(PERCENTILES_TO_CHART)
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,
@@ -560,8 +560,8 @@ class WebUI:
             "show_userclass_picker": self.userclass_picker_is_active,
             "available_user_classes": available_user_classes,
             "available_shape_classes": available_shape_classes,
-            "percentile1": PERCENTILES_TO_CHART[0],
-            "percentile2": PERCENTILES_TO_CHART[1],
+            "percentile1": stats_module.PERCENTILES_TO_CHART[0],
+            "percentile2": stats_module.PERCENTILES_TO_CHART[1],
         }
 
     def _update_shape_class(self, shape_class_name):

--- a/locust/web.py
+++ b/locust/web.py
@@ -340,8 +340,8 @@ class WebUI:
                     "errors": errors,
                     "total_rps": 0.0,
                     "fail_ratio": 0.0,
-                    "current_response_time_percentile_95": None,
-                    "current_response_time_percentile_50": None,
+                    "current_response_time_percentile_1": None,
+                    "current_response_time_percentile_2": None,
                     "state": STATE_MISSING,
                     "user_count": 0,
                 }
@@ -385,14 +385,15 @@ class WebUI:
 
             report = {"stats": truncated_stats, "errors": errors[:500]}
             from .stats import PERCENTILES_TO_CHART
+
             if stats:
                 report["total_rps"] = stats[len(stats) - 1]["current_rps"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
                 report[
-                    "current_response_time_percentile_95"
+                    "current_response_time_percentile_1"
                 ] = environment.runner.stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[0])
                 report[
-                    "current_response_time_percentile_50"
+                    "current_response_time_percentile_2"
                 ] = environment.runner.stats.total.get_current_response_time_percentile(PERCENTILES_TO_CHART[1])
 
             if isinstance(environment.runner, MasterRunner):
@@ -539,6 +540,7 @@ class WebUI:
 
         from .stats import PERCENTILES_TO_CHART
 
+        # print(PERCENTILES_TO_CHART)
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,


### PR DESCRIPTION
Added --percentiles command line argument which is for response time chart in chart page and download report page.
Default value is 95% and 50%. 
example . # locust -f locust_file.py --percentiles 0.99,0.8

This is from issue [#2311](https://github.com/locustio/locust/issues/2311) 
