### PR TITLE
FIX - HTML reports not saved after run-time limit reached in headless mode

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -482,6 +482,8 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
             else:
                 logger.info("--autoquit not specified, leaving web ui running indefinitely")
         else:  # --headless run
+            if options.html_file:
+                save_html_report(options.modern_ui)
             logger.info("--run-time limit reached, shutting down")
             runner.quit()
 


### PR DESCRIPTION
I had an issue with no reports generated after the tests were done in headless mode (--headless) AND (--run-time) limit was set up.
I was running this in a gitlab pipeline along with my tests (wanted the report as an .html artifact) and had this listener set up:
``` 
   @events.test_stop.add_listener
    def on_test_stop(environment):
        print("tests finished - quitting...")
        os._exit(0) #needed this to stop the pipeline completely...to exit locust
```
...after the run time limit was reached, the listener was called, but reports were not generated...
now it's working with this little fix (before it did not do the html report part):
```
[2024-01-11 12:37:54,831] mariaanko/INFO/locust.main: writing html report to file: soak-report.html
[2024-01-11 12:37:55,169] mariaanko/INFO/locust.main: --run-time limit reached, shutting down
tests finished - quitting...
```
**this may be a really stupid fix, but please take this issue into consideration, and if possible please try to do another fix...**

