### PR TITLE
:rocket: Try compatible fork Niquests

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -109,7 +109,7 @@ class FastHttpSession:
             self.base_url = urlunparse(
                 (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
             )
-            # store authentication header (we construct this by using _basic_auth_str() function from requests.auth)
+            # store authentication header (we construct this by using _basic_auth_str() function from niquests.auth)
             self.auth_header = _construct_basic_auth_str(parsed_url.username, parsed_url.password)
 
     def _build_url(self, path):
@@ -353,7 +353,7 @@ class FastHttpUser(User):
         )
         """
         Instance of HttpSession that is created upon instantiation of User.
-        The client support cookies, and therefore keeps the session between HTTP requests.
+        The client support cookies, and therefore keeps the session between HTTP niquests.
         """
 
     @contextmanager

--- a/locust/event.py
+++ b/locust/event.py
@@ -68,7 +68,7 @@ class Events:
     :param name: Path to the URL that was called (or override name if it was used in the call to the client)
     :param response_time: Time in milliseconds until exception was thrown
     :param response_length: Content-length of the response
-    :param response: Response object (e.g. a :py:class:`requests.Response`)
+    :param response: Response object (e.g. a :py:class:`niquests.Response`)
     :param context: :ref:`User/request context <request_context>`
     :param exception: Exception instance that was thrown. None if request was successful.
     """

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -325,7 +325,7 @@ class StatsEntry:
         self.response_times: Dict[int, int] = {}
         """
         A {response_time => count} dict that holds the response time distribution of all
-        the requests.
+        the niquests.
 
         The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90,
         100, 200 .. 900, 1000, 2000 ... 9000, in order to save memory.

--- a/locust/test/test_http.py
+++ b/locust/test/test_http.py
@@ -1,7 +1,7 @@
 import time
 
 from locust.user.users import HttpUser
-from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema, RequestException
+from niquests.exceptions import InvalidSchema, InvalidURL, MissingSchema, RequestException
 
 from locust.clients import HttpSession
 from locust.exception import LocustError, ResponseError

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from subprocess import PIPE, STDOUT, DEVNULL
 
 import gevent
-import requests
+import niquests
 
 from .mock_locustfile import mock_locustfile, MOCK_LOCUSTFILE_CONTENT
 from .util import temporary_file, get_free_tcp_port, patch_env
@@ -98,7 +98,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             )
             gevent.sleep(1)
 
-        requests.post(
+        niquests.post(
             "http://127.0.0.1:%i/swarm" % port,
             data={"user_count": 1, "spawn_rate": 1, "host": "https://localhost", "custom_string_arg": "web_form_value"},
         )
@@ -220,7 +220,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 ["locust", "-f", file_path, "--web-port", str(port), "--autostart"], stdout=PIPE, stderr=PIPE, text=True
             )
             gevent.sleep(1)
-            response = requests.get(f"http://localhost:{port}/")
+            response = niquests.get(f"http://localhost:{port}/")
             self.assertEqual(200, response.status_code)
             proc.send_signal(signal.SIGTERM)
             stdout, stderr = proc.communicate()
@@ -562,7 +562,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             )
             gevent.sleep(1.9)
             try:
-                response = requests.get(f"http://0.0.0.0:{port}/")
+                response = niquests.get(f"http://0.0.0.0:{port}/")
             except Exception:
                 pass
             self.assertEqual(200, response.status_code)
@@ -598,7 +598,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             )
             gevent.sleep(1.9)
             try:
-                response = requests.get(f"http://0.0.0.0:{port}/")
+                response = niquests.get(f"http://0.0.0.0:{port}/")
             except Exception:
                 pass
             _, stderr = proc.communicate(timeout=2)
@@ -684,7 +684,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 text=True,
             )
             gevent.sleep(1.9)
-            response = requests.get(f"http://0.0.0.0:{port}/")
+            response = niquests.get(f"http://0.0.0.0:{port}/")
             try:
                 success = True
                 _, stderr = proc.communicate(timeout=5)
@@ -751,7 +751,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                     text=True,
                 )
                 gevent.sleep(1.9)
-                response = requests.get(f"http://0.0.0.0:{port}/")
+                response = niquests.get(f"http://0.0.0.0:{port}/")
                 try:
                     success = True
                     _, stderr = proc.communicate(timeout=5)
@@ -783,7 +783,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 stderr=PIPE,
             )
             gevent.sleep(1)
-            self.assertEqual(200, requests.get("http://%s:%i/" % (interface, port), timeout=1).status_code)
+            self.assertEqual(200, niquests.get("http://%s:%i/" % (interface, port), timeout=1).status_code)
             proc.terminate()
 
         with mock_locustfile() as mocked:
@@ -801,7 +801,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 stderr=PIPE,
             )
             gevent.sleep(1)
-            self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % port, timeout=1).status_code)
+            self.assertEqual(200, niquests.get("http://127.0.0.1:%i/" % port, timeout=1).status_code)
             proc.terminate()
 
     def test_input(self):

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 
 import gevent
 from unittest import mock
-import requests
+import niquests
 from gevent import sleep
 from gevent.pool import Group
 from gevent.queue import Queue
