### PR TITLE
Refactor - replace list with deque: TaskSet._task_queue & WindowsKeyPoller.captured_chars

### DIFF
--- a/locust/input_events.py
+++ b/locust/input_events.py
@@ -1,3 +1,4 @@
+import collections
 from typing import Dict, Callable
 
 import gevent
@@ -50,7 +51,7 @@ class WindowsKeyPoller:
             self.read_handle.SetConsoleMode(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT)
             self.cur_event_length = 0
             self.cur_keys_length = 0
-            self.captured_chars = []
+            self.captured_chars = collections.deque()
         else:
             raise InitError("Terminal was not a tty. Keyboard input disabled")
 
@@ -59,7 +60,7 @@ class WindowsKeyPoller:
 
     def poll(self):
         if self.captured_chars:
-            return self.captured_chars.pop(0)
+            return self.captured_chars.popleft()
 
         events_peek = self.read_handle.PeekConsoleInput(10000)
 
@@ -76,7 +77,7 @@ class WindowsKeyPoller:
             self.cur_event_length = len(events_peek)
 
         if self.captured_chars:
-            return self.captured_chars.pop(0)
+            return self.captured_chars.popleft()
         else:
             return None
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import random
 import time
@@ -2835,7 +2836,7 @@ class TestMasterRunner(LocustRunnerTestCase):
         class MyTaskSet(TaskSet):
             def __init__(self, *a, **kw):
                 super().__init__(*a, **kw)
-                self._task_queue = [self.will_error, self.will_stop]
+                self._task_queue = collections.deque((self.will_error, self.will_stop))
 
             @task(1)
             def will_error(self):

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import collections
 import logging
 import random
 import traceback
@@ -6,6 +7,7 @@ from time import time
 from typing import (
     TYPE_CHECKING,
     Callable,
+    Deque,
     List,
     TypeVar,
     Optional,
@@ -281,7 +283,7 @@ class TaskSet(metaclass=TaskSetMeta):
     _parent: "User"
 
     def __init__(self, parent: "User") -> None:
-        self._task_queue: List[Callable] = []
+        self._task_queue: Deque[Callable] = collections.deque()
         self._time_start = time()
 
         if isinstance(parent, TaskSet):
@@ -371,7 +373,7 @@ class TaskSet(metaclass=TaskSetMeta):
                     raise
 
     def execute_next_task(self):
-        self.execute_task(self._task_queue.pop(0))
+        self.execute_task(self._task_queue.popleft())
 
     def execute_task(self, task):
         # check if the function is a method bound to the current locust, and if so, don't pass self as first argument
@@ -393,7 +395,7 @@ class TaskSet(metaclass=TaskSetMeta):
         :param first: Optional keyword argument. If True, the task will be put first in the queue.
         """
         if first:
-            self._task_queue.insert(0, task_callable)
+            self._task_queue.appendleft(task_callable)
         else:
             self._task_queue.append(task_callable)
 


### PR DESCRIPTION
TaskSet._task_queue & WindowsKeyPoller.captured_chars use methods responsible for removing/appending elements at beginning & end.
collections.deque performs those in constant time in contrast with list (linear time for appending/removing at beginning).