### PR TITLE
Fix mypy configuration & upgrade typing

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,5 @@
 6ec972f4dbb880bf0c7a11809e6c1ba194c9784c
 # upgrade code style to use f-strings using flynt
 313b80f27f525441c449593a3aeaf38389f63c13
+# upgrade typing annotations using fix-future-annotations
+b5324820b299b1fe7da0608f0cc8ec47f58b1e40

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import platform
 import sys
 import textwrap
-from typing import Dict, List, NamedTuple, Optional, Any
+from typing import NamedTuple, Any
 import configargparse
 
 import locust
@@ -38,11 +40,11 @@ class LocustArgumentParser(configargparse.ArgumentParser):
         return action
 
     @property
-    def args_included_in_web_ui(self) -> Dict[str, configargparse.Action]:
+    def args_included_in_web_ui(self) -> dict[str, configargparse.Action]:
         return {a.dest: a for a in self._actions if hasattr(a, "include_in_web_ui") and a.include_in_web_ui}
 
     @property
-    def secret_args_included_in_web_ui(self) -> Dict[str, configargparse.Action]:
+    def secret_args_included_in_web_ui(self) -> dict[str, configargparse.Action]:
         return {
             a.dest: a
             for a in self._actions
@@ -91,7 +93,7 @@ def find_locustfile(locustfile):
     # Implicit 'return None' if nothing was found
 
 
-def find_locustfiles(locustfiles: List[str], is_directory: bool) -> List[str]:
+def find_locustfiles(locustfiles: list[str], is_directory: bool) -> list[str]:
     """
     Returns a list of relative file paths for the Locustfile Picker. If is_directory is True,
     locustfiles is expected to have a single index which is a directory that will be searched for
@@ -176,7 +178,7 @@ See documentation for more details, including how to set options using a file or
     return parser
 
 
-def parse_locustfile_option(args=None) -> List[str]:
+def parse_locustfile_option(args=None) -> list[str]:
     """
     Construct a command line parser that is only used to parse the -f argument so that we can
     import the test scripts in case any of them adds additional command line arguments to the
@@ -667,10 +669,10 @@ class UIExtraArgOptions(NamedTuple):
     default_value: str
     is_secret: bool
     help_text: str
-    choices: Optional[List[str]] = None
+    choices: list[str] | None = None
 
 
-def ui_extra_args_dict(args=None) -> Dict[str, Dict[str, Any]]:
+def ui_extra_args_dict(args=None) -> dict[str, dict[str, Any]]:
     """Get all the UI visible arguments"""
     locust_args = default_args_dict()
 
@@ -691,7 +693,7 @@ def ui_extra_args_dict(args=None) -> Dict[str, Dict[str, Any]]:
     return extra_args
 
 
-def locustfile_is_directory(locustfiles: List[str]) -> bool:
+def locustfile_is_directory(locustfiles: list[str]) -> bool:
     """
     If a user passes in a locustfile without a file extension and there is a directory with the same name,
     this function defaults to using the file and will raise a warning.

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -323,5 +323,5 @@ def _failure(self):
     )
 
 
-Response.success = _success
-Response.failure = _failure
+Response.success = _success  # type: ignore[attr-defined]
+Response.failure = _failure  # type: ignore[attr-defined]

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import re
 import time
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -48,7 +48,7 @@ class HttpSession(requests.Session):
                            and then mark it as successful even if the response code was not (i.e 500 or 404).
     """
 
-    def __init__(self, base_url, request_event, user, *args, pool_manager: Optional[PoolManager] = None, **kwargs):
+    def __init__(self, base_url, request_event, user, *args, pool_manager: PoolManager | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.base_url = base_url
@@ -57,7 +57,7 @@ class HttpSession(requests.Session):
 
         # User can group name, or use the group context manager to gather performance statistics under a specific name
         # This is an alternative to passing in the "name" parameter to the requests function
-        self.request_name: Optional[str] = None
+        self.request_name: str | None = None
 
         # Check for basic authentication
         parsed_url = urlparse(self.base_url)
@@ -301,7 +301,7 @@ class ResponseContextManager(LocustResponse):
 
 
 class LocustHttpAdapter(HTTPAdapter):
-    def __init__(self, pool_manager: Optional[PoolManager], *args, **kwargs):
+    def __init__(self, pool_manager: PoolManager | None, *args, **kwargs):
         self.poolmanager = pool_manager
         super().__init__(*args, **kwargs)
 

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse, urlunparse
 from ssl import SSLError
 import time
 import traceback
-from typing import Callable, Optional, Tuple, Dict, Any, Generator, cast
+from typing import Callable, Any, Generator, cast
 
 from http.cookiejar import CookieJar
 
@@ -79,10 +79,10 @@ class FastHttpSession:
         self,
         environment: Environment,
         base_url: str,
-        user: Optional[User],
+        user: User | None,
         insecure=True,
-        client_pool: Optional[HTTPClientPool] = None,
-        ssl_context_factory: Optional[Callable] = None,
+        client_pool: HTTPClientPool | None = None,
+        ssl_context_factory: Callable | None = None,
         **kwargs,
     ):
         self.environment = environment
@@ -313,7 +313,7 @@ class FastHttpUser(User):
     insecure: bool = True
     """Parameter passed to FastHttpSession. Default True, meaning no SSL verification."""
 
-    default_headers: Optional[dict] = None
+    default_headers: dict | None = None
     """Parameter passed to FastHttpSession. Adds the listed headers to every request."""
 
     concurrency: int = 10
@@ -321,10 +321,10 @@ class FastHttpUser(User):
     Note that setting this value has no effect when custom client_pool was given, and you need to spawn a your own gevent pool
     to use it (as Users only have one greenlet). See test_fasthttp.py / test_client_pool_concurrency for an example."""
 
-    client_pool: Optional[HTTPClientPool] = None
+    client_pool: HTTPClientPool | None = None
     """HTTP client pool to use. If not given, a new pool is created per single user."""
 
-    ssl_context_factory: Optional[Callable] = None
+    ssl_context_factory: Callable | None = None
     """A callable that return a SSLContext for overriding the default context created by the FastHttpSession."""
 
     abstract = True
@@ -360,7 +360,7 @@ class FastHttpUser(User):
 
     @contextmanager
     def rest(
-        self, method, url, headers: Optional[dict] = None, **kwargs
+        self, method, url, headers: dict | None = None, **kwargs
     ) -> Generator[RestResponseContextManager, None, None]:
         """
         A wrapper for self.client.request that:
@@ -423,36 +423,36 @@ class FastHttpUser(User):
 
 
 class FastRequest(CompatRequest):
-    payload: Optional[str] = None
+    payload: str | None = None
 
     @property
-    def body(self) -> Optional[str]:
+    def body(self) -> str | None:
         return self.payload
 
 
 class FastResponse(CompatResponse):
-    headers: Optional[Headers] = None
+    headers: Headers | None = None
     """Dict like object containing the response headers"""
 
-    _response: Optional[HTTPSocketPoolResponse] = None
+    _response: HTTPSocketPoolResponse | None = None
 
-    encoding: Optional[str] = None
+    encoding: str | None = None
     """In some cases setting the encoding explicitly is needed. If so, do it before calling .text"""
 
-    request: Optional[FastRequest] = None
+    request: FastRequest | None = None
 
     def __init__(
         self,
         ghc_response: HTTPSocketPoolResponse,
-        request: Optional[FastRequest] = None,
-        sent_request: Optional[str] = None,
+        request: FastRequest | None = None,
+        sent_request: str | None = None,
     ):
         super().__init__(ghc_response, request, sent_request)
 
         self.request = request
 
     @property
-    def text(self) -> Optional[str]:
+    def text(self) -> str | None:
         """
         Returns the text content of the response as a decoded string
         """
@@ -472,7 +472,7 @@ class FastResponse(CompatResponse):
         return str(self.content, str(self.encoding), errors="replace")
 
     @property
-    def url(self) -> Optional[str]:
+    def url(self) -> str | None:
         """
         Get "response" URL, which is the same as the request URL. This is a small deviation from HttpSession, which gets the final (possibly redirected) URL.
         """
@@ -527,11 +527,11 @@ class ErrorResponse:
     that doesn't have a real Response object attached. E.g. a socket error or similar
     """
 
-    headers: Optional[Headers] = None
+    headers: Headers | None = None
     content = None
     status_code = 0
-    error: Optional[Exception] = None
-    text: Optional[str] = None
+    error: Exception | None = None
+    text: str | None = None
     request: CompatRequest
 
     def __init__(self, url: str, request: CompatRequest):
@@ -547,7 +547,7 @@ class LocustUserAgent(UserAgent):
     request_type = FastRequest
     valid_response_codes = frozenset([200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 301, 302, 303, 304, 307])
 
-    def __init__(self, client_pool: Optional[HTTPClientPool] = None, **kwargs):
+    def __init__(self, client_pool: HTTPClientPool | None = None, **kwargs):
         super().__init__(**kwargs)
 
         if client_pool is not None:

--- a/locust/debug.py
+++ b/locust/debug.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 import os
 import inspect
 import locust
 import locust.log
 from locust import User, argument_parser
-from typing import Type, Optional
 from locust.env import Environment
 from locust.exception import CatchResponseError, RescheduleTask
 
@@ -94,16 +95,16 @@ class PrintListener:
         print()
 
 
-_env: Optional[Environment] = None  # minimal Environment for debugging
+_env: Environment | None = None  # minimal Environment for debugging
 
 
 def run_single_user(
-    user_class: Type[User],
+    user_class: type[User],
     include_length=False,
     include_time=False,
     include_context=False,
     include_payload=False,
-    loglevel: Optional[str] = "WARNING",
+    loglevel: str | None = "WARNING",
 ):
     """
     Runs a single User. Useful when you want to run a debugger.

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import contextlib
 import itertools
@@ -5,7 +7,7 @@ import math
 import time
 from collections.abc import Iterator
 from operator import attrgetter
-from typing import Dict, Generator, List, TYPE_CHECKING, Optional, Tuple, Type, Set
+from typing import Generator, TYPE_CHECKING
 
 import gevent
 
@@ -49,7 +51,7 @@ class UsersDispatcher(Iterator):
             from 10 to 100.
     """
 
-    def __init__(self, worker_nodes: List["WorkerNode"], user_classes: List[Type[User]]):
+    def __init__(self, worker_nodes: list[WorkerNode], user_classes: list[type[User]]):
         """
         :param worker_nodes: List of worker nodes
         :param user_classes: The user classes
@@ -79,16 +81,16 @@ class UsersDispatcher(Iterator):
 
         self._current_user_count = self.get_current_user_count()
 
-        self._dispatcher_generator: Generator[Dict[str, Dict[str, int]], None, None] = None
+        self._dispatcher_generator: Generator[dict[str, dict[str, int]], None, None] = None
 
         self._user_generator = self._user_gen()
 
         self._worker_node_generator = itertools.cycle(self._worker_nodes)
 
         # To keep track of how long it takes for each dispatch iteration to compute
-        self._dispatch_iteration_durations: List[float] = []
+        self._dispatch_iteration_durations: list[float] = []
 
-        self._active_users: List[Tuple[WorkerNode, str]] = []
+        self._active_users: list[tuple[WorkerNode, str]] = []
 
         # TODO: Test that attribute is set when dispatching and unset when done dispatching
         self._dispatch_in_progress = False
@@ -108,10 +110,10 @@ class UsersDispatcher(Iterator):
         return self._dispatch_in_progress
 
     @property
-    def dispatch_iteration_durations(self) -> List[float]:
+    def dispatch_iteration_durations(self) -> list[float]:
         return self._dispatch_iteration_durations
 
-    def __next__(self) -> Dict[str, Dict[str, int]]:
+    def __next__(self) -> dict[str, dict[str, int]]:
         users_on_workers = next(self._dispatcher_generator)
         # TODO: Is this necessary to copy the users_on_workers if we know
         #       it won't be mutated by external code?
@@ -131,7 +133,7 @@ class UsersDispatcher(Iterator):
         # Sort again, first by index within host, to ensure Users get started evenly across hosts
         self._worker_nodes = sorted(self._worker_nodes, key=lambda worker: (worker._index_within_host, worker.id))
 
-    def _dispatcher(self) -> Generator[Dict[str, Dict[str, int]], None, None]:
+    def _dispatcher(self) -> Generator[dict[str, dict[str, int]], None, None]:
         self._dispatch_in_progress = True
 
         if self._rebalance:
@@ -164,7 +166,7 @@ class UsersDispatcher(Iterator):
 
         self._dispatch_in_progress = False
 
-    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: Optional[List] = None) -> None:
+    def new_dispatch(self, target_user_count: int, spawn_rate: float, user_classes: list | None = None) -> None:
         """
         Initialize a new dispatch cycle.
 
@@ -194,7 +196,7 @@ class UsersDispatcher(Iterator):
 
         self._dispatch_iteration_durations.clear()
 
-    def add_worker(self, worker_node: "WorkerNode") -> None:
+    def add_worker(self, worker_node: WorkerNode) -> None:
         """
         This method is to be called when a new worker connects to the master. When
         a new worker is added, the users dispatcher will flag that a rebalance is required
