### PR TITLE
Add check if remote locustfile is valid pythoncode

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -209,7 +209,7 @@ See documentation for more details, including how to set options using a file or
         "--locustfile",
         metavar="<filename>",
         default="locustfile",
-        help="The Python file or module that contains your test, e.g. 'my_test.py'. Also accepts multiple comma-separated .py files or a package name/directory. Defaults to 'locustfile'.",
+        help="The Python file or module that contains your test, e.g. 'my_test.py'. Accepts multiple comma-separated .py files, a package name/directory or a url to a remote locustfile. Defaults to 'locustfile'.",
         env_var="LOCUST_LOCUSTFILE",
     )
 


### PR DESCRIPTION
Check response from url to see if it's valid pythoncode and exit with a clearer error message if not.