### PR TITLE
Add terraform variables

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -27,6 +27,6 @@ module "loadtest" {
 
     subnet_id = data.aws_subnet.current.id
     locust_plan_filename = var.locust_plan_filename
-    ssh_export_pem = false
+    ssh_export_pem = var.ssh_export_pem
 
 }

--- a/examples/terraform/aws/provisioner.tf
+++ b/examples/terraform/aws/provisioner.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-    region = "us-east-1"
+    region = var.aws_region
 }

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -1,3 +1,9 @@
+variable "aws_region" {
+    type = string
+    default = "us-east-1"
+    description = "AWS Region"
+}
+
 variable "node_size" {
     description = "Size of total nodes"
     default = 2
@@ -14,4 +20,10 @@ variable "locust_plan_filename" {
 variable "subnet_name" {
     default = "subnet-prd-a"
     description = "Subnet name"
+}
+
+variable "ssh_export_pem" {
+ description = "Export private ssh key"
+ type        = bool
+ default     = false
 }


### PR DESCRIPTION
Hi,
This is a very small detail, but I think it makes the Terraform module a bit easier to use.
In Terraform, if there is a setting which the typical user should probably adjust, or consider adjusting, the place to put that is `variables.tf`. 
By reviewing `variables.tf` you see a list of configurations to modify.
In this case, `ssh_export_pem` and `aws_region`. I needed to modify them as likely most users would also.