@@ -207,7 +209,7 @@ class UsersDispatcher(Iterator):
         self._sort_workers()
         self._prepare_rebalance()
 
-    def remove_worker(self, worker_node: "WorkerNode") -> None:
+    def remove_worker(self, worker_node: WorkerNode) -> None:
         """
         This method is similar to the above `add_worker`. When a worker disconnects
         (because of e.g. network failure, worker failure, etc.), this method will ensure that the next
@@ -268,7 +270,7 @@ class UsersDispatcher(Iterator):
         sleep_duration = max(0.0, self._wait_between_dispatch - delta)
         gevent.sleep(sleep_duration)
 
-    def _add_users_on_workers(self) -> Dict[str, Dict[str, int]]:
+    def _add_users_on_workers(self) -> dict[str, dict[str, int]]:
         """Add users on the workers until the target number of users is reached for the current dispatch iteration
 
         :return: The users that we want to run on the workers
@@ -290,7 +292,7 @@ class UsersDispatcher(Iterator):
 
         return self._users_on_workers
 
-    def _remove_users_from_workers(self) -> Dict[str, Dict[str, int]]:
+    def _remove_users_from_workers(self) -> dict[str, dict[str, int]]:
         """Remove users from the workers until the target number of users is reached for the current dispatch iteration
 
         :return: The users that we want to run on the workers
@@ -318,8 +320,8 @@ class UsersDispatcher(Iterator):
 
     def _distribute_users(
         self, target_user_count: int
-    ) -> Tuple[
-        Dict[str, Dict[str, int]], Generator[Optional[str], None, None], itertools.cycle, List[Tuple["WorkerNode", str]]
+    ) -> tuple[
+        dict[str, dict[str, int]], Generator[str | None, None, None], itertools.cycle, list[tuple[WorkerNode, str]]
     ]:
         """
         This function might take some time to complete if the `target_user_count` is a big number. A big number
