### PR TITLE
Feature: Separate fetching and waiting times for response

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -132,7 +132,7 @@ class HttpSession(requests.Session):
 
         # use stream=True to avoid closing socket and downloading content at the beginning
         # we'll download content if actually requested a bit later
-        # 
+        #
         # a bit of a hack to actually estimate fetching time
         stream = kwargs.pop("stream", False)
 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -163,9 +163,7 @@ class HttpSession(requests.Session):
         else:
             request_meta["response_length"] = len(response.content or b"")
         request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-        request_meta["response_time"] = (
-            request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
-        )
+        request_meta["response_time"] = request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
 
         if catch_response:
             return ResponseContextManager(response, request_event=self.request_event, request_meta=request_meta)

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -250,7 +250,7 @@ class FastHttpSession:
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
         request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-        request_meta["response_time"] = int(
+        request_meta["response_time"] = (
             request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
         )
 

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -223,7 +223,7 @@ class FastHttpSession:
             "exception": None,
             "start_time": start_time,
             "url": built_url,  # this is a small deviation from HttpSession, which gets the final (possibly redirected) URL
-            "response_waiting_time": (server_response_time - start_perf_counter) * 1000
+            "response_waiting_time": (server_response_time - start_perf_counter) * 1000,
         }
 
         if not allow_redirects:
@@ -238,7 +238,9 @@ class FastHttpSession:
                 request_meta["response_length"] = len(response.content or "")
             except HTTPParseError as e:
                 request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-                request_meta["response_time"] = request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
+                request_meta["response_time"] = (
+                    request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
+                )
                 request_meta["response_length"] = 0
                 request_meta["exception"] = e
                 self.environment.events.request.fire(**request_meta)
@@ -248,7 +250,9 @@ class FastHttpSession:
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
         request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-        request_meta["response_time"] = int(request_meta["response_waiting_time"] + request_meta["response_fetching_time"])
+        request_meta["response_time"] = int(
+            request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
+        )
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -250,9 +250,7 @@ class FastHttpSession:
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
         request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-        request_meta["response_time"] = (
-            request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
-        )
+        request_meta["response_time"] = request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -223,7 +223,7 @@ class FastHttpSession:
             "exception": None,
             "start_time": start_time,
             "url": built_url,  # this is a small deviation from HttpSession, which gets the final (possibly redirected) URL
-            "waiting_for_server_response_time": (server_response_time - start_perf_counter) * 1000
+            "response_waiting_time": (server_response_time - start_perf_counter) * 1000
         }
 
         if not allow_redirects:
@@ -238,7 +238,7 @@ class FastHttpSession:
                 request_meta["response_length"] = len(response.content or "")
             except HTTPParseError as e:
                 request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-                request_meta["response_time"] = request_meta["waiting_for_server_response_time"] + request_meta["response_fetching_time"]
+                request_meta["response_time"] = request_meta["response_waiting_time"] + request_meta["response_fetching_time"]
                 request_meta["response_length"] = 0
                 request_meta["exception"] = e
                 self.environment.events.request.fire(**request_meta)
@@ -248,7 +248,7 @@ class FastHttpSession:
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
         request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
-        request_meta["response_time"] = int(request_meta["waiting_for_server_response_time"] + request_meta["response_fetching_time"])
+        request_meta["response_time"] = int(request_meta["response_waiting_time"] + request_meta["response_fetching_time"])
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -213,6 +213,8 @@ class FastHttpSession:
         start_perf_counter = time.perf_counter()
         # send request, and catch any exceptions
         response = self._send_request_safe_mode(method, built_url, payload=data, headers=headers, **kwargs)
+        server_response_time = time.perf_counter()
+
         request_meta = {
             "request_type": method,
             "name": name or url,
@@ -221,6 +223,7 @@ class FastHttpSession:
             "exception": None,
             "start_time": start_time,
             "url": built_url,  # this is a small deviation from HttpSession, which gets the final (possibly redirected) URL
+            "waiting_for_server_response_time": (server_response_time - start_perf_counter) * 1000
         }
 
         if not allow_redirects:
@@ -234,7 +237,8 @@ class FastHttpSession:
             try:
                 request_meta["response_length"] = len(response.content or "")
             except HTTPParseError as e:
-                request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
+                request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
+                request_meta["response_time"] = request_meta["waiting_for_server_response_time"] + request_meta["response_fetching_time"]
                 request_meta["response_length"] = 0
                 request_meta["exception"] = e
                 self.environment.events.request.fire(**request_meta)
@@ -243,7 +247,8 @@ class FastHttpSession:
         # Record the consumed time
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
-        request_meta["response_time"] = int((time.perf_counter() - start_perf_counter) * 1000)
+        request_meta["response_fetching_time"] = (time.perf_counter() - server_response_time) * 1000
+        request_meta["response_time"] = int(request_meta["waiting_for_server_response_time"] + request_meta["response_fetching_time"])
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -76,8 +76,10 @@ class TestFastHttpSession(WebserverTestCase):
         in request metadata
         """
         kwargs = {}
+
         def on_request(**kw):
             kwargs.update(kw)
+
         self.environment.events.request.add_listener(on_request)
         s = self.get_client()
 
@@ -88,7 +90,9 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertLess(kwargs["response_fetching_time"], 10)
         self.assertAlmostEqual(
             self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
-            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"],
+            delta=0.1,
+        )
         self.runner.stats.clear_all()
         kwargs.clear()
 
@@ -99,7 +103,9 @@ class TestFastHttpSession(WebserverTestCase):
         self.assertGreater(kwargs["response_fetching_time"], 250)
         self.assertAlmostEqual(
             self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
-            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"],
+            delta=0.1,
+        )
 
     def test_slow_redirect(self):
         s = self.get_client()

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -67,8 +67,10 @@ class TestHttpSession(WebserverTestCase):
         in request metadata
         """
         kwargs = {}
+
         def on_request(**kw):
             kwargs.update(kw)
+
         self.environment.events.request.add_listener(on_request)
         s = self.get_client()
 
@@ -79,7 +81,9 @@ class TestHttpSession(WebserverTestCase):
         self.assertLess(kwargs["response_fetching_time"], 10)
         self.assertAlmostEqual(
             self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
-            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"],
+            delta=0.1,
+        )
         self.runner.stats.clear_all()
         kwargs.clear()
 
@@ -90,8 +94,9 @@ class TestHttpSession(WebserverTestCase):
         self.assertGreater(kwargs["response_fetching_time"], 250)
         self.assertAlmostEqual(
             self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
-            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
-
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"],
+            delta=0.1,
+        )
 
     def test_slow_redirect(self):
         s = self.get_client()

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -61,6 +61,38 @@ class TestHttpSession(WebserverTestCase):
         # download the content of the streaming response (so we don't get an ugly exception in the log)
         _ = r.content
 
+    def test_response_times_are_separated_in_request_metadata(self):
+        """
+        Test that request times for server response and fetching are accessible
+        in request metadata
+        """
+        kwargs = {}
+        def on_request(**kw):
+            kwargs.update(kw)
+        self.environment.events.request.add_listener(on_request)
+        s = self.get_client()
+
+        # Verify that fetching content time is close to 0, when stream=True
+        s.get("/streaming/50", stream=True)
+        self.assertGreater(kwargs["response_waiting_time"], 0)
+        self.assertLess(kwargs["response_waiting_time"], 250)
+        self.assertLess(kwargs["response_fetching_time"], 10)
+        self.assertAlmostEqual(
+            self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
+        self.runner.stats.clear_all()
+        kwargs.clear()
+
+        # Now that we actually check fetching time
+        s.get("/streaming/50")
+        self.assertGreater(kwargs["response_waiting_time"], 0)
+        self.assertLess(kwargs["response_waiting_time"], 250)
+        self.assertGreater(kwargs["response_fetching_time"], 250)
+        self.assertAlmostEqual(
+            self.runner.stats.get("/streaming/50", method="GET").avg_response_time,
+            kwargs["response_waiting_time"] + kwargs["response_fetching_time"], delta=0.1)
+
+
     def test_slow_redirect(self):
         s = self.get_client()
         url = "/redirect?url=/redirect&delay=0.5"


### PR DESCRIPTION
Adding just a tiny bit more granularity for metadata returned when executing requests. Similarly as browsers do this and provide info when server first responded and how long it took to actually fetch the content.

![image](https://github.com/locustio/locust/assets/18267226/033bca42-48d8-422b-a84f-05edcd8c3216)
