### PR TITLE
Ruff set python version and enable more rules

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,5 @@
 313b80f27f525441c449593a3aeaf38389f63c13
 # upgrade typing annotations using fix-future-annotations
 b5324820b299b1fe7da0608f0cc8ec47f58b1e40
+# upgrade code style to 3.8 using pyupgrade
+60f3bceacc4ab9567433d40ae3ed280750f55ff1

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -632,8 +632,8 @@ if __name__ == "__main__":
         print()
         print(table)
 
-        with open(f"results-dispatch-benchmarks-{int(now)}.txt", "wt") as file:
+        with open(f"results-dispatch-benchmarks-{int(now)}.txt", "w") as file:
             file.write(table.get_string())
 
-        with open(f"results-dispatch-benchmarks-{int(now)}.json", "wt") as file:
+        with open(f"results-dispatch-benchmarks-{int(now)}.json", "w") as file:
             file.write(table.get_json_string())

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -124,7 +124,7 @@ class UsersDispatcher(Iterator):
         worker_nodes_by_id = sorted(self._worker_nodes, key=lambda w: w.id)
 
         # Give every worker an index indicating how many workers came before it on that host
-        workers_per_host = defaultdict(lambda: 0)
+        workers_per_host = defaultdict(int)
         for worker_node in worker_nodes_by_id:
             host = worker_node.id.split("_")[0]
             worker_node._index_within_host = workers_per_host[host]

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -215,8 +215,7 @@ class Runner:
             self.update_state(STATE_SPAWNING)
 
         logger.debug(
-            "Spawning additional %s (%s already running)..."
-            % (json.dumps(user_classes_spawn_count), json.dumps(self.user_classes_count))
+            f"Spawning additional {json.dumps(user_classes_spawn_count)} ({json.dumps(self.user_classes_count)} already running)..."
         )
 
         def spawn(user_class: str, spawn_count: int) -> list[User]:
@@ -902,7 +901,7 @@ class MasterRunner(DistributedRunner):
         self.stop(send_stop_to_client=False)
         logger.debug("Quitting...")
         for client in self.clients.all:
-            logger.debug("Sending quit message to worker %s (index %s)" % (client.id, self.get_worker_index(client.id)))
+            logger.debug(f"Sending quit message to worker {client.id} (index {self.get_worker_index(client.id)})")
             self.server.send_to_client(Message("quit", None, client.id))
         gevent.sleep(0.5)  # wait for final stats report from all workers
         self.greenlet.kill(block=True)
@@ -1123,7 +1122,7 @@ class MasterRunner(DistributedRunner):
 
     @property
     def reported_user_classes_count(self) -> dict[str, int]:
-        reported_user_classes_count: dict[str, int] = defaultdict(lambda: 0)
+        reported_user_classes_count: dict[str, int] = defaultdict(int)
         for client in self.clients.ready + self.clients.spawning + self.clients.running:
             for name, count in client.user_classes_count.items():
                 reported_user_classes_count[name] += count
@@ -1139,11 +1138,11 @@ class MasterRunner(DistributedRunner):
                             If None, will send to all attached workers
         """
         if client_id:
-            logger.debug("Sending %s message to worker %s" % (msg_type, client_id))
+            logger.debug(f"Sending {msg_type} message to worker {client_id}")
             self.server.send_to_client(Message(msg_type, data, client_id))
         else:
             for client in self.clients.all:
-                logger.debug("Sending %s message to worker %s" % (msg_type, client.id))
+                logger.debug(f"Sending {msg_type} message to worker {client.id}")
                 self.server.send_to_client(Message(msg_type, data, client.id))
 
 

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -423,10 +423,8 @@ class TaskSet(metaclass=TaskSetMeta):
             return random.randint(self.min_wait, self.max_wait) / 1000.0
         else:
             raise MissingWaitTimeError(
-                "You must define a wait_time method on either the %s or %s class"
-                % (
-                    type(self.user).__name__,
-                    type(self).__name__,
+                "You must define a wait_time method on either the {} or {} class".format(
+                    type(self.user).__name__, type(self).__name__
                 )
             )
 

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -423,9 +423,7 @@ class TaskSet(metaclass=TaskSetMeta):
             return random.randint(self.min_wait, self.max_wait) / 1000.0
         else:
             raise MissingWaitTimeError(
-                "You must define a wait_time method on either the {} or {} class".format(
-                    type(self.user).__name__, type(self).__name__
-                )
+                "You must define a wait_time method on either the {type(self.user).__name__} or {type(self).__name__} class"
             )
 
     def wait(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ extend-exclude = [
     "src/readthedocs-sphinx-search/",
 ]
 ignore = ["E402", "E501", "E713", "E731", "E741", "F401"]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "UP", "FA102"]
 
 [tool.ruff.per-file-ignores]
 "examples/*" = ["F841"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.ruff]
+target-version = "py38"
 line-length = 120
 extend-exclude = [
     "build",


### PR DESCRIPTION
1. Set python target-version for ruff.
2. Enable FA102 rule (Checks for uses of PEP 585- and PEP 604-style type annotations in Python modules that lack the required from __future__ import annotations import for compatibility with older Python versions).
3. Enable pyupgrade rules.
4. Make code compatible with rules.
