### PR TITLE
chore: bump dockerfile to 3.11-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.11-slim as base
 
 FROM base as builder
 RUN apt-get update && apt-get install -y git 


### PR DESCRIPTION
Bumped python version for official locust Dockerfile.