### PR TITLE
Web UI dropdown for custom args with choices

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -194,7 +194,7 @@ On windows:
 Custom arguments
 ----------------
 
-You can add your own command line arguments to Locust, using the :py:attr:`init_command_line_parser <locust.event.Events.init_command_line_parser>` Event. Custom arguments are also presented and editable in the web UI.
+You can add your own command line arguments to Locust, using the :py:attr:`init_command_line_parser <locust.event.Events.init_command_line_parser>` Event. Custom arguments are also presented and editable in the web UI. If `choices` are specified for the argument, they will be presented as a dropdown in the web UI.
 
 .. literalinclude:: ../examples/add_command_line_argument.py
     :language: python

--- a/examples/add_command_line_argument.py
+++ b/examples/add_command_line_argument.py
@@ -4,6 +4,8 @@ from locust import HttpUser, task, events
 @events.init_command_line_parser.add_listener
 def _(parser):
     parser.add_argument("--my-argument", type=str, env_var="LOCUST_MY_ARGUMENT", default="", help="It's working")
+    # Choices will validate command line input and show a dropdown in the web UI
+    parser.add_argument("--env", choices=["dev", "staging", "prod"], default="dev", help="Environment")
     # Set `include_in_web_ui` to False if you want to hide from the web UI
     parser.add_argument("--my-ui-invisible-argument", include_in_web_ui=False, default="I am invisible")
     # Set `is_secret` to True if you want the text input to be password masked in the web UI

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -2,7 +2,7 @@ import os
 import platform
 import sys
 import textwrap
-from typing import Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple, Optional
 
 import configargparse
 
@@ -619,6 +619,7 @@ class UIExtraArgOptions(NamedTuple):
     default_value: str
     is_secret: bool
     help_text: str
+    choices: Optional[List[str]] = None
 
 
 def ui_extra_args_dict(args=None) -> Dict[str, UIExtraArgOptions]:
@@ -633,6 +634,7 @@ def ui_extra_args_dict(args=None) -> Dict[str, UIExtraArgOptions]:
             default_value=v,
             is_secret=k in parser.secret_args_included_in_web_ui,
             help_text=parser.args_included_in_web_ui[k].help,
+            choices=parser.args_included_in_web_ui[k].choices,
         )
         for k, v in all_args.items()
         if k not in locust_args and k in parser.args_included_in_web_ui

--- a/locust/static/css/application.css
+++ b/locust/static/css/application.css
@@ -281,6 +281,14 @@ body.running .top .top-content .boxes .top_box.box_status .edit-test, body.spawn
   font-size: 24px;
   padding-left: 10px;
 }
+.dialogs .dialog select.val {
+  border: none;
+  background: #fff;
+  height: 52px;
+  width: 340px;
+  font-size: 24px;
+  padding-left: 10px;
+}
 .dialogs .dialog button {
   margin-top: 20px;
   float: right;

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -110,7 +110,15 @@
                                     <span style="color:#8a8a8a;">({{value.help_text}})</span>
                                 {% endif %}
                             </label>
-                            <input type="{{'password' if value.is_secret else 'text'}}" name="{{key}}" id="{{key}}" class="val" value="{{value.default_value}}" /><br>
+                            {% if value.choices %}
+                                <select name="{{key}}" id="{{key}}" class="val">
+                                    {% for choice in value.choices %}
+                                        <option value="{{choice}}" {% if choice == value.default_value %}selected{% endif %}>{{choice}}</option>
+                                    {% endfor %}
+                                </select><br>
+                            {% else %}
+                                <input type="{{'password' if value.is_secret else 'text'}}" name="{{key}}" id="{{key}}" class="val" value="{{value.default_value}}" /><br>
+                            {% endif %}
                         {% endif %}
                     {% endfor %}
                     {% set glob={'header_printed': False} %}

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -740,11 +740,11 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         response = requests.get("http://127.0.0.1:%i/" % self.web_port)
         self.assertEqual(200, response.status_code)
 
-        # regex to match a select tag with id my-argument
+        # regex to match the intended select tag with id from the custom argument
         dropdown_pattern = re.compile(r"<select[^>]*id=\"my_argument\"[^>]*>", flags=re.I)
         self.assertRegex(response.text, dropdown_pattern)
 
-        # regex to match an input text tag with id my-argument
+        # regex to match the input that generates if it fails to find the choices
         textfield_pattern = re.compile(r"<input[^>]*id=\"my_argument\"[^>]*>", flags=re.I)
         self.assertNotRegex(response.text, textfield_pattern)
 

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -2,6 +2,7 @@ import copy
 import csv
 import json
 import os
+import re
 import textwrap
 import traceback
 from io import StringIO
@@ -722,6 +723,30 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual(my_dict["val"], 42)
+
+    def test_custom_argument_dropdown(self):
+        class MyUser(User):
+            host = "http://example.com"
+
+        @locust.events.init_command_line_parser.add_listener
+        def _(parser, **kw):
+            parser.add_argument("--my-argument", default="a", choices=["a", "b"], help="Pick one")
+
+        parsed_options = parse_options(args=["--my-argument", "b"])
+        self.environment.user_classes = [MyUser]
+        self.environment.parsed_options = parsed_options
+        self.environment.web_ui.parsed_options = parsed_options
+
+        response = requests.get("http://127.0.0.1:%i/" % self.web_port)
+        self.assertEqual(200, response.status_code)
+
+        # regex to match a select tag with id my-argument
+        dropdown_pattern = re.compile(r"<select[^>]*id=\"my_argument\"[^>]*>", flags=re.I)
+        self.assertRegex(response.text, dropdown_pattern)
+
+        # regex to match an input text tag with id my-argument
+        textfield_pattern = re.compile(r"<input[^>]*id=\"my_argument\"[^>]*>", flags=re.I)
+        self.assertNotRegex(response.text, textfield_pattern)
 
     def test_swarm_host_value_not_specified(self):
         class MyUser(User):


### PR DESCRIPTION
Addresses #2371 

This adds web UI support for a dropdown list in custom arguments:
<img width="416" alt="Screen Shot 2023-07-16 at 7 34 44 PM" src="https://github.com/locustio/locust/assets/2133115/a1d55d48-37be-4812-8619-6eebac49a69e">

Code:
```
parser.add_argument("--env", choices=["dev", "staging", "prod"], default="dev")
```

argparse already checks those choices on command-line args, this PR just makes the web UI behave similarly.

The CSS width is different for select (340) vs input (set to 328, actual 340) to get them to be the same actual width. I'm not exactly sure why but it looks like it has to do with differences in how padding is handled between the two tags.

# Testing
I ran locally with `scripts/run-local-web.sh` on OS X in a virtual env with Python 3.11.3

I wasn't able to get the tox tests running locally (I tried on master before making changes but it failed). Sorry about that! Hopefully the github actions aren't too burdensome.