@@ -349,7 +351,7 @@ class UsersDispatcher(Iterator):
 
         return users_on_workers, user_gen, worker_gen, active_users
 
-    def _user_gen(self) -> Generator[Optional[str], None, None]:
+    def _user_gen(self) -> Generator[str | None, None, None]:
         """
         This method generates users according to their weights using
         a smooth weighted round-robin algorithm implemented by https://github.com/linnik/roundrobin.
@@ -361,7 +363,7 @@ class UsersDispatcher(Iterator):
         less accurate during ramp-up/down.
         """
 
-        def infinite_cycle_gen(users: List[Tuple[Type[User], int]]) -> itertools.cycle:
+        def infinite_cycle_gen(users: list[tuple[type[User], int]]) -> itertools.cycle:
             if not users:
                 return itertools.cycle([None])
 
@@ -401,9 +403,9 @@ class UsersDispatcher(Iterator):
             if self._try_dispatch_fixed:
                 self._try_dispatch_fixed = False
                 current_fixed_users_count = {u: self._get_user_current_count(u) for u in fixed_users}
-                spawned_classes: Set[str] = set()
+                spawned_classes: set[str] = set()
                 while len(spawned_classes) != len(fixed_users):
-                    user_name: Optional[str] = next(cycle_fixed_gen)
+                    user_name: str | None = next(cycle_fixed_gen)
                     if not user_name:
                         break
 
@@ -422,7 +424,7 @@ class UsersDispatcher(Iterator):
             yield next(cycle_weighted_gen)
 
     @staticmethod
