### PR TITLE
Import locust_plugins if available to give access to its custom arguments

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -23,8 +23,13 @@ from .contrib.fasthttp import FastHttpUser
 from .user.wait_time import between, constant, constant_pacing, constant_throughput
 from .shape import LoadTestShape
 from .debug import run_single_user
-
 from .event import Events
+
+try:
+    # import locust_plugins if it is installed, to allow it to register custom arguments etc
+    import locust_plugins  # pyright: ignore[reportMissingImports]
+except ModuleNotFoundError:
+    pass
 
 events = Events()
 


### PR DESCRIPTION
... without having to do `import locust_plugins` in every locustfile.