### PR TITLE
FastHttpUser: encoding return str when response is empty

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -463,7 +463,7 @@ class FastResponse(CompatResponse):
             if self.headers is None:
                 self.encoding = "utf-8"
             else:
-                self.encoding = get_encoding_from_headers(self.headers)
+                self.encoding = get_encoding_from_headers(self.headers) or ""
         return str(self.content, self.encoding, errors="replace")
 
     @property


### PR DESCRIPTION
self.encoding requires a str value. request util can return None which throws 
`TypeError: str() argument 'encoding' must be str, not None`

fixes #2450