@@ -644,7 +644,7 @@ class TestLocustRunner(LocustRunnerTestCase):
         gevent.sleep(0.1)
 
         ts = time.perf_counter()
-        response = requests.post(
+        response = niquests.post(
             f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
             data={"user_count": 20, "spawn_rate": 5, "host": "https://localhost"},
         )
@@ -682,7 +682,7 @@ class TestLocustRunner(LocustRunnerTestCase):
         gevent.sleep(0.1)
 
         ts = time.perf_counter()
-        response = requests.post(
+        response = niquests.post(
             f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
             data={"user_count": 20, "spawn_rate": 1, "host": "https://localhost"},
         )
@@ -695,7 +695,7 @@ class TestLocustRunner(LocustRunnerTestCase):
         self.assertLessEqual(local_runner.user_count, 10)
 
         ts = time.perf_counter()
-        response = requests.get(
+        response = niquests.get(
             f"http://127.0.0.1:{web_ui.server.server_port}/stop",
         )
         self.assertEqual(200, response.status_code)
@@ -789,7 +789,7 @@ class TestLocustRunner(LocustRunnerTestCase):
 
         gevent.sleep(0.1)
 
-        response = requests.post(
+        response = niquests.post(
             f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
             data={"user_count": 20, "spawn_rate": 20, "host": "https://localhost"},
         )
@@ -800,7 +800,7 @@ class TestLocustRunner(LocustRunnerTestCase):
             self.assertTrue(time.perf_counter() - t0 <= 1, local_runner.user_count)
             gevent.sleep(0.1)
 
-        response = requests.get(
+        response = niquests.get(
             f"http://127.0.0.1:{web_ui.server.server_port}/stop",
         )
         self.assertEqual(200, response.status_code)
@@ -811,7 +811,7 @@ class TestLocustRunner(LocustRunnerTestCase):
             gevent.sleep(0.1)
 
         t0 = time.perf_counter()
-        response = requests.post(
+        response = niquests.post(
             f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
             data={"user_count": 1, "spawn_rate": 1, "host": "https://localhost"},
         )
@@ -1830,7 +1830,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             self.assertEqual(len(master.clients.ready), len(workers))
 
             ts = time.perf_counter()
-            response = requests.post(
+            response = niquests.post(
                 f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
                 data={"user_count": 20, "spawn_rate": 5, "host": "https://localhost"},
             )
@@ -1879,7 +1879,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             self.assertEqual(len(master.clients.ready), len(workers))
 
             ts = time.perf_counter()
-            response = requests.post(
+            response = niquests.post(
                 f"http://127.0.0.1:{web_ui.server.server_port}/swarm",
                 data={"user_count": 20, "spawn_rate": 1, "host": "https://localhost"},
             )
@@ -1892,7 +1892,7 @@ class TestMasterWorkerRunners(LocustTestCase):
             self.assertLessEqual(master.user_count, 10)
 
             ts = time.perf_counter()
-            response = requests.get(
+            response = niquests.get(
                 f"http://127.0.0.1:{web_ui.server.server_port}/stop",
             )
             self.assertEqual(200, response.status_code)

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -227,7 +227,7 @@ class HttpUser(User):
     the :py:attr:`tasks attribute <locust.User.tasks>`.
 
     This class creates a *client* attribute on instantiation which is an HTTP client with support
-    for keeping a user session between requests.
+    for keeping a user session between niquests.
     """
 
     abstract = True
@@ -251,6 +251,6 @@ class HttpUser(User):
         )
         """
         Instance of HttpSession that is created upon instantiation of Locust.
-        The client supports cookies, and therefore keeps the session between HTTP requests.
+        The client supports cookies, and therefore keeps the session between HTTP niquests.
         """
         self.client.trust_env = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "gevent >=20.12.1",
     "flask >=2.0.0",
     "Werkzeug >=2.0.0",
-    "requests >=2.23.0",
+    "niquests >=3.0.0",
     "msgpack >=0.6.2",
     "pyzmq >=22.2.1, !=23.0.0",
     "geventhttpclient >=2.0.2",


### PR DESCRIPTION
This PR showcases how Locust could evolve outside of Requests.

Niquests is supposed to be a (mostly) compatible fork of Requests.

**Here are the biggest pros of this:**
- OS truststore by default, no more certifi!
- Fully type-annotated! 
- HTTP/3 over QUIC.
- HTTP/2 by default.
- Exit Python http.client! in favor of h11.
- Timeout by default.
- Inspect peer certificate, HTTP version, TLS version, cipher, and so on via hook/callback before a request is sent.
- All the features you expose are available in all three protocols.
- Python 3.7+, no sacrifice needed.

I took the time to verify that it works properly as-is.
A minimal patch was required but no feature was tampered with or broken in the process.

Also, there is room for adding features, like spawning requests per protocols (1.1, 2, and 3) could be interesting.
This PR is a "solid" proof of concept, if you want to, we can make this work/distributable.

Finally, I plan to land full support for multiplexed requests in HTTP/2 and HTTP/3 soon! Probably going to be useful here.
https://github.com/jawah/niquests