### PR TITLE
feat(shape): support user base custom load shape

### DIFF
--- a/docs/custom-load-shape.rst
+++ b/docs/custom-load-shape.rst
@@ -41,6 +41,18 @@ This functionality is further demonstrated in the `examples on github <https://g
 
 One further method may be helpful for your custom load shapes: `get_current_user_count()`, which returns the total number of active users. This method can be used to prevent advancing to subsequent steps until the desired number of users has been reached. This is especially useful if the initialization process for each user is slow or erratic in how long it takes. If this sounds like your use case, see the `example on github <https://github.com/locustio/locust/tree/master/examples/custom_shape/wait_user_count.py>`_.
 
+Note that if you want to defined your own custom base shape, you need to define the `abstract` attribute to `True` to avoid it being picked as Shape when imported:
+
+.. code-block:: python
+
+    class MyBaseShape(LoadTestShape):
+        abstract = True
+        
+        def tick(self):
+            # Something reusable but needing inheritance
+            return None
+
+
 Combining Users with different load profiles
 --------------------------------------------
 

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,19 +1,32 @@
 from __future__ import annotations
 import time
-from typing import Optional, Tuple, List, Type
-from abc import ABC, abstractmethod
+from typing import ClassVar, Optional, Tuple, List, Type
+from abc import ABCMeta, abstractmethod
 
 from . import User
 from .runners import Runner
 
 
-class LoadTestShape(ABC):
+class LoadTestShapeMeta(ABCMeta):
+    """
+    Meta class for the main User class. It's used to allow User classes to specify task execution
+    ratio using an {task:int} dict, or a [(task0,int), ..., (taskN,int)] list.
+    """
+
+    def __new__(mcs, classname, bases, class_dict):
+        class_dict["abstract"] = class_dict.get("abstract", False)
+        return super().__new__(mcs, classname, bases, class_dict)
+
+
+class LoadTestShape(metaclass=LoadTestShapeMeta):
     """
     Base class for custom load shapes.
     """
 
     runner: Optional[Runner] = None
     """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
+
+    abstract: ClassVar[bool] = True
 
     def __init__(self):
         self.start_time = time.perf_counter()

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -76,6 +76,41 @@ class TestLoadLocustfile(LocustTestCase):
             self.assertNotIn("NotUserSubclass", user_classes)
             self.assertEqual(shape_class.__class__.__name__, "LoadTestShape")
 
+    def test_with_abstract_shape_class(self):
+        content = MOCK_LOCUSTFILE_CONTENT + textwrap.dedent(
+            """\
+        class UserBaseLoadTestShape(LoadTestShape):
+            abstract = True
+
+            def tick(self):
+                pass
+
+
+        class UserLoadTestShape(UserBaseLoadTestShape):
+            pass
+        """
+        )
+
+        with mock_locustfile(content=content) as mocked:
+            _, user_classes, shape_class = main.load_locustfile(mocked.file_path)
+            self.assertNotIn("UserBaseLoadTestShape", user_classes)
+            self.assertNotIn("UserLoadTestShape", user_classes)
+            self.assertEqual(shape_class.__class__.__name__, "UserLoadTestShape")
+
+    def test_with_not_imported_shape_class(self):
+        content = MOCK_LOCUSTFILE_CONTENT + textwrap.dedent(
+            """\
+        class UserLoadTestShape(LoadTestShape):
+            def tick(self):
+                pass
+        """
+        )
+
+        with mock_locustfile(content=content) as mocked:
+            _, user_classes, shape_class = main.load_locustfile(mocked.file_path)
+            self.assertNotIn("UserLoadTestShape", user_classes)
+            self.assertEqual(shape_class.__class__.__name__, "UserLoadTestShape")
+
     def test_create_environment(self):
         options = parse_options(
             args=[

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -18,9 +18,7 @@ def is_shape_class(item):
     """
     Check if a class is a LoadTestShape
     """
-    return bool(
-        inspect.isclass(item) and issubclass(item, LoadTestShape) and item.__dict__["__module__"] != "locust.shape"
-    )
+    return bool(inspect.isclass(item) and issubclass(item, LoadTestShape) and not getattr(item, "abstract", True))
 
 
 def load_locustfile(path) -> Tuple[Optional[str], Dict[str, User], Optional[LoadTestShape]]:


### PR DESCRIPTION
This PR improves the abstract custom base shape detection by using the same pattern than the base `User` class: abstract base classes should define the `abstract`attribute to `True`.

This change is entirely backward compatible and tested.

This PR fixes the following case:
- define a reusable `LoadTestShape` in your common modules (let's say `lib.BaseShape`)
- create a locust file, create a child shape (cf. below)
- run the bench

This will result in:
- without this change, the imported base class is picked as shape, the child class is ignored.
- with this change, the imported abstract base is ignored and the child class is selected as shape

`lib.py`
```python

class BaseShape(LoadTestShape):
	abstract = True

	some_class_attr = None # to be provided by child implementation

	def tick(self):
        # Do something with `self.__class__.some_class_attr`
```
`locusfile`
```python
from lib import BaseShape

class MyShape(BaseShape):
    some_class_attr = ["my test data"]
```

Currently, `BaseShape` will be chosen as `shape_class` and `MyShape` will be silently ignored (unless you specify it on the command line, or you rely on the class picker in which `BaseShape` will appear and shouldn't).

With this change, `BaseShape` is seen as abstract and is ignored from shape candidates, won't appear in the class picker and `MyShape` will be chosen if not explicitly told.
