### PR TITLE
Removed exit error when run-time and load shape supplied

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -356,9 +356,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
             # start the test
             if environment.shape_class:
-                if options.run_time:
-                    sys.stderr.write("It makes no sense to combine --run-time and LoadShapes. Bailing out.\n")
-                    sys.exit(1)
                 environment.runner.start_shape()
                 environment.runner.shape_greenlet.join()
                 stop_and_optionally_quit()


### PR DESCRIPTION
I noticed a little discrepancy, when running in headless mode with `run-time` parameter and a `LoadTestShape` I got the error: `It makes no sense to combine --run-time and LoadShapes. Bailing out.`. I also noticed that the same thing doesn't occur when running with GUI. I tested my solution locally and it seems to work fine. I also ran the automated tools and the following failed two: `test_print_stats, test_print_percentile_stats`. However they also failed without the change and I'm not sure if its related to me running them in WLS2. Could someone who is more involved with the project test this changes properly and merge if everything is ok?