### PR TITLE
Add --processes parameter to automatically fork subprocesses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - { name: "flake8", python: "3.11", os: ubuntu-latest, tox: "flake8" }
           - { name: "black", python: "3.11", os: ubuntu-latest, tox: "black" }
           - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy" }
+          - { name: "fast_integration_test", python: "3.12", os: ubuntu-latest, tox: fast_integration_test }
           - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312 }
           - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
           - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          #- {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
           #- {name: Windows, python: '3.9', os: windows-latest, tox: py39}
           #- {name: Mac, python: '3.9', os: macos-latest, tox: py39}
           - { name: "flake8", python: "3.11", os: ubuntu-latest, tox: "flake8" }
           - { name: "black", python: "3.11", os: ubuntu-latest, tox: "black" }
           - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy" }
-          - { name: "fast_integration_test", python: "3.12", os: ubuntu-latest, tox: fast_integration_test }
+          # run some integration tests and abort immediately if they fail, for faster feedback
+          - { name: "fail_fast_test_main", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main }
           - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312 }
           - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
           - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -424,6 +424,12 @@ Only the LOCUSTFILE (-f option) needs to be specified when starting a Worker, si
         env_var="LOCUST_MODE_WORKER",
     )
     worker_group.add_argument(
+        "--processes",
+        type=int,
+        help="Number of times to fork the locust process, to enable using multiple CPU cores. Use -1 to launch one process per CPU core in your system. Combine with --worker flag or let it automatically set --worker and --master flags for an all-in-one-solution. Not available on Windows. Experimental.",
+        env_var="LOCUST_PROCESSES",
+    )
+    worker_group.add_argument(
         "--slave",
         action="store_true",
         help=configargparse.SUPPRESS,

--- a/locust/main.py
+++ b/locust/main.py
@@ -211,7 +211,7 @@ def main():
                 # nothing more to do, just wait for the children to exit
                 for child_pid in children:
                     _, child_status = os.waitpid(child_pid, 0)
-                    if sys.version_info >= (3, 8):  # dammit python 3.8...
+                    if sys.version_info > (3, 8):  # dammit python 3.8...
                         child_exit_code = os.waitstatus_to_exitcode(child_status)
                         exit_code = max(exit_code, child_exit_code)
                 sys.exit(exit_code)

--- a/locust/main.py
+++ b/locust/main.py
@@ -211,9 +211,12 @@ def main():
                 # nothing more to do, just wait for the children to exit
                 for child_pid in children:
                     _, child_status = os.waitpid(child_pid, 0)
-                    if sys.version_info > (3, 8):  # dammit python 3.8...
-                        child_exit_code = os.waitstatus_to_exitcode(child_status)
-                        exit_code = max(exit_code, child_exit_code)
+                    try:
+                        if sys.version_info > (3, 8):
+                            child_exit_code = os.waitstatus_to_exitcode(child_status)
+                            exit_code = max(exit_code, child_exit_code)
+                    except AttributeError:
+                        pass  # dammit python 3.8...
                 sys.exit(exit_code)
             else:
                 options.master = True
@@ -230,9 +233,12 @@ def main():
                     logging.debug("waiting for children to terminate")
                     for child_pid in children:
                         _, child_status = os.waitpid(child_pid, 0)
-                        if sys.version_info > (3, 8):  # dammit python 3.8...
-                            child_exit_code = os.waitstatus_to_exitcode(child_status)
-                            exit_code = max(exit_code, child_exit_code)
+                        try:
+                            if sys.version_info > (3, 8):
+                                child_exit_code = os.waitstatus_to_exitcode(child_status)
+                                exit_code = max(exit_code, child_exit_code)
+                        except AttributeError:
+                            pass  # dammit python 3.8...
                     if exit_code > 1:
                         logging.error(f"bad response code from worker children: {exit_code}")
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -38,8 +38,6 @@ except ModuleNotFoundError:
 
 version = locust.__version__
 
-first_call = True
-
 # Options to ignore when using a custom shape class without `use_common_options=True`
 # See: https://docs.locust.io/en/stable/custom-load-shape.html#use-common-options
 COMMON_OPTIONS = {
@@ -191,10 +189,7 @@ def main():
             if options.worker:
                 # ignore the first sigint in parent, and wait for the children to handle sigint
                 def sigint_handler(_signal, _frame):
-                    global first_call
-                    if first_call:
-                        first_call = False
-                    else:
+                    if getattr(sigint_handler, "has_run"):
                         # if parent gets repeated sigint, we kill the children hard
                         for child_pid in children:
                             try:
@@ -205,6 +200,7 @@ def main():
                             except Exception:
                                 logging.error(traceback.format_exc())
                         sys.exit(1)
+                    sigint_handler.has_run = True
 
                 signal.signal(signal.SIGINT, sigint_handler)
                 exit_code = 0

--- a/locust/main.py
+++ b/locust/main.py
@@ -188,24 +188,24 @@ def main():
                 break
         else:
             # we're in the parent process
-            def sigint_handler(_signal, _frame):
-                # ignore the first sigint in parent, and wait for the children to handle sigint
-                global first_call
-                if first_call:
-                    first_call = False
-                else:
-                    # if parent gets repeated sigint, we kill the children hard
-                    for child_pid in children:
-                        try:
-                            logging.debug(f"Sending SIGKILL to child with pid {child_pid}")
-                            os.kill(child_pid, signal.SIGKILL)
-                        except ProcessLookupError:
-                            pass  # process already dead
-                        except Exception:
-                            logging.error(traceback.format_exc())
-                    sys.exit(1)
-
             if options.worker:
+                # ignore the first sigint in parent, and wait for the children to handle sigint
+                def sigint_handler(_signal, _frame):
+                    global first_call
+                    if first_call:
+                        first_call = False
+                    else:
+                        # if parent gets repeated sigint, we kill the children hard
+                        for child_pid in children:
+                            try:
+                                logging.debug(f"Sending SIGKILL to child with pid {child_pid}")
+                                os.kill(child_pid, signal.SIGKILL)
+                            except ProcessLookupError:
+                                pass  # process already dead
+                            except Exception:
+                                logging.error(traceback.format_exc())
+                        sys.exit(1)
+
                 signal.signal(signal.SIGINT, sigint_handler)
                 exit_code = 0
                 # nothing more to do, just wait for the children to exit

--- a/locust/main.py
+++ b/locust/main.py
@@ -230,8 +230,9 @@ def main():
                     logging.debug("waiting for children to terminate")
                     for child_pid in children:
                         _, child_status = os.waitpid(child_pid, 0)
-                        child_exit_code = os.waitstatus_to_exitcode(child_status)
-                        exit_code = max(exit_code, child_exit_code)
+                        if sys.version_info > (3, 8):  # dammit python 3.8...
+                            child_exit_code = os.waitstatus_to_exitcode(child_status)
+                            exit_code = max(exit_code, child_exit_code)
                     if exit_code > 1:
                         logging.error(f"bad response code from worker children: {exit_code}")
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -211,8 +211,9 @@ def main():
                 # nothing more to do, just wait for the children to exit
                 for child_pid in children:
                     _, child_status = os.waitpid(child_pid, 0)
-                    child_exit_code = os.waitstatus_to_exitcode(child_status)
-                    exit_code = max(exit_code, child_exit_code)
+                    if sys.version_info >= (3, 8):  # dammit python 3.8...
+                        child_exit_code = os.waitstatus_to_exitcode(child_status)
+                        exit_code = max(exit_code, child_exit_code)
                 sys.exit(exit_code)
             else:
                 options.master = True

--- a/locust/main.py
+++ b/locust/main.py
@@ -28,6 +28,7 @@ from .exception import AuthCredentialsError
 from .input_events import input_listener
 from .html import get_html_report
 from .util.load_locustfile import load_locustfile
+import traceback
 
 try:
     # import locust_plugins if it is installed, to allow it to register custom arguments etc
@@ -37,6 +38,7 @@ except ModuleNotFoundError:
 
 version = locust.__version__
 
+first_call = True
 
 # Options to ignore when using a custom shape class without `use_common_options=True`
 # See: https://docs.locust.io/en/stable/custom-load-shape.html#use-common-options
@@ -161,6 +163,78 @@ def main():
         else:
             sys.stderr.write("Invalid --loglevel. Valid values are: DEBUG/INFO/WARNING/ERROR/CRITICAL\n")
             sys.exit(1)
+
+    children = []
+
+    if options.processes:
+        if os.name == "nt":
+            raise Exception("--processes is not supported in Windows (except in WSL)")
+        if options.processes == -1:
+            options.processes = os.cpu_count()
+            assert options.processes, "couldnt detect number of cpus!?"
+        elif options.processes < -1:
+            raise Exception(f"invalid processes count {options.processes}")
+        for _ in range(options.processes):
+            child_pid = gevent.fork()
+            if child_pid:
+                children.append(child_pid)
+                logging.debug(f"Started child worker with pid #{child_pid}")
+            else:
+                # child is always a worker, even when it wasnt set on command line
+                options.worker = True
+                # remove options that dont make sense on worker
+                options.run_time = None
+                options.autostart = None
+                break
+        else:
+            # we're in the parent process
+            def sigint_handler(_signal, _frame):
+                # ignore the first sigint in parent, and wait for the children to handle sigint
+                global first_call
+                if first_call:
+                    first_call = False
+                else:
+                    # if parent gets repeated sigint, we kill the children hard
+                    for child_pid in children:
+                        try:
+                            logging.debug(f"Sending SIGKILL to child with pid {child_pid}")
+                            os.kill(child_pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass  # process already dead
+                        except:
+                            logging.error(traceback.format_exc())
+                    sys.exit(1)
+
+            if options.worker:
+                signal.signal(signal.SIGINT, sigint_handler)
+                exit_code = 0
+                # nothing more to do, just wait for the children to exit
+                for child_pid in children:
+                    _, child_status = os.waitpid(child_pid, 0)
+                    child_exit_code = os.waitstatus_to_exitcode(child_status)
+                    exit_code = max(exit_code, child_exit_code)
+                sys.exit(exit_code)
+            else:
+                options.master = True
+                options.expect_workers = options.processes
+
+                def kill_workers(children):
+                    exit_code = 0
+                    logging.debug("Sending SIGINT to children")
+                    for child_pid in children:
+                        try:
+                            os.kill(child_pid, signal.SIGINT)
+                        except ProcessLookupError:
+                            pass  # never mind, process was already dead
+                    logging.debug("waiting for children to terminate")
+                    for child_pid in children:
+                        _, child_status = os.waitpid(child_pid, 0)
+                        child_exit_code = os.waitstatus_to_exitcode(child_status)
+                        exit_code = max(exit_code, child_exit_code)
+                    if exit_code > 1:
+                        logging.error(f"bad response code from worker children: {exit_code}")
+
+                atexit.register(kill_workers, children)
 
     logger = logging.getLogger(__name__)
     greenlet_exception_handler = greenlet_exception_logger(logger)
@@ -486,7 +560,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
             print_stats(runner.stats, current=False)
             print_percentile_stats(runner.stats)
             print_error_report(runner.stats)
-
         environment.events.quit.fire(exit_code=code)
         sys.exit(code)
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -189,7 +189,7 @@ def main():
             if options.worker:
                 # ignore the first sigint in parent, and wait for the children to handle sigint
                 def sigint_handler(_signal, _frame):
-                    if getattr(sigint_handler, "has_run"):
+                    if getattr(sigint_handler, "has_run", False):
                         # if parent gets repeated sigint, we kill the children hard
                         for child_pid in children:
                             try:

--- a/locust/main.py
+++ b/locust/main.py
@@ -201,7 +201,7 @@ def main():
                             os.kill(child_pid, signal.SIGKILL)
                         except ProcessLookupError:
                             pass  # process already dead
-                        except:
+                        except Exception:
                             logging.error(traceback.format_exc())
                     sys.exit(1)
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1360,7 +1360,11 @@ class WorkerRunner(DistributedRunner):
     def connect_to_master(self):
         self.retry += 1
         self.client.send(Message("client_ready", __version__, self.client_id))
-        success = self.connection_event.wait(timeout=CONNECT_TIMEOUT)
+        try:
+            success = self.connection_event.wait(timeout=CONNECT_TIMEOUT)
+        except KeyboardInterrupt:
+            # dont complain about getting CTRL-C
+            sys.exit(1)
         if not success:
             if self.retry < 3:
                 logger.debug(

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1832,6 +1832,9 @@ class AnyUser(HttpUser):
             self.assertIn("Shutting down (exit code 0)", master_stderr)
 
     def test_processes_ctrl_c(self):
+        # this test case might take >10s
+        self.timeout.cancel()
+
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
                 f"locust -f {mocked.file_path} --processes 4 --headless",
@@ -1846,7 +1849,7 @@ class AnyUser(HttpUser):
                 _, stderr = proc.communicate(timeout=6)
             except Exception:
                 proc.kill()
-                _, stderr = proc.communicate()
+                _, stderr = proc.communicate(timeout=10)
                 assert False, f"locust process never finished: {stderr}"
             self.assertNotIn("Traceback", stderr)
             self.assertIn("(index 3) reported as ready", stderr)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1843,7 +1843,7 @@ class AnyUser(HttpUser):
             gevent.sleep(3)
             proc.send_signal(signal.SIGINT)
             try:
-                _, stderr = proc.communicate(timeout=3)
+                _, stderr = proc.communicate(timeout=6)
             except Exception:
                 proc.kill()
                 _, stderr = proc.communicate()

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1837,7 +1837,7 @@ class AnyUser(HttpUser):
 
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
-                f"locust -f {mocked.file_path} --processes 4 --headless",
+                f"locust -f {mocked.file_path} --processes 4 --headless -L DEBUG",
                 shell=True,
                 stdout=PIPE,
                 stderr=PIPE,
@@ -1846,7 +1846,7 @@ class AnyUser(HttpUser):
             gevent.sleep(3)
             proc.send_signal(signal.SIGINT)
             try:
-                _, stderr = proc.communicate(timeout=6)
+                _, stderr = proc.communicate(timeout=10)
             except Exception:
                 proc.kill()
                 _, stderr = proc.communicate(timeout=10)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1837,8 +1837,16 @@ class AnyUser(HttpUser):
 
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
-                f"locust -f {mocked.file_path} --processes 4 --headless -L DEBUG",
-                shell=True,
+                [
+                    "locust",
+                    "-f",
+                    mocked.file_path,
+                    "--processes",
+                    "4",
+                    "--headless",
+                    "-L",
+                    "DEBUG",
+                ],
                 stdout=PIPE,
                 stderr=PIPE,
                 text=True,

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1761,7 +1761,7 @@ class AnyUser(HttpUser):
             )
             try:
                 _, stderr = proc.communicate(timeout=9)
-            except:
+            except Exception:
                 proc.kill()
                 assert False, f"locust process never finished: {command}"
             self.assertNotIn("Traceback", stderr)
@@ -1780,7 +1780,7 @@ class AnyUser(HttpUser):
             )
             try:
                 _, stderr = proc.communicate(timeout=9)
-            except:
+            except Exception:
                 proc.kill()
                 assert False, f"locust process never finished: {command}"
             self.assertNotIn("Traceback", stderr)
@@ -1807,17 +1807,19 @@ class AnyUser(HttpUser):
 
             try:
                 _, worker_stderr = worker_parent_proc.communicate(timeout=9)
-            except:
+            except Exception:
                 master_proc.kill()
                 worker_parent_proc.kill()
                 _, worker_stderr = worker_parent_proc.communicate()
+                _, master_stderr = master_proc.communicate()
                 assert False, f"worker never finished: {worker_stderr}"
 
             try:
                 _, master_stderr = master_proc.communicate(timeout=9)
-            except:
+            except Exception:
                 master_proc.kill()
                 worker_parent_proc.kill()
+                _, worker_stderr = worker_parent_proc.communicate()
                 _, master_stderr = master_proc.communicate()
                 assert False, f"master never finished: {master_stderr}"
 
@@ -1842,7 +1844,7 @@ class AnyUser(HttpUser):
             proc.send_signal(signal.SIGINT)
             try:
                 _, stderr = proc.communicate(timeout=3)
-            except:
+            except Exception:
                 proc.kill()
                 _, stderr = proc.communicate()
                 assert False, f"locust process never finished: {stderr}"

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1832,9 +1832,6 @@ class AnyUser(HttpUser):
             self.assertIn("Shutting down (exit code 0)", master_stderr)
 
     def test_processes_ctrl_c(self):
-        # this test case might take >10s
-        self.timeout.cancel()
-
         with mock_locustfile() as mocked:
             proc = subprocess.Popen(
                 [
@@ -1854,10 +1851,10 @@ class AnyUser(HttpUser):
             gevent.sleep(3)
             proc.send_signal(signal.SIGINT)
             try:
-                _, stderr = proc.communicate(timeout=10)
+                _, stderr = proc.communicate(timeout=3)
             except Exception:
                 proc.kill()
-                _, stderr = proc.communicate(timeout=10)
+                _, stderr = proc.communicate()
                 assert False, f"locust process never finished: {stderr}"
             self.assertNotIn("Traceback", stderr)
             self.assertIn("(index 3) reported as ready", stderr)

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 [testenv:fast_integration_test]
 commands = 
     python3 -m pip install .
-    python3 -m unittest -ff locust/test/test_main.py DistributedIntegrationTests
+    python3 -m unittest -ff locust.test.test_main
 
 [testenv:black]
 deps = black==23.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     black
     mypy
     py{37,38,39,310,311,312}
+    fast_integration_test
 
 [flake8]
 extend-exclude = build,examples/issue_*.py,src/readthedocs-sphinx-search/
@@ -33,6 +34,9 @@ commands =
     ; grep -qm 1 'ZeroDivisionError: division by zero at.*Response was {"ar' {temp_dir}/out.txt
     ; bash -ec '! grep . {temp_dir}/err.txt' # should be empty
     bash -ec 'PYTHONUNBUFFERED=1 python3 examples/debugging_advanced.py | grep done'
+
+[testenv:fast_integration_test]
+commands = python3 -m unittest locust/test/test_main.py DistributedIntegrationTests
 
 [testenv:black]
 deps = black==23.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 [testenv:fast_integration_test]
 commands = 
     python3 -m pip install .
-    python3 -m unittest locust/test/test_main.py DistributedIntegrationTests
+    python3 -m unittest -ff locust/test/test_main.py DistributedIntegrationTests
 
 [testenv:black]
 deps = black==23.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,9 @@ commands =
     bash -ec 'PYTHONUNBUFFERED=1 python3 examples/debugging_advanced.py | grep done'
 
 [testenv:fast_integration_test]
-commands = python3 -m unittest locust/test/test_main.py DistributedIntegrationTests
+commands = 
+    python3 -m pip install .
+    python3 -m unittest locust/test/test_main.py DistributedIntegrationTests
 
 [testenv:black]
 deps = black==23.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     black
     mypy
     py{37,38,39,310,311,312}
-    fast_integration_test
+    fail_fast_test_main
 
 [flake8]
 extend-exclude = build,examples/issue_*.py,src/readthedocs-sphinx-search/
@@ -35,7 +35,7 @@ commands =
     ; bash -ec '! grep . {temp_dir}/err.txt' # should be empty
     bash -ec 'PYTHONUNBUFFERED=1 python3 examples/debugging_advanced.py | grep done'
 
-[testenv:fast_integration_test]
+[testenv:fail_fast_test_main]
 commands = 
     python3 -m pip install .
     python3 -m unittest -ff locust.test.test_main

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 [testenv:fail_fast_test_main]
 commands = 
     python3 -m pip install .
-    python3 -m unittest -ff locust.test.test_main
+    python3 -m unittest -f locust.test.test_main
 
 [testenv:black]
 deps = black==23.10.1


### PR DESCRIPTION
Use it to set the number of times to fork the locust process, to enable using multiple CPU cores. Use `-1` to launch one process per CPU core in your system. Combine with --worker flag or let it automatically set --worker and --master flags for an all-in-one-solution.

Consider it experimental for now, but it looks promising.