### PR TITLE
Support IPv6 for zmq connection between master and worker

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -13,6 +13,7 @@ class BaseSocket:
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+        self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()
     def send(self, msg):

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -8,7 +8,7 @@ from locust.exception import RPCError, RPCSendError, RPCReceiveError
 class ZMQRPC_tests(LocustTestCase):
     def setUp(self):
         super().setUp()
-        self.server = zmqrpc.Server("127.0.0.1", 0)
+        self.server = zmqrpc.Server("*", 0)
         self.client = zmqrpc.Client("localhost", self.server.port, "identity")
 
     def tearDown(self):
@@ -19,8 +19,10 @@ class ZMQRPC_tests(LocustTestCase):
     def test_constructor(self):
         self.assertEqual(self.server.socket.getsockopt(zmq.TCP_KEEPALIVE), 1)
         self.assertEqual(self.server.socket.getsockopt(zmq.TCP_KEEPALIVE_IDLE), 30)
+        self.assertEqual(self.server.socket.getsockopt(zmq.IPV6), 1)
         self.assertEqual(self.client.socket.getsockopt(zmq.TCP_KEEPALIVE), 1)
         self.assertEqual(self.client.socket.getsockopt(zmq.TCP_KEEPALIVE_IDLE), 30)
+        self.assertEqual(self.client.socket.getsockopt(zmq.IPV6), 1)
 
     def test_client_send(self):
         self.client.send(Message("test", "message", "identity"))
@@ -40,15 +42,15 @@ class ZMQRPC_tests(LocustTestCase):
         self.assertEqual(msg.node_id, "identity")
 
     def test_client_retry(self):
-        server = zmqrpc.Server("127.0.0.1", 0)
+        server = zmqrpc.Server("*", 0)
         server.socket.close()
         with self.assertRaises(RPCError):
             server.recv_from_client()
 
     def test_rpc_error(self):
-        server = zmqrpc.Server("127.0.0.1", 0)
+        server = zmqrpc.Server("*", 0)
         with self.assertRaises(RPCError):
-            server = zmqrpc.Server("127.0.0.1", server.port)
+            server = zmqrpc.Server("*", server.port)
         server.close()
         with self.assertRaises(RPCSendError):
             server.send_to_client(Message("test", "message", "identity"))


### PR DESCRIPTION
This is a follow up for PR https://github.com/locustio/locust/pull/2290.

The solution is based on http://api.zeromq.org/4-2:zmq-setsockopt. 

> Set the IPv6 option for the socket. A value of 1 means IPv6 is enabled on the socket, while 0 means the socket will use only IPv4. When IPv6 is enabled the socket will connect to, or accept connections from, both IPv4 and IPv6 hosts.


The test is done with kind for 3 env, ipv4 only, ipv6 only and dual stack. With help of https://abdelrhmanhamouda.github.io/locust-k8s-operator/

Test result:
ipv4-only  before-patch(success) after-patch(success)
ipv6-only before-patch(fail, the worker can't connect with master) after-patch(success)
dualstack before-patch(success) after-patch(success)
