### PR TITLE
refactor(shape): allows custom shapes to reuse run-time, spawn-rate and users parameters

### DIFF
--- a/docs/custom-load-shape.rst
+++ b/docs/custom-load-shape.rst
@@ -78,6 +78,7 @@ Adding the element ``user_classes`` to the return value gives you more detailed 
             {"duration": 30, "users": 50, "spawn_rate": 10, "user_classes": [UserA, UserB]},
             {"duration": 60, "users": 100, "spawn_rate": 10, "user_classes": [UserB]},
             {"duration": 120, "users": 100, "spawn_rate": 10, "user_classes": [UserA,UserB]},
+        ]
 
         def tick(self):
             run_time = self.get_run_time()
@@ -93,3 +94,30 @@ Adding the element ``user_classes`` to the return value gives you more detailed 
             return None
 
 This shape would create create in the first 10 seconds 10 User of ``UserA``. In the next twenty seconds 40 of type ``UserA / UserB`` and this continues until the stages end.
+
+
+.. _use-common-options:
+
+Reusing command line parameters in custom shapes
+------------------------------------------------
+
+By default, using a custom shape will disable default run paramaters (in both the CLI and the Web UI):
+- `--run-time` (providing this one with a custom shape will make locust to bail out)
+- `--spawn-rate`
+- `--users`
+
+
+If you need one or all of those parameters, you can force locust to accept them by setting the `use_common_options` attribute to `True`:
+
+
+.. code-block:: python
+
+    class MyCustomShape(LoadTestShape):
+
+        use_common_options = True
+
+        def tick(self):
+            expected_run_time = self.runner.environment.parsed_options.run_time
+            # Do something with this expected run time
+            ...
+            return None

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -329,7 +329,7 @@ class Runner:
             logger.info("There is an ongoing shape test running. Editing is disabled")
             return
 
-        logger.info("Shape test starting. User count and spawn rate are ignored for this type of load test")
+        logger.info("Shape test starting.")
         self.update_state(STATE_INIT)
         self.shape_greenlet = self.greenlet.spawn(self.shape_worker)
         self.shape_greenlet.link_exception(greenlet_exception_handler)

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -28,6 +28,8 @@ class LoadTestShape(metaclass=LoadTestShapeMeta):
 
     abstract: ClassVar[bool] = True
 
+    use_common_options: ClassVar[bool] = False
+
     def __init__(self):
         self.start_time = time.perf_counter()
 

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -65,7 +65,7 @@
                         {% for user in available_user_classes %}
                             <option value="{{user}}" selected>{{user}}</option>
                         {% endfor %}
-                        </select><br>
+                        </select><br>range
                         <label for="available_shape_classes">ShapeClass </label>
                         <select name="shape_class" id="shape-classes" class="shapeClass">
                         {% for shape_class in available_shape_classes %}
@@ -73,7 +73,7 @@
                         {% endfor %}
                         </select><br>
                     {% endif %}
-                    {% if is_shape %}
+                    {% if hide_common_options %}
                         <label for="user_count">Number of users <span style="color:#8a8a8a;">(peak concurrency)</span></label>
                         <input type="text" name="user_count" id="user_count" class="val_disabled" value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
                         <input type="hidden" name="user_count" id="user_count" value="0"/><br>
@@ -144,7 +144,7 @@
             <div class="padder">
                 <h2>Edit running load test</h2>
                 <form action="./swarm" method="POST" id="edit_form">
-                    {% if is_shape %}
+                    {% if hide_common_options %}
                         <label for="new_user_count">Number of users (peak concurrency)</label>
                         <input type="text" name="user_count" id="new_user_count" class="val_disabled"  value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
                         <label for="spawn_rate">Spawn rate <span style="color:#8a8a8a;">(users added/stopped per second)</span></label>
@@ -155,7 +155,7 @@
                         <label for="spawn_rate">Spawn rate <span style="color:#8a8a8a;">(users added/stopped per second)</span></label>
                         <input type="text" name="spawn_rate" id="new_spawn_rate" class="val"  value="{{ spawn_rate or "1" }}" onfocus="this.select()"/><br>
                     {% endif %}
-                    {% if is_shape %}
+                    {% if hide_common_options %}
                         <button type="submit" disabled>Start swarming</button>
                     {% else %}
                         <button type="submit">Start swarming</button>

--- a/locust/web.py
+++ b/locust/web.py
@@ -553,7 +553,10 @@ class WebUI:
             "num_users": options and options.num_users,
             "spawn_rate": options and options.spawn_rate,
             "worker_count": worker_count,
-            "is_shape": self.environment.shape_class and not self.userclass_picker_is_active,
+            "hide_common_options": (
+                self.environment.shape_class
+                and not (self.userclass_picker_is_active or self.environment.shape_class.use_common_options)
+            ),
             "stats_history_enabled": options and options.stats_history_enabled,
             "tasks": dumps({}),
             "extra_options": extra_options,


### PR DESCRIPTION
Currently, it is not possible for a custom `LoadTestShape` to reuse the built-in `run_time`, `num_users` and `spawn_rate` parameters, even if they need/use it (they are rather classical load testing parameters).
There must be an undocumented reason somewhere for this choice.

This pull request allows custom `LoadTestShape` to reuse those command line parameters if explicitly told with the `reuse_parameters` attribute.

So with this change, the following code will work:

```python
class MyCustomShape(LoadTestShape):

    reuse_parameters = True

    def tick(self):
        expected_run_time = self.runner.environment.parsed_options.run_time
        # Do something with this expected run time
        ...
        return None
```

This change is tested, documented and backward compatible. The WebUI swarm form behavior has been adapted to it (`user_count` and `spawn_rate` fields are not disabled with `reuse_parameters = True`).

**Note**: ~~build is failing on github while succeeded in `tox` locally (for all Python version).~~ I added some output to the test in case of failure to understand why it fails on github.
