### PR TITLE
Add charset_normalizer dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "Flask-Cors >=3.0.10",
     "roundrobin >=0.0.2",
     "pywin32;platform_system=='Windows'",
+    "charset_normalizer >=3.3.0"
 ]
 classifiers = [
     "Topic :: Software Development :: Testing :: Traffic Generation",


### PR DESCRIPTION
A previous PR introduced charset_normalizer as a dep, but did not explicitly add it to the pyproject.toml file.

This causes a breaking change on import.

So this PR explicitly includes it.

Resolves #2505 