### PR TITLE
Ruff enable isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,5 @@
 b5324820b299b1fe7da0608f0cc8ec47f58b1e40
 # upgrade code style to 3.8 using pyupgrade
 60f3bceacc4ab9567433d40ae3ed280750f55ff1
+# sort imports using ruff
+993eda8a3dbbec8563f5e1b91d2192ca65918c71

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@
 
 import os
 import subprocess
+
 import sphinx_rtd_theme
 
 from locust.argument_parser import get_empty_argument_parser, setup_parser_arguments

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import subprocess
 import os
+import subprocess
 import sys
 
 github_api_token = (

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -15,15 +15,15 @@ from gevent import monkey
 monkey.patch_all()
 
 from ._version import version as __version__
-from .user.sequential_taskset import SequentialTaskSet
-from .user import wait_time
-from .user.task import task, tag, TaskSet
-from .user.users import HttpUser, User
 from .contrib.fasthttp import FastHttpUser
-from .user.wait_time import between, constant, constant_pacing, constant_throughput
-from .shape import LoadTestShape
 from .debug import run_single_user
 from .event import Events
+from .shape import LoadTestShape
+from .user import wait_time
+from .user.sequential_taskset import SequentialTaskSet
+from .user.task import TaskSet, tag, task
+from .user.users import HttpUser, User
+from .user.wait_time import between, constant, constant_pacing, constant_throughput
 
 events = Events()
 
@@ -46,5 +46,5 @@ __all__ = (
 )
 
 # Used for raising a DeprecationWarning if old Locust/HttpLocust is used
-from .util.deprecation import DeprecatedLocustClass as Locust
 from .util.deprecation import DeprecatedHttpLocustClass as HttpLocust
+from .util.deprecation import DeprecatedLocustClass as Locust

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -4,7 +4,8 @@ import os
 import platform
 import sys
 import textwrap
-from typing import NamedTuple, Any
+from typing import Any, NamedTuple
+
 import configargparse
 
 import locust

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import re
 import time
 from contextlib import contextmanager

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -1,34 +1,34 @@
 from __future__ import annotations
-import re
-import socket
+
 import json
 import json as unshadowed_json  # some methods take a named parameter called json
-from base64 import b64encode
-from contextlib import contextmanager
-from json.decoder import JSONDecodeError
-from urllib.parse import urlparse, urlunparse
-from ssl import SSLError
+import re
+import socket
 import time
 import traceback
-from typing import Callable, Any, Generator, cast
-
+from base64 import b64encode
+from contextlib import contextmanager
 from http.cookiejar import CookieJar
+from json.decoder import JSONDecodeError
+from ssl import SSLError
+from typing import Any, Callable, Generator, cast
+from urllib.parse import urlparse, urlunparse
 
 import gevent
+from charset_normalizer import detect
 from gevent.timeout import Timeout
 from geventhttpclient._parser import HTTPParseError
 from geventhttpclient.client import HTTPClientPool
-from geventhttpclient.useragent import UserAgent, CompatRequest, CompatResponse, ConnectionError
-from geventhttpclient.response import HTTPConnectionClosed, HTTPSocketPoolResponse
 from geventhttpclient.header import Headers
+from geventhttpclient.response import HTTPConnectionClosed, HTTPSocketPoolResponse
+from geventhttpclient.useragent import CompatRequest, CompatResponse, ConnectionError, UserAgent
 
 # borrow requests's content-type header parsing
 from requests.utils import get_encoding_from_headers
-from charset_normalizer import detect
 
-from locust.user import User
-from locust.exception import LocustError, CatchResponseError, ResponseError
 from locust.env import Environment
+from locust.exception import CatchResponseError, LocustError, ResponseError
+from locust.user import User
 from locust.util.deprecation import DeprecatedFastHttpLocustClass as FastHttpLocust
 
 # Monkey patch geventhttpclient.useragent.CompatRequest so that Cookiejar works with Python >= 3.3

--- a/locust/debug.py
+++ b/locust/debug.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import inspect
 import os
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 import locust
 import locust.log
-from locust import User, argument_parser
+from locust import argument_parser
 from locust.env import Environment
 from locust.exception import CatchResponseError, RescheduleTask
 
+if TYPE_CHECKING:
+    from . import User
 
 def _print_t(s):
     """

--- a/locust/debug.py
+++ b/locust/debug.py
@@ -14,6 +14,7 @@ from locust.exception import CatchResponseError, RescheduleTask
 if TYPE_CHECKING:
     from . import User
 
+
 def _print_t(s):
     """
     Print something with a tab instead of newline at the end

--- a/locust/debug.py
+++ b/locust/debug.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-import os
 import inspect
+import os
+from datetime import datetime, timezone
+
 import locust
 import locust.log
 from locust import User, argument_parser

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Generator
 import gevent
 from roundrobin import smooth
 
-
 if TYPE_CHECKING:
     from locust import User
     from locust.runners import WorkerNode

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-from collections import defaultdict
 import contextlib
 import itertools
 import math
 import time
+from collections import defaultdict
 from collections.abc import Iterator
 from operator import attrgetter
-from typing import Generator, TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator
 
 import gevent
-
 from roundrobin import smooth
 
 from locust import User

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Generator
 import gevent
 from roundrobin import smooth
 
-from locust import User
 
 if TYPE_CHECKING:
+    from locust import User
     from locust.runners import WorkerNode
 
 

--- a/locust/env.py
+++ b/locust/env.py
@@ -7,13 +7,12 @@ from configargparse import Namespace
 
 from .event import Events
 from .exception import RunnerAlreadyExistsError
-from .stats import RequestStats, StatsCSV
-from .runners import Runner, LocalRunner, MasterRunner, WorkerRunner
-from .web import WebUI
-from .user import User
-from .user.task import filter_tasks_by_tags, TaskSet, TaskHolder
+from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
 from .shape import LoadTestShape
-
+from .stats import RequestStats, StatsCSV
+from .user import User
+from .user.task import TaskHolder, TaskSet, filter_tasks_by_tags
+from .web import WebUI
 
 RunnerType = TypeVar("RunnerType", bound=Runner)
 

--- a/locust/event.py
+++ b/locust/event.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import logging
-from . import log
+import time
 import traceback
 from contextlib import contextmanager
-from typing import Generator, Any
-import time
-from .exception import StopUser, RescheduleTask, RescheduleTaskImmediately, InterruptTaskSet
+from typing import Any, Generator
+
+from . import log
+from .exception import InterruptTaskSet, RescheduleTask, RescheduleTaskImmediately, StopUser
 
 
 class EventHook:

--- a/locust/html.py
+++ b/locust/html.py
@@ -1,16 +1,17 @@
-from jinja2 import Environment, FileSystemLoader
-import os
-import glob
-import pathlib
 import datetime
-from itertools import chain
-from .stats import sort_stats
-from . import stats as stats_module
-from .user.inspectuser import get_ratio
+import glob
+import os
+import pathlib
 from html import escape
+from itertools import chain
 from json import dumps
-from .runners import MasterRunner, STATE_STOPPED, STATE_STOPPING
 
+from jinja2 import Environment, FileSystemLoader
+
+from . import stats as stats_module
+from .runners import STATE_STOPPED, STATE_STOPPING, MasterRunner
+from .stats import sort_stats
+from .user.inspectuser import get_ratio
 
 PERCENTILES_FOR_HTML_REPORT = [0.50, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0]
 

--- a/locust/input_events.py
+++ b/locust/input_events.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from typing import Callable
-
-import gevent
 import logging
 import os
 import sys
+from typing import Callable
+
+import gevent
 
 if os.name == "nt":
     from win32api import STD_INPUT_HANDLE
     from win32console import (
-        GetStdHandle,
-        KEY_EVENT,
         ENABLE_ECHO_INPUT,
         ENABLE_LINE_INPUT,
         ENABLE_PROCESSED_INPUT,
+        KEY_EVENT,
+        GetStdHandle,
     )
 else:
     import select

--- a/locust/main.py
+++ b/locust/main.py
@@ -1,35 +1,38 @@
 from __future__ import annotations
 
+import atexit
 import errno
+import inspect
 import logging
 import os
 import signal
 import sys
 import time
-import atexit
-import inspect
+import traceback
+
 import gevent
+
 import locust
-from . import log
+
+from . import log, stats
 from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
-from .log import setup_logging, greenlet_exception_logger
-from . import stats
+from .html import get_html_report
+from .input_events import input_listener
+from .log import greenlet_exception_logger, setup_logging
 from .stats import (
+    StatsCSV,
+    StatsCSVFileWriter,
     print_error_report,
     print_percentile_stats,
     print_stats,
     print_stats_json,
-    stats_printer,
     stats_history,
+    stats_printer,
 )
-from .stats import StatsCSV, StatsCSVFileWriter
 from .user.inspectuser import print_task_ratio, print_task_ratio_json
-from .util.timespan import parse_timespan
-from .input_events import input_listener
-from .html import get_html_report
 from .util.load_locustfile import load_locustfile
-import traceback
+from .util.timespan import parse_timespan
 
 try:
     # import locust_plugins if it is installed, to allow it to register custom arguments etc

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import msgpack
 import datetime
+
+import msgpack
 
 try:
     from bson import ObjectId  # type: ignore

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,9 +1,11 @@
-import zmq.green as zmq
-from .protocol import Message
-from locust.util.exception_handler import retry
-from locust.exception import RPCError, RPCSendError, RPCReceiveError
-import zmq.error as zmqerr
 import msgpack.exceptions as msgerr
+import zmq.error as zmqerr
+import zmq.green as zmq
+
+from locust.exception import RPCError, RPCReceiveError, RPCSendError
+from locust.util.exception_handler import retry
+
+from .protocol import Message
 
 
 class BaseSocket:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -38,7 +38,7 @@ from gevent.pool import Group
 
 from locust import __version__
 
-from . import User, argument_parser
+from . import argument_parser
 from .dispatch import UsersDispatcher
 from .exception import RPCError, RPCReceiveError, RPCSendError
 from .log import greenlet_exception_logger
@@ -53,6 +53,7 @@ from .stats import (
 )
 
 if TYPE_CHECKING:
+    from . import User
     from .env import Environment
 
 logger = logging.getLogger(__name__)

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import json
 import logging
 import os
@@ -19,24 +20,25 @@ from operator import (
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
+    Any,
+    Callable,
     Iterator,
     NoReturn,
-    ValuesView,
-    Any,
-    cast,
-    Callable,
     TypedDict,
+    ValuesView,
+    cast,
 )
 from uuid import uuid4
+
 import gevent
 import greenlet
 import psutil
 from gevent.event import Event
 from gevent.pool import Group
-import inspect
 
-from . import User
 from locust import __version__
+
+from . import User, argument_parser
 from .dispatch import UsersDispatcher
 from .exception import RPCError, RPCReceiveError, RPCSendError
 from .log import greenlet_exception_logger
@@ -49,7 +51,6 @@ from .stats import (
     StatsError,
     setup_distributed_stats_event_listeners,
 )
-from . import argument_parser
 
 if TYPE_CHECKING:
     from .env import Environment

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import time
 from abc import ABCMeta, abstractmethod
-from typing import ClassVar
+from typing import ClassVar, TYPE_CHECKING
 
-from . import User
 from .runners import Runner
+
+if TYPE_CHECKING:
+    from . import User
 
 
 class LoadTestShapeMeta(ABCMeta):

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from abc import ABCMeta, abstractmethod
-from typing import ClassVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from .runners import Runner
 

--- a/locust/shape.py
+++ b/locust/shape.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import time
-from typing import ClassVar
 from abc import ABCMeta, abstractmethod
+from typing import ClassVar
 
 from . import User
 from .runners import Runner

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,43 +1,44 @@
 from __future__ import annotations
-from abc import abstractmethod
+
+import csv
 import datetime
 import hashlib
 import json
-from tempfile import NamedTemporaryFile
-import time
-from collections import namedtuple, OrderedDict
-from copy import copy
-from itertools import chain
+import logging
 import os
-import csv
 import signal
-import gevent
+import time
+from abc import abstractmethod
+from collections import OrderedDict, namedtuple
+from copy import copy
 from html import escape
-from .util.rounding import proper_round
-
+from itertools import chain
+from tempfile import NamedTemporaryFile
+from types import FrameType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Iterable,
     NoReturn,
-    OrderedDict as OrderedDictType,
-    Callable,
-    TypeVar,
-    cast,
     Protocol,
     TypedDict,
+    TypeVar,
+    cast,
+)
+from typing import (
+    OrderedDict as OrderedDictType,
 )
 
