### PR TITLE
Duplicated titles

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ Getting started
 
 .. toctree ::
     :maxdepth: 2
-    :caption: Getting started
 
     what-is-locust
     installation
@@ -28,7 +27,6 @@ Writing Locust tests
 
 .. toctree ::
     :maxdepth: 2
-    :caption: Writing Locust tests
 
     writing-a-locustfile
 
@@ -38,7 +36,6 @@ Running your Locust tests
 
 .. toctree ::
     :maxdepth: 1
-    :caption: Running your Locust tests
 
     configuration
     running-distributed
@@ -53,7 +50,6 @@ Other functionalities
 
 .. toctree ::
     :maxdepth: 2
-    :caption: Other functionalities
 
     custom-load-shape
     retrieving-stats
@@ -69,7 +65,6 @@ Further reading / knowledgebase
 
 .. toctree ::
     :maxdepth: 1
-    :caption: Further reading / knowledgebase
 
     developing-locust
     further-reading
@@ -79,7 +74,6 @@ API
 ---
 .. toctree ::
     :maxdepth: 4
-    :caption: API
 
     api
 
@@ -90,6 +84,5 @@ Changelog
 
 .. toctree ::
     :maxdepth: 2
-    :caption: Changelog
 
     changelog


### PR DESCRIPTION
RIght now in https://docs.locust.io/en/latest/ the edited titles are shown duplicated: 
![image](https://github.com/locustio/locust/assets/23295253/32c71497-8a07-4bf8-be6b-c4788e9c0204)
 