### PR TITLE
DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

### DIFF
--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -59,6 +59,10 @@ def load_locustfile(path) -> tuple[str | None, dict[str, User], list[LoadTestSha
     module_name = os.path.splitext(locustfile)[0]
     loader = importlib.machinery.SourceFileLoader(module_name, path)
     spec = importlib.util.spec_from_file_location(module_name, path, loader=loader)
+    if spec is None:
+        sys.stderr.write(f"Unable to get module spec for {module_name} in {path}")
+        sys.exit(1)
+
     imported = importlib.util.module_from_spec(spec)
     sys.modules[imported.__name__] = imported
     loader.exec_module(imported)


### PR DESCRIPTION
When running the unit tests and looking at the output, the `DeprecationWarning` in the title is thrown/visible a couple of times.

In python 3.4 `load_module` was replaced with `exec_module`. [0][1]

> Deprecated since version 3.4: The recommended API for loading a module is [exec_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.exec_module) (and [create_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.create_module)). Loaders should implement it instead of [load_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module). The import machinery takes care of all the other responsibilities of [load_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) when [exec_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.exec_module) is implemented.

The tests does indeed work on 3.12, so seems like it hasn't been removed yet, 
but this PR replaces the call to `load_module` in `locust.util.load_locustfile.load_locustfile` to use `exec_module` instead.

[0] https://peps.python.org/pep-0451/
[1] https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module