### PR TITLE
Work around issue with locustfiles named "locust.py"

### DIFF
--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -50,6 +50,16 @@ class TestLoadLocustfile(LocustTestCase):
                 os.path.join(os.path.relpath(mocked.directory, os.getcwd()), mocked.filename)
             )
 
+    def test_load_locust_file_called_locust_dot_py(self):
+        with mock_locustfile() as mocked:
+            new_filename = mocked.file_path.replace(mocked.filename, "locust.py")
+            os.rename(mocked.file_path, new_filename)
+            try:
+                docstring, user_classes, shape_classes = main.load_locustfile(new_filename)
+            finally:
+                # move it back, so it can be deleted
+                os.rename(new_filename, mocked.file_path)
+
     def test_load_locust_file_with_a_dot_in_filename(self):
         with mock_locustfile(filename_prefix="mocked.locust.file") as mocked:
             docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -57,6 +57,8 @@ def load_locustfile(path) -> tuple[str | None, dict[str, User], list[LoadTestSha
 
     # Perform the import
     module_name = os.path.splitext(locustfile)[0]
+    if module_name == "locust":
+        module_name = "locustfile"  # Avoid conflict with locust package
     loader = importlib.machinery.SourceFileLoader(module_name, path)
     spec = importlib.util.spec_from_file_location(module_name, path, loader=loader)
     if spec is None:


### PR DESCRIPTION
If the locustfile is called "locust.py" it collides with the locust module during import, but it can be worked around (this used to work before https://github.com/locustio/locust/pull/2576)