### PR TITLE
setting initial _cp_last_run on TaskSet in order to allow constant_pacing wait time strategy

### DIFF
--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -298,6 +298,7 @@ class TaskSet(metaclass=TaskSetMeta):
             self.max_wait = self.user.max_wait
         if not self.wait_function:
             self.wait_function = self.user.wait_function
+        self._cp_last_run = time()  # used by constant_pacing wait_time
 
     @property
     def user(self) -> "User":


### PR DESCRIPTION
fixes #2532 
---
Setting the initial value for `_cp_last_run` inside the `TaskSet` initializer.
Thus the attribute will not be missing when being called inside the `constant_pacing` wait time strategy.
Similar to what is happening in the `User` class.
