### PR TITLE
Fix too long first wait time for constant_pacing (and constant_throughput)

### DIFF
--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Callable, Dict, List, Optional, final
 
+import time
 from gevent import GreenletExit, greenlet
 from gevent.pool import Group
 from urllib3 import PoolManager
@@ -119,6 +120,7 @@ class User(metaclass=UserMeta):
         self._greenlet: greenlet.Greenlet = None
         self._group: Group
         self._taskset_instance: TaskSet = None
+        self._cp_last_run = time.time()  # used by constant_pacing wait_time
 
     def on_start(self):
         """

--- a/locust/user/wait_time.py
+++ b/locust/user/wait_time.py
@@ -47,15 +47,12 @@ def constant_pacing(wait_time):
     """
 
     def wait_time_func(self):
-        if not hasattr(self, "_cp_last_run"):
-            self._cp_last_wait_time = wait_time
-            self._cp_last_run = time()
-            return wait_time
-        else:
-            run_time = time() - self._cp_last_run - self._cp_last_wait_time
-            self._cp_last_wait_time = max(0, wait_time - run_time)
-            self._cp_last_run = time()
-            return self._cp_last_wait_time
+        if not hasattr(self, "_cp_last_wait_time"):
+            self._cp_last_wait_time = 0
+        run_time = time() - self._cp_last_run - self._cp_last_wait_time
+        self._cp_last_wait_time = max(0, wait_time - run_time)
+        self._cp_last_run = time()
+        return self._cp_last_wait_time
 
     return wait_time_func
 


### PR DESCRIPTION
It incorrectly assumed the first iteration was instantaneous (because it had no way of knowing when the first iteration started), thus making the first sleep longer than it should be.

Fixes #2427