### PR TITLE
Allow selecting user classes using LOCUST_USER_CLASSES env var

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -583,7 +583,8 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         "user_classes",
         nargs="*",
         metavar="UserClass",
-        help="Optionally specify which User classes that should be used (available User classes can be listed with -l or --list)",
+        help="Optionally specify which User classes that should be used (available User classes can be listed with -l or --list). LOCUST_USER_CLASSES environment variable can also be used to specify User classes",
+        default=os.environ.get("LOCUST_USER_CLASSES", "").split(),
     )
 
 

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -93,6 +93,34 @@ class TestArgumentParser(LocustTestCase):
         # check default arg
         self.assertEqual(8089, options.web_port)
 
+    def test_parse_options_from_env(self):
+        os.environ["LOCUST_LOCUSTFILE"] = "locustfile.py"
+        os.environ["LOCUST_USERS"] = "100"
+        os.environ["LOCUST_SPAWN_RATE"] = "10"
+        os.environ["LOCUST_RUN_TIME"] = "5m"
+        os.environ["LOCUST_RESET_STATS"] = "true"
+        os.environ["LOCUST_STOP_TIMEOUT"] = "5"
+        os.environ["LOCUST_USER_CLASSES"] = "MyUserClass"
+        options = parse_options(args=[])
+
+        self.assertEqual("locustfile.py", options.locustfile)
+        self.assertEqual(100, options.num_users)
+        self.assertEqual(10, options.spawn_rate)
+        self.assertEqual("5m", options.run_time)
+        self.assertTrue(options.reset_stats)
+        self.assertEqual("5", options.stop_timeout)
+        self.assertEqual(["MyUserClass"], options.user_classes)
+        # check default arg
+        self.assertEqual(8089, options.web_port)
+
+        del os.environ["LOCUST_LOCUSTFILE"]
+        del os.environ["LOCUST_USERS"]
+        del os.environ["LOCUST_SPAWN_RATE"]
+        del os.environ["LOCUST_RUN_TIME"]
+        del os.environ["LOCUST_RESET_STATS"]
+        del os.environ["LOCUST_STOP_TIMEOUT"]
+        del os.environ["LOCUST_USER_CLASSES"]
+
     def test_parse_locustfile(self):
         with mock_locustfile() as mocked:
             locustfiles = parse_locustfile_option(


### PR DESCRIPTION
This pull request introduces an improvement to Locust, enabling the specification of `user_classes` through the `LOCUST_USER_CLASSES` environment variable. Currently, `user_classes` can only be defined via command-line arguments, limiting flexibility. With this enhancement, users can conveniently configure a list of user classes separated by spaces, making it easier to simulate specific user behaviors when running Locust in a Docker container.

**Details:**
In the existing implementation of Locust, when executing it within a Docker container, `user_classes` must be specified using command-line arguments. This approach can be cumbersome, requiring modifications to the command every time different user classes need to be tested. This pull request addresses this limitation by introducing support for user_classes through the `LOCUST_USER_CLASSES` environment variable.

To utilize this new feature, users can now set the `LOCUST_USER_CLASSES` environment variable with a list of user class names separated by spaces. For example, if the desired user classes are "UserClass1", "UserClass2", and "UserClass3", the environment variable would be set as follows: `LOCUST_USER_CLASSES="UserClass1 UserClass2 UserClass3"`.