### PR TITLE
Fix useSwarmUi Test with Mock Timers

### DIFF
--- a/locust/webui/src/components/LineChart/LineChart.test.tsx
+++ b/locust/webui/src/components/LineChart/LineChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 
 import LineChart from 'components/LineChart/LineChart';
-import { getStatsResponseTransformed } from 'test/mocks/statsRequest.mock';
+import { statsResponseTransformed } from 'test/mocks/statsRequest.mock';
 import { renderWithProvider } from 'test/testUtils';
 import { ICharts } from 'types/ui.types';
 
@@ -18,7 +18,7 @@ describe('LineChart', () => {
   test('renders LineChart with charts and lines', () => {
     const { container } = renderWithProvider(
       <LineChart
-        charts={getStatsResponseTransformed().charts}
+        charts={statsResponseTransformed.charts}
         colors={mockChart.colors}
         lines={mockChart.lines}
         title={mockChart.title}

--- a/locust/webui/src/hooks/tests/useSwarmUi.test.tsx
+++ b/locust/webui/src/hooks/tests/useSwarmUi.test.tsx
@@ -9,9 +9,10 @@ import { swarmActions } from 'redux/slice/swarm.slice';
 import { TEST_BASE_API } from 'test/constants';
 import {
   ratiosResponseMock,
-  getStatsResponseTransformed,
+  statsResponseTransformed,
   statsResponseMock,
   exceptionsResponseMock,
+  mockDate,
 } from 'test/mocks/statsRequest.mock';
 import { swarmStateMock } from 'test/mocks/swarmState.mock';
 import { renderWithProvider } from 'test/testUtils';
@@ -35,10 +36,18 @@ describe('useSwarmUi', () => {
   afterAll(() => server.close());
 
   test('should fetch request stats, ratios, and exceptions and update UI accordingly', async () => {
-    const { store } = renderWithProvider(<MockHook />);
+    act(async () => {
+      vi.useFakeTimers();
 
-    await waitFor(() => {
-      expect(store.getState().ui).toEqual(getStatsResponseTransformed());
+      vi.setSystemTime(mockDate);
+
+      const { store } = renderWithProvider(<MockHook />);
+
+      await vi.runAllTimersAsync();
+
+      expect(store.getState().ui).toEqual(statsResponseTransformed);
+
+      vi.useRealTimers();
     });
   });
 

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -97,7 +97,9 @@ export const exceptionsResponseMock = {
   ],
 };
 
-export const getStatsResponseTransformed = () => ({
+export const mockDate = new Date(1970, 1);
+
+export const statsResponseTransformed = {
   totalRps: 1932.5,
   failRatio: 100,
   stats: [
@@ -151,7 +153,7 @@ export const getStatsResponseTransformed = () => ({
     currentFailPerSec: [1932.5],
     userCount: [1],
     totalAvgResponseTime: [0.41],
-    time: [new Date().toLocaleTimeString()],
+    time: [mockDate.toLocaleTimeString()],
   },
   ratios: {
     perClass: {
@@ -169,4 +171,4 @@ export const getStatsResponseTransformed = () => ({
   },
   userCount: 1,
   workers: undefined,
-});
+};


### PR DESCRIPTION
- Use mock timers in the `useSwarmUi` test to avoid false test failures
- Remove the dependency on `waitFor` in favor of `runAllTimersAsync`