-    def _fast_users_on_workers_copy(users_on_workers: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
+    def _fast_users_on_workers_copy(users_on_workers: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
         """deepcopy is too slow, so we use this custom copy function.
 
         The implementation was profiled and compared to other implementations such as dict-comprehensions

--- a/locust/env.py
+++ b/locust/env.py
@@ -1,12 +1,7 @@
+from __future__ import annotations
+
 from operator import methodcaller
-from typing import (
-    Callable,
-    Dict,
-    List,
-    Type,
-    TypeVar,
-    Optional,
-)
+from typing import Callable, TypeVar
 
 from configargparse import Namespace
 
@@ -27,27 +22,27 @@ class Environment:
     def __init__(
         self,
         *,
-        user_classes: Optional[List[Type[User]]] = None,
-        shape_class: Optional[LoadTestShape] = None,
-        tags: Optional[List[str]] = None,
-        locustfile: Optional[str] = None,
-        exclude_tags: Optional[List[str]] = None,
-        events: Optional[Events] = None,
-        host: Optional[str] = None,
+        user_classes: list[type[User]] | None = None,
+        shape_class: LoadTestShape | None = None,
+        tags: list[str] | None = None,
+        locustfile: str | None = None,
+        exclude_tags: list[str] | None = None,
+        events: Events | None = None,
+        host: str | None = None,
         reset_stats=False,
-        stop_timeout: Optional[float] = None,
+        stop_timeout: float | None = None,
         catch_exceptions=True,
-        parsed_options: Optional[Namespace] = None,
-        available_user_classes: Optional[Dict[str, User]] = None,
-        available_shape_classes: Optional[Dict[str, LoadTestShape]] = None,
+        parsed_options: Namespace | None = None,
+        available_user_classes: dict[str, User] | None = None,
+        available_shape_classes: dict[str, LoadTestShape] | None = None,
     ):
-        self.runner: Optional[Runner] = None
+        self.runner: Runner | None = None
         """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
 
-        self.web_ui: Optional[WebUI] = None
+        self.web_ui: WebUI | None = None
         """Reference to the WebUI instance"""
 
-        self.process_exit_code: Optional[int] = None
+        self.process_exit_code: int | None = None
         """
         If set it'll be the exit code of the Locust process
         """
@@ -63,7 +58,7 @@ class Environment:
 
         self.locustfile = locustfile
         """Filename (not path) of locustfile"""
-        self.user_classes: List[Type[User]] = user_classes or []
+        self.user_classes: list[type[User]] = user_classes or []
         """User classes that the runner will run"""
         self.shape_class = shape_class
         """A shape class to control the shape of the load test"""
@@ -105,7 +100,7 @@ class Environment:
 
     def _create_runner(
         self,
-        runner_class: Type[RunnerType],
+        runner_class: type[RunnerType],
         *args,
         **kwargs,
     ) -> RunnerType:
@@ -160,9 +155,9 @@ class Environment:
         host="",
         port=8089,
         web_login: bool = False,
-        tls_cert: Optional[str] = None,
-        tls_key: Optional[str] = None,
-        stats_csv_writer: Optional[StatsCSV] = None,
+        tls_cert: str | None = None,
+        tls_key: str | None = None,
+        stats_csv_writer: StatsCSV | None = None,
         delayed_start=False,
         userclass_picker_is_active=False,
         modern_ui=False,
@@ -244,7 +239,7 @@ class Environment:
         """
         for u in self.user_classes:
             u.weight = 1
-            user_tasks: List[TaskSet | Callable] = []
+            user_tasks: list[TaskSet | Callable] = []
             tasks_frontier = u.tasks
             while len(tasks_frontier) != 0:
                 t = tasks_frontier.pop()
@@ -274,5 +269,5 @@ class Environment:
             )
 
     @property
-    def user_classes_by_name(self) -> Dict[str, Type[User]]:
+    def user_classes_by_name(self) -> dict[str, type[User]]:
         return {u.__name__: u for u in self.user_classes}

--- a/locust/event.py
+++ b/locust/event.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 from . import log
 import traceback
 from contextlib import contextmanager
-from typing import Generator, Any, Dict
+from typing import Generator, Any
 import time
 from .exception import StopUser, RescheduleTask, RescheduleTaskImmediately, InterruptTaskSet
 
@@ -52,7 +54,7 @@ class EventHook:
     @contextmanager
     def measure(
         self, request_type: str, name: str, response_length: int = 0, context=None
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Convenience method for firing the event with automatically calculated response time and automatically marking the request as failed if an exception is raised (this is really only useful for the *request* event)
 
         Example usage (in a task):

--- a/locust/event.py
+++ b/locust/event.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-
 import logging
 from . import log
 import traceback
 from contextlib import contextmanager
-from typing import Generator, Any
+from typing import Generator, Any 
 import time
 from .exception import StopUser, RescheduleTask, RescheduleTaskImmediately, InterruptTaskSet
 
@@ -232,11 +231,12 @@ class Events:
     """
 
     def __init__(self):
-        # For backwarde compatibility use also values of class attributes
+        # For backward compatibility use also values of class attributes
         for name, value in vars(type(self)).items():
-            if value == EventHook:
-                setattr(self, name, value())
+            if value == "EventHook":
+                setattr(self, name, EventHook())
 
         for name, value in self.__annotations__.items():
-            if value == EventHook:
-                setattr(self, name, value())
+            if value == "EventHook":
+                setattr(self, name, EventHook())
+

--- a/locust/event.py
+++ b/locust/event.py
@@ -3,7 +3,7 @@ import logging
 from . import log
 import traceback
 from contextlib import contextmanager
-from typing import Generator, Any 
+from typing import Generator, Any
 import time
 from .exception import StopUser, RescheduleTask, RescheduleTaskImmediately, InterruptTaskSet
 
@@ -239,4 +239,3 @@ class Events:
         for name, value in self.__annotations__.items():
             if value == "EventHook":
                 setattr(self, name, EventHook())
-

--- a/locust/input_events.py
+++ b/locust/input_events.py
@@ -1,4 +1,6 @@
-from typing import Dict, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 import gevent
 import logging
@@ -88,7 +90,7 @@ def get_poller():
         return UnixKeyPoller()
 
 
-def input_listener(key_to_func_map: Dict[str, Callable]):
+def input_listener(key_to_func_map: dict[str, Callable]):
     def input_listener_func():
         try:
             poller = get_poller()

--- a/locust/main.py
+++ b/locust/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 import logging
 import os
@@ -8,7 +10,6 @@ import atexit
 import inspect
 import gevent
 import locust
-from typing import Dict
 from . import log
 from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
@@ -83,7 +84,7 @@ def main():
     locustfile = locustfiles[0] if locustfiles_length == 1 else None
 
     # Importing Locustfile(s) - setting available UserClasses and ShapeClasses to choose from in UI
-    user_classes: Dict[str, locust.User] = {}
+    user_classes: dict[str, locust.User] = {}
     available_user_classes = {}
     available_shape_classes = {}
     shape_class = None

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import msgpack
 import datetime
-from typing import Type
 
 try:
     from bson import ObjectId  # type: ignore

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import time
-from typing import ClassVar, Optional, Tuple, List, Type
+from typing import ClassVar
 from abc import ABCMeta, abstractmethod
 
 from . import User
@@ -23,7 +23,7 @@ class LoadTestShape(metaclass=LoadTestShapeMeta):
     Base class for custom load shapes.
     """
 
-    runner: Optional[Runner] = None
+    runner: Runner | None = None
     """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
 
     abstract: ClassVar[bool] = True
@@ -52,7 +52,7 @@ class LoadTestShape(metaclass=LoadTestShapeMeta):
         return self.runner.user_count
 
     @abstractmethod
-    def tick(self) -> Tuple[int, float] | Tuple[int, float, Optional[List[Type[User]]]] | None:
+    def tick(self) -> tuple[int, float] | tuple[int, float, list[type[User]] | None] | None:
         """
         Returns a tuple with 2 elements to control the running load test:
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -18,12 +18,8 @@ from .util.rounding import proper_round
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterable,
     NoReturn,
-    Tuple,
-    List,
-    Optional,
     OrderedDict as OrderedDictType,
     Callable,
     TypeVar,
@@ -66,18 +62,18 @@ class StatsBaseDict(TypedDict):
 
 
 class StatsEntryDict(StatsBaseDict):
-    last_request_timestamp: Optional[float]
+    last_request_timestamp: float | None
     start_time: float
     num_requests: int
     num_none_requests: int
     num_failures: int
     total_response_time: int
     max_response_time: int
-    min_response_time: Optional[int]
+    min_response_time: int | None
     total_content_length: int
-    response_times: Dict[int, int]
-    num_reqs_per_sec: Dict[int, int]
-    num_fail_per_sec: Dict[int, int]
+    response_times: dict[int, int]
+    num_reqs_per_sec: dict[int, int]
+    num_fail_per_sec: dict[int, int]
 
 
 class StatsErrorDict(StatsBaseDict):
@@ -93,7 +89,7 @@ class StatsHolder(Protocol):
 S = TypeVar("S", bound=StatsHolder)
 
 
-def resize_handler(signum: int, frame: Optional[FrameType]):
+def resize_handler(signum: int, frame: FrameType | None):
     global STATS_NAME_WIDTH
     if STATS_AUTORESIZE:
         try:
@@ -139,7 +135,7 @@ class RequestStatsAdditionError(Exception):
     pass
 
 
-def get_readable_percentiles(percentile_list: List[float]) -> List[str]:
+def get_readable_percentiles(percentile_list: list[float]) -> list[str]:
     """
     Converts a list of percentiles from 0-1 fraction to 0%-100% view for using in console & csv reporting
     :param percentile_list: The list of percentiles in range 0-1
@@ -151,7 +147,7 @@ def get_readable_percentiles(percentile_list: List[float]) -> List[str]:
     ]
 
 
-def calculate_response_time_percentile(response_times: Dict[int, int], num_requests: int, percent: float) -> int:
+def calculate_response_time_percentile(response_times: dict[int, int], num_requests: int, percent: float) -> int:
     """
     Get the response time that a certain number of percent of the requests
     finished within. Arguments:
@@ -172,7 +168,7 @@ def calculate_response_time_percentile(response_times: Dict[int, int], num_reque
     return 0
 
 
-def diff_response_time_dicts(latest: Dict[int, int], old: Dict[int, int]) -> Dict[int, int]:
+def diff_response_time_dicts(latest: dict[int, int], old: dict[int, int]) -> dict[int, int]:
     """
     Returns the delta between two {response_times:request_count} dicts.
 
@@ -212,8 +208,8 @@ class RequestStats:
                                          is not needed.
         """
         self.use_response_times_cache = use_response_times_cache
-        self.entries: Dict[Tuple[str, str], StatsEntry] = EntriesDict(self)
-        self.errors: Dict[str, StatsError] = {}
+        self.entries: dict[tuple[str, str], StatsEntry] = EntriesDict(self)
+        self.errors: dict[str, StatsError] = {}
         self.total = StatsEntry(self, "Aggregated", None, use_response_times_cache=self.use_response_times_cache)
         self.history = []
 
@@ -253,7 +249,7 @@ class RequestStats:
             self.errors[key] = entry
         entry.occurred()
 
-    def get(self, name: str, method: str) -> "StatsEntry":
+    def get(self, name: str, method: str) -> StatsEntry:
         """
         Retrieve a StatsEntry instance by name and method
         """
@@ -278,12 +274,12 @@ class RequestStats:
         self.errors = {}
         self.history = []
 
-    def serialize_stats(self) -> List["StatsEntryDict"]:
+    def serialize_stats(self) -> list[StatsEntryDict]:
         return [
             e.get_stripped_report() for e in self.entries.values() if not (e.num_requests == 0 and e.num_failures == 0)
         ]
 
-    def serialize_errors(self) -> Dict[str, "StatsErrorDict"]:
+    def serialize_errors(self) -> dict[str, StatsErrorDict]:
         return {k: e.serialize() for k, e in self.errors.items()}
 
 
@@ -292,7 +288,7 @@ class StatsEntry:
     Represents a single stats entry (name and method)
     """
 
-    def __init__(self, stats: Optional[RequestStats], name: str, method: str, use_response_times_cache: bool = False):
+    def __init__(self, stats: RequestStats | None, name: str, method: str, use_response_times_cache: bool = False):
         self.stats = stats
         self.name = name
         """ Name (URL) of this stats entry """
@@ -313,15 +309,15 @@ class StatsEntry:
         """ Number of failed request """
         self.total_response_time: int = 0
         """ Total sum of the response times """
-        self.min_response_time: Optional[int] = None
+        self.min_response_time: int | None = None
         """ Minimum response time """
         self.max_response_time: int = 0
         """ Maximum response time """
-        self.num_reqs_per_sec: Dict[int, int] = {}
+        self.num_reqs_per_sec: dict[int, int] = {}
         """ A {second => request_count} dict that holds the number of requests made per second """
-        self.num_fail_per_sec: Dict[int, int] = {}
+        self.num_fail_per_sec: dict[int, int] = {}
         """ A (second => failure_count) dict that hold the number of failures per second """
-        self.response_times: Dict[int, int] = {}
+        self.response_times: dict[int, int] = {}
         """
         A {response_time => count} dict that holds the response time distribution of all
         the requests.
@@ -331,7 +327,7 @@ class StatsEntry:
 
         This dict is used to calculate the median and percentile response times.
         """
-        self.response_times_cache: Optional[OrderedDictType[int, CachedResponseTimes]] = None
+        self.response_times_cache: OrderedDictType[int, CachedResponseTimes] | None = None
         """
         If use_response_times_cache is set to True, this will be a {timestamp => CachedResponseTimes()}
         OrderedDict that holds a copy of the response_times dict for each of the last 20 seconds.
@@ -340,7 +336,7 @@ class StatsEntry:
         """ The sum of the content length of all the responses for this entry """
         self.start_time: float = 0.0
         """ Time of the first request for this entry """
-        self.last_request_timestamp: Optional[float] = None
+        self.last_request_timestamp: float | None = None
         """ Time of the last request for this entry """
         self.reset()
 
@@ -456,7 +452,7 @@ class StatsEntry:
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
-        reqs: List[int | float] = [
+        reqs: list[int | float] = [
             self.num_reqs_per_sec.get(t, 0) for t in range(slice_start_time, int(self.stats.last_request_timestamp) - 2)
         ]
         return avg(reqs)
@@ -497,7 +493,7 @@ class StatsEntry:
         except ZeroDivisionError:
             return 0
 
-    def extend(self, other: "StatsEntry") -> None:
+    def extend(self, other: StatsEntry) -> None:
         """
         Extend the data from the current StatsEntry with the stats from another
         StatsEntry instance.
@@ -545,7 +541,7 @@ class StatsEntry:
         return cast(StatsEntryDict, {key: getattr(self, key, None) for key in StatsEntryDict.__annotations__.keys()})
 
     @classmethod
-    def unserialize(cls, data: StatsEntryDict) -> "StatsEntry":
+    def unserialize(cls, data: StatsEntryDict) -> StatsEntry:
         """Return the unserialzed version of the specified dict"""
         obj = cls(None, data["name"], data["method"])
         valid_keys = StatsEntryDict.__annotations__.keys()
@@ -608,7 +604,7 @@ class StatsEntry:
         """
         return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
 
-    def get_current_response_time_percentile(self, percent: float) -> Optional[int]:
+    def get_current_response_time_percentile(self, percent: float) -> int | None:
         """
         Calculate the *current* response time for a certain percentile. We use a sliding
         window of (approximately) the last 10 seconds (specified by CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
@@ -626,13 +622,13 @@ class StatsEntry:
         # when trying to fetch the cached response_times. We construct this list in such a way
         # that it's ordered by preference by starting to add t-10, then t-11, t-9, t-12, t-8,
         # and so on
-        acceptable_timestamps: List[int] = []
+        acceptable_timestamps: list[int] = []
         acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW)
         for i in range(1, 9):
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW - i)
             acceptable_timestamps.append(t - CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + i)
 