-from types import FrameType
+import gevent
 
-from .exception import CatchResponseError
 from .event import Events
-
-import logging
+from .exception import CatchResponseError
+from .util.rounding import proper_round
 
 if TYPE_CHECKING:
-    from .runners import Runner
     from .env import Environment
+    from .runners import Runner
 
 console_logger = logging.getLogger("locust.stats_logger")
 

--- a/locust/user/__init__.py
+++ b/locust/user/__init__.py
@@ -1,2 +1,2 @@
-from .task import task, tag, TaskSet
+from .task import TaskSet, tag, task
 from .users import HttpUser, User

--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections import defaultdict
 import inspect
+from collections import defaultdict
 from json import dumps
 
 from .task import TaskSet

--- a/locust/user/sequential_taskset.py
+++ b/locust/user/sequential_taskset.py
@@ -1,5 +1,7 @@
 import logging
+
 from locust.exception import LocustError
+
 from .task import TaskSet, TaskSetMeta
 
 

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import logging
 import random
 import traceback
@@ -6,17 +7,18 @@ from time import time
 from typing import (
     TYPE_CHECKING,
     Callable,
-    TypeVar,
-    Type,
-    overload,
     Protocol,
+    Type,
+    TypeVar,
     final,
+    overload,
     runtime_checkable,
 )
