### PR TITLE
Fix an edge case when no directory is part of csv-prefix

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -400,7 +400,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     if options.csv_prefix:
         base_csv_file = os.path.basename(options.csv_prefix)
         base_csv_dir = options.csv_prefix[: -len(base_csv_file)]
-        if not os.path.exists(base_csv_dir):
+        if not os.path.exists(base_csv_dir) and len(base_csv_dir) != 0:
             os.makedirs(base_csv_dir)
         stats_csv_writer = StatsCSVFileWriter(
             environment, stats.PERCENTILES_TO_REPORT, options.csv_prefix, options.stats_history_enabled


### PR DESCRIPTION
This would previously result in an error being raised

e.g.

```python
import os

os.path.exists('') # False
os.makedirs('') # FileNotFoundError: [Errno 2] No such file or directory: ''
```

my bad