-        cached: Optional[CachedResponseTimes] = None
+        cached: CachedResponseTimes | None = None
         if self.response_times_cache is not None:
             for ts in acceptable_timestamps:
                 if ts in self.response_times_cache:
@@ -748,7 +744,7 @@ class StatsError:
         return f"{self.method} {self.name}: {unwrapped_error}"
 
     def serialize(self) -> StatsErrorDict:
-        def _getattr(obj: "StatsError", key: str, default: Optional[Any]) -> Optional[Any]:
+        def _getattr(obj: StatsError, key: str, default: Any | None) -> Any | None:
             value = getattr(obj, key, default)
 
             if key in ["error"]:
@@ -759,7 +755,7 @@ class StatsError:
         return cast(StatsErrorDict, {key: _getattr(self, key, None) for key in StatsErrorDict.__annotations__.keys()})
 
     @classmethod
-    def unserialize(cls, data: StatsErrorDict) -> "StatsError":
+    def unserialize(cls, data: StatsErrorDict) -> StatsError:
         return cls(data["method"], data["name"], data["error"], data["occurrences"])
 
     def to_dict(self, escape_string_values=False):
@@ -771,11 +767,11 @@ class StatsError:
         }
 
 
-def avg(values: List[float | int]) -> float:
+def avg(values: list[float | int]) -> float:
     return sum(values, 0.0) / max(len(values), 1)
 
 
