### PR TITLE
FastResponse: Use utf-8 instead of empty string as default in response text encoding

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -463,7 +463,7 @@ class FastResponse(CompatResponse):
             if self.headers is None:
                 self.encoding = "utf-8"
             else:
-                self.encoding = get_encoding_from_headers(self.headers) or ""
+                self.encoding = get_encoding_from_headers(self.headers) or "utf-8"
         return str(self.content, self.encoding, errors="replace")
 
     @property


### PR DESCRIPTION
FastResponse: Use utf-8 instead of empty string as default in response text encoding, if no response headers or no response encoding are set in the headers. Having no headers already used `utf-8` and having response headers but no information on encoding in them used an empty string which always throws an error [str constructor](https://docs.python.org/3.9/library/stdtypes.html#str).