### PR TITLE
Clarify documentation string for `total_content_length`

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -331,7 +331,7 @@ class StatsEntry:
         OrderedDict that holds a copy of the response_times dict for each of the last 20 seconds.
         """
         self.total_content_length: int = 0
-        """ The sum of the content length of all the requests for this entry """
+        """ The sum of the content length of all the responses for this entry """
         self.start_time: float = 0.0
         """ Time of the first request for this entry """
         self.last_request_timestamp: Optional[float] = None


### PR DESCRIPTION
I believe the comment is wrong, `total_content_length` is used to sum up the content length of the response, not the request, see for example https://github.com/locustio/locust/blob/7002fb72de84f707defbcf5e183013de08f443ba/locust/runners.py#L133C1-L136