-def median_from_dict(total: int, count: Dict[int, int]) -> int:
+def median_from_dict(total: int, count: dict[int, int]) -> int:
     """
     total is the number of requests made
     count is a dict {response_time: count}
@@ -790,13 +786,13 @@ def median_from_dict(total: int, count: Dict[int, int]) -> int:
 
 
 def setup_distributed_stats_event_listeners(events: Events, stats: RequestStats) -> None:
-    def on_report_to_master(client_id: str, data: Dict[str, Any]) -> None:
+    def on_report_to_master(client_id: str, data: dict[str, Any]) -> None:
         data["stats"] = stats.serialize_stats()
         data["stats_total"] = stats.total.get_stripped_report()
         data["errors"] = stats.serialize_errors()
         stats.errors = {}
 
-    def on_worker_report(client_id: str, data: Dict[str, Any]) -> None:
+    def on_worker_report(client_id: str, data: dict[str, Any]) -> None:
         for stats_data in data["stats"]:
             entry = StatsEntry.unserialize(stats_data)
             request_key = (entry.name, entry.method)
@@ -826,7 +822,7 @@ def print_stats_json(stats: RequestStats) -> None:
     print(json.dumps(stats.serialize_stats(), indent=4))
 
 
-def get_stats_summary(stats: RequestStats, current=True) -> List[str]:
+def get_stats_summary(stats: RequestStats, current=True) -> list[str]:
     """
     stats summary will be returned as list of string
     """
@@ -852,7 +848,7 @@ def print_percentile_stats(stats: RequestStats) -> None:
     console_logger.info("")
 
 
-def get_percentile_stats_summary(stats: RequestStats) -> List[str]:
+def get_percentile_stats_summary(stats: RequestStats) -> list[str]:
     """
     Percentile stats summary will be returned as list of string
     """
@@ -886,7 +882,7 @@ def print_error_report(stats: RequestStats) -> None:
             console_logger.info(line)
 
 
-def get_error_report_summary(stats) -> List[str]:
+def get_error_report_summary(stats) -> list[str]:
     summary = ["Error report"]
     summary.append("%-18s %-100s" % ("# occurrences", "Error"))
     separator = f'{"-" * 18}|{"-" * ((80 + STATS_NAME_WIDTH) - 19)}'
@@ -907,11 +903,11 @@ def stats_printer(stats: RequestStats) -> Callable[[], None]:
     return stats_printer_func
 
 
-def sort_stats(stats: Dict[Any, S]) -> List[S]:
+def sort_stats(stats: dict[Any, S]) -> list[S]:
     return [stats[key] for key in sorted(stats.keys())]
 
 
-def stats_history(runner: "Runner") -> None:
+def stats_history(runner: Runner) -> None:
     """Save current stats info to history for charts of report."""
     while True:
         stats = runner.stats
@@ -943,7 +939,7 @@ def stats_history(runner: "Runner") -> None:
 class StatsCSV:
     """Write statistics to csv_writer stream."""
 
-    def __init__(self, environment: "Environment", percentiles_to_report: List[float]) -> None:
+    def __init__(self, environment: Environment, percentiles_to_report: list[float]) -> None:
         self.environment = environment
         self.percentiles_to_report = percentiles_to_report
 
@@ -977,7 +973,7 @@ class StatsCSV:
             "Nodes",
         ]
 
-    def _percentile_fields(self, stats_entry: StatsEntry, use_current: bool = False) -> List[str] | List[int]:
+    def _percentile_fields(self, stats_entry: StatsEntry, use_current: bool = False) -> list[str] | list[int]:
         if not stats_entry.num_requests:
             return self.percentiles_na
         elif use_current:
@@ -1045,8 +1041,8 @@ class StatsCSVFileWriter(StatsCSV):
 
     def __init__(
         self,
-        environment: "Environment",
-        percentiles_to_report: List[float],
+        environment: Environment,
+        percentiles_to_report: list[float],
         base_filepath: str,
         full_history: bool = False,
     ):
@@ -1142,7 +1138,7 @@ class StatsCSVFileWriter(StatsCSV):
 
         stats = self.environment.stats
         timestamp = int(now)
-        stats_entries: List[StatsEntry] = []
+        stats_entries: list[StatsEntry] = []
         if self.full_history:
             stats_entries = sort_stats(stats.entries)
 

--- a/locust/test/mock_logging.py
+++ b/locust/test/mock_logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from typing import List, Union, Dict
@@ -7,11 +9,11 @@ LogMessage = List[Union[str, Dict[str, TracebackType]]]
 
 
 class MockedLoggingHandler(logging.Handler):
-    debug: List[LogMessage] = []
-    warning: List[LogMessage] = []
-    info: List[LogMessage] = []
-    error: List[LogMessage] = []
-    critical: List[LogMessage] = []
+    debug: list[LogMessage] = []
+    warning: list[LogMessage] = []
+    info: list[LogMessage] = []
+    error: list[LogMessage] = []
+    critical: list[LogMessage] = []
 
     def emit(self, record):
         if record.exc_info:

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import time
 import unittest
 from operator import attrgetter
-from typing import Dict, List, Tuple, Type
 
 from locust import User
 from locust.dispatch import UsersDispatcher
@@ -3372,7 +3373,7 @@ class TestAddWorker(unittest.TestCase):
 
 class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
     class RampUpCase:
-        def __init__(self, fixed_counts: Tuple[int], weights: Tuple[int], target_user_count: int):
+        def __init__(self, fixed_counts: tuple[int], weights: tuple[int], target_user_count: int):
             self.fixed_counts = fixed_counts
             self.weights = weights
             self.target_user_count = target_user_count
@@ -3382,7 +3383,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                 self.fixed_counts, self.weights, self.target_user_count
             )
 
-    def case_handler(self, cases: List[RampUpCase], expected: List[Dict[str, int]], user_classes: List[Type[User]]):
+    def case_handler(self, cases: list[RampUpCase], expected: list[dict[str, int]], user_classes: list[type[User]]):
         self.assertEqual(len(cases), len(expected))
 
         for case_num in range(len(cases)):
@@ -4092,14 +4093,14 @@ class TestRampUpDifferentUsers(unittest.TestCase):
         self.assertEqual(_user_count_on_worker(dispatched_users, worker_nodes[2].id), 6)
 
 
-def _aggregate_dispatched_users(d: Dict[str, Dict[str, int]]) -> Dict[str, int]:
+def _aggregate_dispatched_users(d: dict[str, dict[str, int]]) -> dict[str, int]:
     user_classes = list(next(iter(d.values())).keys())
     return {u: sum(d[u] for d in d.values()) for u in user_classes}
 
 
-def _user_count(d: Dict[str, Dict[str, int]]) -> int:
+def _user_count(d: dict[str, dict[str, int]]) -> int:
     return sum(map(sum, map(dict.values, d.values())))  # type: ignore
 
 
-def _user_count_on_worker(d: Dict[str, Dict[str, int]], worker_node_id: str) -> int:
+def _user_count_on_worker(d: dict[str, dict[str, int]], worker_node_id: str) -> int:
     return sum(d[worker_node_id].values())

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import csv
 import json
@@ -8,7 +10,6 @@ import traceback
 import logging
 from io import StringIO
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import List, Optional, Tuple, Type
 
 import gevent
 import requests

--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import inspect
 from json import dumps
-from typing import List, Type, Dict
 
 from .task import TaskSet
 from .users import User
@@ -49,11 +50,11 @@ def _print_task_ratio(x, level=0):
             _print_task_ratio(v["tasks"], level + 1)
 
 
-def get_ratio(user_classes: List[Type[User]], user_spawned: Dict[str, int], total: bool) -> Dict[str, Dict[str, float]]:
+def get_ratio(user_classes: list[type[User]], user_spawned: dict[str, int], total: bool) -> dict[str, dict[str, float]]:
     user_count = sum(user_spawned.values()) or 1
-    ratio_percent: Dict[Type[User], float] = {u: user_spawned.get(u.__name__, 0) / user_count for u in user_classes}
+    ratio_percent: dict[type[User], float] = {u: user_spawned.get(u.__name__, 0) / user_count for u in user_classes}
 
-    task_dict: Dict[str, Dict[str, float]] = {}
+    task_dict: dict[str, dict[str, float]] = {}
     for u, r in ratio_percent.items():
         d = {"ratio": r}
         d["tasks"] = _get_task_ratio(u.tasks, total, r)

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -6,13 +6,9 @@ from time import time
 from typing import (
     TYPE_CHECKING,
     Callable,
-    List,
     TypeVar,
-    Optional,
     Type,
     overload,
-    Dict,
-    Set,
     Protocol,
     final,
     runtime_checkable,
@@ -34,7 +30,7 @@ LOCUST_STATE_RUNNING, LOCUST_STATE_WAITING, LOCUST_STATE_STOPPING = ["running", 
 
 @runtime_checkable
 class TaskHolder(Protocol[TaskT]):
-    tasks: List[TaskT]
+    tasks: list[TaskT]
 
 
 @overload
@@ -170,10 +166,10 @@ def get_tasks_from_base_classes(bases, class_dict):
 
 
 def filter_tasks_by_tags(
-    task_holder: Type[TaskHolder],
-    tags: Optional[Set[str]] = None,
-    exclude_tags: Optional[Set[str]] = None,
-    checked: Optional[Dict[TaskT, bool]] = None,
+    task_holder: type[TaskHolder],
+    tags: set[str] | None = None,
+    exclude_tags: set[str] | None = None,
+    checked: dict[TaskT, bool] | None = None,
 ):
     """
     Function used by Environment to recursively remove any tasks/TaskSets from a TaskSet/User that
