### PR TITLE
Apply patch for handling `InterruptTaskSet` exception

### DIFF
--- a/locust/test/test_interruptable_task.py
+++ b/locust/test/test_interruptable_task.py
@@ -1,0 +1,48 @@
+from collections import defaultdict
+from unittest import TestCase
+
+from locust import SequentialTaskSet, User, constant, task
+from locust.env import Environment
+from locust.exception import StopUser
+
+
+class InterruptableTaskSet(SequentialTaskSet):
+    counter: defaultdict[str, int] = defaultdict(int)
+
+    def on_start(self):
+        super().on_start()
+        self.counter["on_start"] += 1
+
+    @task
+    def t1(self):
+        self.counter["t1"] += 1
+        self.interrupt(reschedule=False)
+
+    @task
+    def t2(self):
+        self.counter["t2"] += 1
+
+    def on_stop(self):
+        super().on_stop()
+        self.counter["on_stop"] += 1
+        if self.counter["on_stop"] >= 2:
+            raise StopUser()
+
+
+class TestInterruptableTask(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        class InterruptableUser(User):
+            host = "127.0.0.1"
+            tasks = [InterruptableTaskSet]
+            wait_time = constant(0)
+
+        self.locust = InterruptableUser(Environment(catch_exceptions=True))
+
+    def test_interruptable_task(self):
+        self.locust.run()
+        self.assertEqual(InterruptableTaskSet.counter.get("on_start"), 2)
+        self.assertEqual(InterruptableTaskSet.counter.get("t1"), 2)
+        self.assertEqual(InterruptableTaskSet.counter.get("t2", 0), 0)
+        self.assertEqual(InterruptableTaskSet.counter.get("on_stop"), 2)

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -350,6 +350,8 @@ class TaskSet(metaclass=TaskSetMeta):
             except InterruptTaskSet as e:
                 try:
                     self.on_stop()
+                except (StopUser, GreenletExit):
+                    raise
                 except Exception:
                     logging.error("Uncaught exception in on_stop: \n%s", traceback.format_exc())
                 if e.reschedule:


### PR DESCRIPTION
The #2402 introduced change which wraps `on_stop` call around try/except block inside handling of `InterruptTaskSet` exception.

The initial implementation assumed that every exception shall be handled and logged, without any further consequences. 
This appeared to be a little bit too greedy. It allowed the execution to carry on. 

When running our unit tests we observed a situation where the execution falls into infinite loop. This was because our `on_stop` method implementation counted its invocation and was supposed to raise `StopUser` exception after reaching some arbitrarly chosen number.

We do believe that this behavior is inappropriate, as `StopUser` is supposed to always stop execution of current user.

We wanted to propose a solution for this issue presented in this Pull Request.

Attached unit test is a simple copy of our unit test. The purpose of this unit test is to verify whether interrupts in `SequentialTaskSet` truly reschedule the execution of whole taskset. If interrupt occurs before calling all tasks, tasks defined after the interrupt shall never be executed. This was verified by the counter in our test. In order to exit the loop, we deliberately raise `StopUser` in `on_stop` method.  