### PR TITLE
fix(typing): typing.DefaultDict in test_interruptable_task.py

### DIFF
--- a/locust/test/test_interruptable_task.py
+++ b/locust/test/test_interruptable_task.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from unittest import TestCase
+from typing import DefaultDict
 
 from locust import SequentialTaskSet, User, constant, task
 from locust.env import Environment
@@ -7,7 +8,7 @@ from locust.exception import StopUser
 
 
 class InterruptableTaskSet(SequentialTaskSet):
-    counter: defaultdict[str, int] = defaultdict(int)
+    counter: DefaultDict[str, int] = defaultdict(int)
 
     def on_start(self):
         super().on_start()


### PR DESCRIPTION
Fixing minor type hint issue introduced in #2486.
(collections.defaultdict support subscripting ([]) since version 3.9)