@@ -238,7 +234,7 @@ class TaskSet(metaclass=TaskSetMeta):
     will then continue in the first TaskSet).
     """
 
-    tasks: List[TaskSet | Callable] = []
+    tasks: list[TaskSet | Callable] = []
     """
     Collection of python callables and/or TaskSet classes that the User(s) will run.
 
@@ -253,7 +249,7 @@ class TaskSet(metaclass=TaskSetMeta):
             tasks = {ThreadPage:15, write_post:1}
     """
 
-    min_wait: Optional[float] = None
+    min_wait: float | None = None
     """
     Deprecated: Use wait_time instead.
     Minimum waiting time between the execution of user tasks. Can be used to override
@@ -261,7 +257,7 @@ class TaskSet(metaclass=TaskSetMeta):
     TaskSet.
     """
 
-    max_wait: Optional[float] = None
+    max_wait: float | None = None
     """
     Deprecated: Use wait_time instead.
     Maximum waiting time between the execution of user tasks. Can be used to override
@@ -277,11 +273,11 @@ class TaskSet(metaclass=TaskSetMeta):
     if not set on the TaskSet.
     """
 
-    _user: "User"
-    _parent: "User"
+    _user: User
+    _parent: User
 
-    def __init__(self, parent: "User") -> None:
-        self._task_queue: List[Callable] = []
+    def __init__(self, parent: User) -> None:
+        self._task_queue: list[Callable] = []
         self._time_start = time()
 
         if isinstance(parent, TaskSet):
@@ -301,7 +297,7 @@ class TaskSet(metaclass=TaskSetMeta):
         self._cp_last_run = time()  # used by constant_pacing wait_time
 
     @property
-    def user(self) -> "User":
+    def user(self) -> User:
         """:py:class:`User <locust.User>` instance that this TaskSet was created by"""
         return self._user
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Dict, List, Optional, final
+from typing import Callable, final
 
 import time
 from gevent import GreenletExit, greenlet
@@ -59,7 +59,7 @@ class User(metaclass=UserMeta):
     :py:class:`HttpUser <locust.HttpUser>` class.
     """
 
