### PR TITLE
Log a deprecation warning in Python 3.7

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -210,6 +210,9 @@ It's not high enough for load testing, and the OS didn't allow locust to increas
 See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit for more info."""
             )
 
+    if sys.version_info <= (3, 8):
+        logger.info("Python 3.7 support is deprecated and will be removed soon")
+
     # create locust Environment
     locustfile_path = None if not locustfile else os.path.basename(locustfile)
 


### PR DESCRIPTION
Python 3.7 is not receiving fixes any more and 3.8 comes with a few nice syntax improvements. So I want to drop support for 3.7 soon. This is just a warning for now, we're still supporting 3.7.