### PR TITLE
Fix #1910 KeyboardInterrupt with load shapes

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -378,9 +378,13 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
                 if options.run_time:
                     sys.stderr.write("It makes no sense to combine --run-time and LoadShapes. Bailing out.\n")
                     sys.exit(1)
-                environment.runner.start_shape()
-                environment.runner.shape_greenlet.join()
-                stop_and_optionally_quit()
+                try:
+                    environment.runner.start_shape()
+                    environment.runner.shape_greenlet.join()
+                except KeyboardInterrupt:
+                    logging.info("Exiting due to CTRL+C interruption")
+                finally:
+                    stop_and_optionally_quit()
             else:
                 headless_master_greenlet = gevent.spawn(runner.start, options.num_users, options.spawn_rate)
                 headless_master_greenlet.link_exception(greenlet_exception_handler)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1205,7 +1205,7 @@ class MyUser(HttpUser):
                 class TestUser(User):
                     @task
                     def my_task(self):
-                        raise KeyboardInterrupt
+                        print("running my_task()")
             """
             )
         ) as mocked:
@@ -1221,9 +1221,10 @@ class MyUser(HttpUser):
                 text=True,
             )
             gevent.sleep(1.9)
+            proc.send_signal(signal.SIGINT)
             stdout, stderr = proc.communicate()
             print(stderr, stdout)
-            self.assertIn("Starting Locust", stderr)
+            self.assertIn("Shape test starting", stderr)
             self.assertIn("Exiting due to CTRL+C interruption", stderr)
             self.assertIn("Test Stopped", stdout)
             # ensure stats printer printed at least one report before shutting down and that there was a final report printed as well

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1226,6 +1226,8 @@ class MyUser(HttpUser):
             self.assertIn("Starting Locust", stderr)
             self.assertIn("Exiting due to CTRL+C interruption", stderr)
             self.assertIn("Test Stopped", stdout)
+            # ensure stats printer printed at least one report before shutting down and that there was a final report printed as well
+            self.assertRegex(stderr, r".*Aggregated[\S\s]*Shutting down[\S\s]*Aggregated.*")
 
 
 class DistributedIntegrationTests(ProcessIntegrationTest):


### PR DESCRIPTION
To be honest this is probably more of a bandaid solution, but for dealing with `KeyboardInterrupt`  this is hopefully sufficient. I've added an integration test that raises a `KeyboardInterrupt`. The logic being that if properly handled, the test will end properly, `@events.test_stop.add_listener` will execute, and a report will be generated. 