-    host: Optional[str] = None
+    host: str | None = None
     """Base hostname to swarm. i.e: http://127.0.0.1:1234"""
 
     min_wait = None
@@ -89,7 +89,7 @@ class User(metaclass=UserMeta):
     Method that returns the time between the execution of locust tasks in milliseconds
     """
 
-    tasks: List[TaskSet | Callable] = []
+    tasks: list[TaskSet | Callable] = []
     """
     Collection of python callables and/or TaskSet classes that the Locust user(s) will run.
 
@@ -216,7 +216,7 @@ class User(metaclass=UserMeta):
     def greenlet(self):
         return self._greenlet
 
-    def context(self) -> Dict:
+    def context(self) -> dict:
         """
         Adds the returned value (a dict) to the context for :ref:`request event <request_context>`.
         Override this in your User class to customize the context.
@@ -244,7 +244,7 @@ class HttpUser(User):
     abstract = True
     """If abstract is True, the class is meant to be subclassed, and users will not choose this locust during a test"""
 
-    pool_manager: Optional[PoolManager] = None
+    pool_manager: PoolManager | None = None
     """Connection pool manager to use. If not given, a new manager is created per single user."""
 
     def __init__(self, *args, **kwargs):

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import importlib
 import inspect
 import os
 import sys
-from typing import Dict, List, Optional, Tuple
 from ..shape import LoadTestShape
 from ..user import User
 
@@ -21,7 +22,7 @@ def is_shape_class(item):
     return bool(inspect.isclass(item) and issubclass(item, LoadTestShape) and not getattr(item, "abstract", True))
 
 
-def load_locustfile(path) -> Tuple[Optional[str], Dict[str, User], List[LoadTestShape]]:
+def load_locustfile(path) -> tuple[str | None, dict[str, User], list[LoadTestShape]]:
     """
     Import given locustfile path and return (docstring, callables).
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -9,7 +9,7 @@ from io import StringIO
 from json import dumps
 from itertools import chain
 from time import time
-from typing import TYPE_CHECKING, Optional, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 import gevent
 from flask import (
@@ -55,7 +55,7 @@ class WebUI:
     in :attr:`environment.stats <locust.env.Environment.stats>`
     """
 
-    app: Optional[Flask] = None
+    app: Flask | None = None
     """
     Reference to the :class:`flask.Flask` app. Can be used to add additional web routes and customize
     the Flask app in other various ways. Example::
@@ -67,30 +67,30 @@ class WebUI:
             return "your IP is: %s" % request.remote_addr
     """
 
-    greenlet: Optional[gevent.Greenlet] = None
+    greenlet: gevent.Greenlet | None = None
     """
     Greenlet of the running web server
     """
 
-    server: Optional[pywsgi.WSGIServer] = None
+    server: pywsgi.WSGIServer | None = None
     """Reference to the :class:`pyqsgi.WSGIServer` instance"""
 
-    template_args: Dict[str, Any]
+    template_args: dict[str, Any]
     """Arguments used to render index.html for the web UI. Must be used with custom templates
     extending index.html."""
 
-    auth_args: Dict[str, Any]
+    auth_args: dict[str, Any]
     """Arguments used to render auth.html for the web UI auth page. Must be used when configuring auth"""
 
     def __init__(
         self,
-        environment: "Environment",
+        environment: Environment,
         host: str,
         port: int,
         web_login: bool = False,
-        tls_cert: Optional[str] = None,
-        tls_key: Optional[str] = None,
-        stats_csv_writer: Optional[StatsCSV] = None,
+        tls_cert: str | None = None,
+        tls_key: str | None = None,
+        stats_csv_writer: StatsCSV | None = None,
         delayed_start=False,
         userclass_picker_is_active=False,
         modern_ui=False,
@@ -126,8 +126,8 @@ class WebUI:
         root_path = os.path.dirname(os.path.abspath(__file__))
         app.root_path = root_path
         self.webui_build_path = os.path.join(root_path, "webui", "dist")
-        self.greenlet: Optional[gevent.Greenlet] = None
-        self._swarm_greenlet: Optional[gevent.Greenlet] = None
+        self.greenlet: gevent.Greenlet | None = None
+        self._swarm_greenlet: gevent.Greenlet | None = None
         self.template_args = {}
         self.auth_args = {}
 
@@ -370,8 +370,8 @@ class WebUI:
         @self.auth_required_if_enabled
         @memoize(timeout=DEFAULT_CACHE_TIME, dynamic_timeout=True)
         def request_stats() -> Response:
-            stats: List[Dict[str, Any]] = []
-            errors: List[StatsErrorDict] = []
+            stats: list[dict[str, Any]] = []
+            errors: list[StatsErrorDict] = []
 
             if environment.runner is None:
                 report = {
@@ -481,9 +481,9 @@ class WebUI:
 
         @app.route("/tasks")
         @self.auth_required_if_enabled
-        def tasks() -> Dict[str, Dict[str, Dict[str, float]]]:
+        def tasks() -> dict[str, dict[str, dict[str, float]]]:
             runner = self.environment.runner
-            user_spawned: Dict[str, int]
+            user_spawned: dict[str, int]
             if runner is None:
                 user_spawned = {}
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ locust = "locust.main:main"
 [tool.mypy]
 # missing type stubs
 ignore_missing_imports = true
+python_version = "3.8"
 
 [[tool.mypy.overrides]]
 module = ["requests.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,5 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [[tool.mypy.overrides]]
-module = ["requests.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = ["locust.dispatch"]
 no_strict_optional = true

--- a/tox.ini
+++ b/tox.ini
@@ -49,5 +49,7 @@ deps = flake8==6.0.0
 commands = flake8 . --count --show-source --statistics
 
 [testenv:mypy]
-deps = mypy==1.7.1
+deps =
+    mypy==1.8.0
+    types-requests
 commands = mypy locust/


### PR DESCRIPTION
1. Mypy: check typing compatibility for the oldest supported Python version - currently Python3.8.
2. Fix mypy errors, add from \_\_future__ import annotations & upgrade type annotations using fix-future-annotations.
3. Upgrade mypy, set types-requests as mypy test dependency in tox.