### PR TITLE
Ensure to wait a second before next `tick()`

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -345,7 +345,6 @@ class Runner:
                 self.shape_last_tick = None
                 return
             elif self.shape_last_tick != current_tick:
-                shape_adjustment_start = time.time()
                 if len(current_tick) == 2:
                     user_count, spawn_rate = current_tick  # type: ignore
                     user_classes = None

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -348,7 +348,7 @@ class Runner:
             else:
                 shape_adjustment_start = time.time()
                 if len(current_tick) == 2:
-                    current_tick = (*current_tick, None)
+                    current_tick = (*current_tick, None)  # type: ignore
                 user_count, spawn_rate, user_classes = current_tick  # type: ignore
                 logger.info("Shape test updating to %d users at %.2f spawn rate" % (user_count, spawn_rate))
                 # TODO: This `self.start()` call is blocking until the ramp-up is completed. This can leads

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -347,9 +347,7 @@ class Runner:
                 gevent.sleep(1)
             else:
                 shape_adjustment_start = time.time()
-                if len(current_tick) == 2:
-                    current_tick = (*current_tick, None)  # type: ignore
-                user_count, spawn_rate, user_classes = current_tick  # type: ignore
+                user_count, spawn_rate, user_classes = current_tick if len(current_tick) == 3 else (*current_tick, None)  # type: ignore
                 logger.info("Shape test updating to %d users at %.2f spawn rate" % (user_count, spawn_rate))
                 # TODO: This `self.start()` call is blocking until the ramp-up is completed. This can leads
                 #       to unexpected behaviours such as the one in the following example:
@@ -367,8 +365,7 @@ class Runner:
                 self.start(user_count=user_count, spawn_rate=spawn_rate, user_classes=user_classes)
                 self.shape_last_tick = current_tick
                 shape_adjustment_time_ms = time.time() - shape_adjustment_start
-                if shape_adjustment_time_ms < 1:
-                    gevent.sleep(1 - shape_adjustment_time_ms)
+                gevent.sleep(max(1 - shape_adjustment_time_ms, 0))
 
     def stop(self) -> None:
         """

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -346,11 +346,10 @@ class Runner:
             elif self.shape_last_tick == current_tick:
                 gevent.sleep(1)
             else:
+                shape_adjustment_start = time.time()
                 if len(current_tick) == 2:
-                    user_count, spawn_rate = current_tick  # type: ignore
-                    user_classes = None
-                else:
-                    user_count, spawn_rate, user_classes = current_tick  # type: ignore
+                    current_tick = (*current_tick, None)
+                user_count, spawn_rate, user_classes = current_tick  # type: ignore
                 logger.info("Shape test updating to %d users at %.2f spawn rate" % (user_count, spawn_rate))
                 # TODO: This `self.start()` call is blocking until the ramp-up is completed. This can leads
                 #       to unexpected behaviours such as the one in the following example:
@@ -367,6 +366,9 @@ class Runner:
                 #        of each load test shape stage.
                 self.start(user_count=user_count, spawn_rate=spawn_rate, user_classes=user_classes)
                 self.shape_last_tick = current_tick
+                shape_adjustment_time_ms = time.time() - shape_adjustment_start
+                if shape_adjustment_time_ms < 1:
+                    gevent.sleep(1 - shape_adjustment_time_ms)
 
     def stop(self) -> None:
         """


### PR DESCRIPTION
When developing a custom `TestShape`, a developer needs to implement `tick()` method, that manages `Users` spawning. As mentioned in the [official documentation](https://docs.locust.io/en/stable/custom-load-shape.html#custom-load-shapes):

> Locust will call the tick() method approximately once per second.

Therefore, a developer may design a `TestShape` with a strong assumption that the number of `Users` will be adjusted with ~1 second interval. Unfortunately, the interval is indeed kept only when no adjustment in `Users` number is made - hence it seems useless, as any interval is meaningful only during some changes. Here's an example of logs from Locust master when a custom `TestShape` was implemented and  the `tick()` method is clearly triggered too often:

<img width="1276" alt="locust_logs" src="https://github.com/locustio/locust/assets/16019477/d639dcb2-42ab-44dc-995c-692611151228">

the timestamps of log messages show, that 20 `Users` were spawned within ~6 seconds, while the spawn rate is set to `1.0`. In fact I was able to achieve much bigger discrepancies between expected/declared and actual number of users.

In this PR I provide a small adjustment in `Runner`'s code to ensure the ~1 second interval is maintained. Also a small code optimization in handling the `current_tick` Tuple was added to keep the file length almost unchanged :) 