### PR TITLE
Issue #1363: Adding option for exlusion time of failed requests from time metrics

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -488,6 +488,14 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         env_var="LOCUST_ONLY_SUMMARY",
     )
     stats_group.add_argument(
+        "--exclude-failures",
+        action="store_true",
+        default=False,
+        dest="exclude_failures_time",
+        help="Excludes response times of failed requests from time-based metrics (but not from total/failed requests count)",
+        env_var="EXCLUDE_FAILURES",
+    )
+    stats_group.add_argument(
         "--reset-stats",
         action="store_true",
         help="Reset statistics once spawning has been completed. Should be set on both master and workers when running in distributed mode",

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -492,7 +492,8 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         action="store_true",
         default=False,
         dest="exclude_failures_time",
-        help="Excludes response times of failed requests from time-based metrics (but not from total/failed requests count)",
+        help="Excludes response times of failed requests from time-based metrics (but not from total/failed requests count)."
+             "This option can be set or overridden for specified requests by passing 'exclude_failures=True/False' keyword parameter to the request",
         env_var="EXCLUDE_FAILURES",
     )
     stats_group.add_argument(

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -492,8 +492,7 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         action="store_true",
         default=False,
         dest="exclude_failures_time",
-        help="Excludes response times of failed requests from time-based metrics (but not from total/failed requests count)."
-             "This option can be set or overridden for specified requests by passing 'exclude_failures=True/False' keyword parameter to the request",
+        help="Excludes response times of failed requests from time-based metrics (but not from total/failed requests count). This option can be set or overridden for specified requests by passing 'exclude_failures=True/False' keyword parameter to the request",
         env_var="EXCLUDE_FAILURES",
     )
     stats_group.add_argument(

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -132,7 +132,12 @@ class Runner:
         # set up event listeners for recording requests
         def on_request(request_type, name, response_time, response_length, exception=None, **_kwargs):
             if exception:
-                if self.environment.parsed_options and self.environment.parsed_options.exclude_failures_time:
+                exclude_failures = None
+                if _kwargs and _kwargs.get("exclude_failures") is not None:
+                    exclude_failures = _kwargs.get("exclude_failures")
+                elif self.environment.parsed_options and self.environment.parsed_options.exclude_failures_time:
+                    exclude_failures = True
+                if exclude_failures:
                     response_time = None
                 self.stats.log_request(request_type, name, response_time, response_length)
                 self.stats.log_error(request_type, name, exception)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -131,9 +131,13 @@ class Runner:
 
         # set up event listeners for recording requests
         def on_request(request_type, name, response_time, response_length, exception=None, **_kwargs):
-            self.stats.log_request(request_type, name, response_time, response_length)
             if exception:
+                if self.environment.parsed_options and self.environment.parsed_options.exclude_failures_time:
+                    response_time = None
+                self.stats.log_request(request_type, name, response_time, response_length)
                 self.stats.log_error(request_type, name, exception)
+            else:
+                self.stats.log_request(request_type, name, response_time, response_length)
 
         self.environment.events.request.add_listener(on_request)
 

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -78,6 +78,7 @@ class TestArgumentParser(LocustTestCase):
                 "-t",
                 "5m",
                 "--reset-stats",
+                "--exclude-failures",
                 "--stop-timeout",
                 "5",
                 "MyUserClass",
@@ -88,6 +89,7 @@ class TestArgumentParser(LocustTestCase):
         self.assertEqual(10, options.spawn_rate)
         self.assertEqual("5m", options.run_time)
         self.assertTrue(options.reset_stats)
+        self.assertTrue(options.exclude_failures_time)
         self.assertEqual("5", options.stop_timeout)
         self.assertEqual(["MyUserClass"], options.user_classes)
         # check default arg


### PR DESCRIPTION
This PR revives the request from https://github.com/locustio/locust/issues/1363 (_If possible, please reopen it_)

It allows adding the parameter  `--exсlude-failures` to locust runner to ignore response times of failed requests from time-based metrics (min,max, avg, percentiles etc.)

This helps to exclude abnormal values (too big or too small) from time statistics produced by failed requests. (For example, when getting gateway timeout errors equal to 60 seconds or more)
At the same time, it keeps stats for the total requests number and failures number.

**Example:** 
9 passed requests with 1 second response time + 1 failed request with 5 seconds response time

Without option:
`Avg time = (9*1 + 1*5) / 10 = 1.4 sec, Max time = 5 sec`

With option `--exclude-failures`:
`Avg time = (9*1) / 9 = 1 sec, Max time = 1 sec`

Total/Failed = 10/1 in both cases

**Update:** In a second commit added a feature for setting or overriding global setting for exclusion failures by passing keyword parameter to specified request(s).