+
 import gevent
 from gevent import GreenletExit
 
-from locust.exception import InterruptTaskSet, RescheduleTask, RescheduleTaskImmediately, StopUser, MissingWaitTimeError
+from locust.exception import InterruptTaskSet, MissingWaitTimeError, RescheduleTask, RescheduleTaskImmediately, StopUser
 
 if TYPE_CHECKING:
     from locust import User

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
+import logging
+import time
+import traceback
 from typing import Callable, final
 
-import time
 from gevent import GreenletExit, greenlet
 from gevent.pool import Group
 from urllib3 import PoolManager
-import logging
-import traceback
 
 logger = logging.getLogger(__name__)
 from locust.clients import HttpSession

--- a/locust/util/deprecation.py
+++ b/locust/util/deprecation.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 # Show deprecation warnings
 warnings.filterwarnings("always", category=DeprecationWarning, module="locust")
 

--- a/locust/util/exception_handler.py
+++ b/locust/util/exception_handler.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import os
 import sys
+
 from ..shape import LoadTestShape
 from ..user import User
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -1,42 +1,43 @@
 from __future__ import annotations
+
 import csv
 import logging
 import os.path
 from functools import wraps
-
 from html import escape
 from io import StringIO
-from json import dumps
 from itertools import chain
+from json import dumps
 from time import time
 from typing import TYPE_CHECKING, Any
 
 import gevent
 from flask import (
     Flask,
-    make_response,
+    Response,
     jsonify,
+    make_response,
+    redirect,
     render_template,
     request,
     send_file,
-    Response,
     send_from_directory,
-    redirect,
     url_for,
 )
