### PR TITLE
Update shape class' runner when Web UI picker is used

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -103,6 +103,10 @@ class Environment:
         self._validate_user_class_name_uniqueness()
         self._validate_shape_class_instance()
 
+    def update_shape_class_runner(self, runner: Optional[Runner] = None) -> None:
+        if self.shape_class:
+            self.shape_class.runner = runner or self.runner
+
     def _create_runner(
         self,
         runner_class: Type[RunnerType],
@@ -114,8 +118,7 @@ class Environment:
         self.runner = runner_class(self, *args, **kwargs)
 
         # Attach the runner to the shape class so that the shape class can access user count state
-        if self.shape_class:
-            self.shape_class.runner = self.runner
+        self.update_shape_class_runner()
 
         return self.runner
 

--- a/locust/env.py
+++ b/locust/env.py
@@ -103,10 +103,6 @@ class Environment:
         self._validate_user_class_name_uniqueness()
         self._validate_shape_class_instance()
 
-    def update_shape_class_runner(self, runner: Optional[Runner] = None) -> None:
-        if self.shape_class:
-            self.shape_class.runner = runner or self.runner
-
     def _create_runner(
         self,
         runner_class: Type[RunnerType],
@@ -118,7 +114,8 @@ class Environment:
         self.runner = runner_class(self, *args, **kwargs)
 
         # Attach the runner to the shape class so that the shape class can access user count state
-        self.update_shape_class_runner()
+        if self.shape_class:
+            self.shape_class.runner = self.runner
 
         return self.runner
 

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -14,7 +14,7 @@ import gevent
 import requests
 from pyquery import PyQuery as pq
 import locust
-from locust import User, constant, LoadTestShape
+from locust import constant, LoadTestShape
 from locust.argument_parser import get_parser, parse_options
 from locust.user import User, task
 from locust.env import Environment

--- a/locust/web.py
+++ b/locust/web.py
@@ -634,7 +634,7 @@ class WebUI:
 
         # Validating ShapeClass
         self.environment.shape_class = shape_class
-        self.environment.update_shape_class_runner()
+        self.environment.shape_class.runner = self.environment.runner
         self.environment._validate_shape_class_instance()
 
     def _update_user_classes(self, user_classes):

--- a/locust/web.py
+++ b/locust/web.py
@@ -629,12 +629,12 @@ class WebUI:
     def _update_shape_class(self, shape_class_name):
         if shape_class_name:
             shape_class = self.environment.available_shape_classes[shape_class_name]
+            shape_class.runner = self.environment.runner
         else:
             shape_class = None
 
         # Validating ShapeClass
         self.environment.shape_class = shape_class
-        self.environment.shape_class.runner = self.environment.runner
         self.environment._validate_shape_class_instance()
 
     def _update_user_classes(self, user_classes):

--- a/locust/web.py
+++ b/locust/web.py
@@ -634,6 +634,7 @@ class WebUI:
 
         # Validating ShapeClass
         self.environment.shape_class = shape_class
+        self.environment.update_shape_class_runner()
         self.environment._validate_shape_class_instance()
 
     def _update_user_classes(self, user_classes):


### PR DESCRIPTION
a shape class' `.runner` member is set by `_create_runner` method of `Environment` class. However, when the UI picker is used, the `shape_class` member of an `Environment` instance is not initialized yet, hence, there's no `Runner` assignment on initialization. Therefore, if you'd like to refer to `self.runner` in your custom test shape (for instance to get the number of users running), you receive an error saying that `self.runner` is `None`. 

Hence, I added the shape class `runner` initialization also when the shape class is selected with UI picker.