### PR TITLE
Update minimum version of various dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,15 @@ description = "Developer friendly load testing framework"
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "gevent >=20.12.1",
+    "gevent >=22.10.2",
     "flask >=2.0.0",
     "Werkzeug >=2.0.0",
     "requests >=2.23.0",
-    "msgpack >=0.6.2",
-    "pyzmq >=22.2.1, !=23.0.0",
-    "geventhttpclient >=2.0.2",
-    "ConfigArgParse >=1.7",
-    "psutil >=5.6.7",
+    "msgpack >=1.0.0",
+    "pyzmq >=25.0.0",
+    "geventhttpclient >=2.0.11",
+    "ConfigArgParse >=1.5.5",
+    "psutil >=5.9.1",
     "Flask-BasicAuth >=0.2.0",
     "Flask-Cors >=3.0.10",
     "roundrobin >=0.0.2",


### PR DESCRIPTION
While older versions of our dependencies *may* work, we dont really test them, and they could have security issues or bugs.

We dont require the very latest version of everything, to ensure compatibility with whatever other things you might want to use with locust.