+from flask_cors import CORS
 from flask_login import LoginManager, login_required
 from gevent import pywsgi
 
-from .runners import MasterRunner, STATE_RUNNING, STATE_MISSING
+from . import __version__ as version
+from . import argument_parser
+from . import stats as stats_module
+from .html import get_html_report
 from .log import greenlet_exception_logger
-from .stats import StatsCSVFileWriter, StatsErrorDict, sort_stats
-from . import stats as stats_module, __version__ as version, argument_parser
-from .stats import StatsCSV
+from .runners import STATE_MISSING, STATE_RUNNING, MasterRunner
+from .stats import StatsCSV, StatsCSVFileWriter, StatsErrorDict, sort_stats
 from .user.inspectuser import get_ratio
 from .util.cache import memoize
 from .util.timespan import parse_timespan
-from .html import get_html_report
-from flask_cors import CORS
 
 if TYPE_CHECKING:
     from .env import Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ select = ["E", "F", "W", "UP", "FA102", "I001"]
 [tool.ruff.per-file-ignores]
 "examples/*" = ["F841", "I001"]
 "locust/test/*" = ["F841", "I001"]
+"scripts/*" = ["I001"]
+# I001: In locustfiles locust is imported first (because of gevent monkey patching)
 
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ extend-exclude = [
     "src/readthedocs-sphinx-search/",
 ]
 ignore = ["E402", "E501", "E713", "E731", "E741", "F401"]
-select = ["E", "F", "W", "UP", "FA102"]
+select = ["E", "F", "W", "UP", "FA102", "I001"]
 
 [tool.ruff.per-file-ignores]
-"examples/*" = ["F841"]
-"locust/test/*" = ["F841"]
+"examples/*" = ["F841", "I001"]
+"locust/test/*" = ["F841", "I001"]
 
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Enable ruff isort-like import sorting & make code compatible with them.

Alternative solutions:
1. `from .user.users import HttpUser, User  # isort: skip` in `locust/__init__.py` instead of
```py
if TYPE_CHECKING:
    from . import User
```
   in debug.py, dispatch.py, runners.py, shape.py.
2. [Custom Sections and Ordering](https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html) instead of excluding folders (pyproject.toml).
 