### PR TITLE
Add run_single_user to __all__ variable

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -42,6 +42,7 @@ __all__ = (
     "constant_throughput",
     "events",
     "LoadTestShape",
+    "run_single_user",
 )
 
 # Used for raising a DeprecationWarning if old Locust/HttpLocust is used


### PR DESCRIPTION
run_single_user method added to `__all__` variable.

In #1985 run_single_user function was created and was added to top `__init__.py` file in https://github.com/locustio/locust/commit/68f1af3558cf87aa2d99de0daa741780cbeb9e66.
However, it wasn't added to `__all__`.

run_single_user is part of official API (https://docs.locust.io/en/stable/api.html#locust.debug.run_single_userl) and "from locust import run_single_user" statement is used in examples (e.g. [/examples/debugging.py](https://github.com/locustio/locust/blob/master/examples/debugging.py)).
Currently, many linters show warnings like "'run_single_user' is not declared in `__all__`" which may confuse people and make them think that they use Locust incorrectly.