### PR TITLE
pluggable dispatcher logic

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -5,7 +5,7 @@ from typing import Callable, TypeVar
 
 from configargparse import Namespace
 
-from .dispatch import UsersDispatcher, UsersDispatcherType
+from .dispatch import UsersDispatcher
 from .event import Events
 from .exception import RunnerAlreadyExistsError
 from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
@@ -36,7 +36,7 @@ class Environment:
         available_user_classes: dict[str, User] | None = None,
         available_shape_classes: dict[str, LoadTestShape] | None = None,
         available_user_tasks: dict[str, list[TaskSet | Callable]] | None = None,
-        dispatcher_class: type[UsersDispatcherType] = UsersDispatcher,
+        dispatcher_class: type[UsersDispatcher] = UsersDispatcher,
     ):
         self.runner: Runner | None = None
         """Reference to the :class:`Runner <locust.runners.Runner>` instance"""

--- a/locust/env.py
+++ b/locust/env.py
@@ -5,6 +5,7 @@ from typing import Callable, TypeVar
 
 from configargparse import Namespace
 
+from .dispatch import UsersDispatcher, UsersDispatcherType
 from .event import Events
 from .exception import RunnerAlreadyExistsError
 from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
@@ -35,6 +36,7 @@ class Environment:
         available_user_classes: dict[str, User] | None = None,
         available_shape_classes: dict[str, LoadTestShape] | None = None,
         available_user_tasks: dict[str, list[TaskSet | Callable]] | None = None,
+        dispatcher_class: type[UsersDispatcherType] = UsersDispatcher,
     ):
         self.runner: Runner | None = None
         """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
@@ -95,6 +97,8 @@ class Environment:
         """List of the available Shape Classes to pick from in the ShapeClass Picker"""
         self.available_user_tasks = available_user_tasks
         """List of the available Tasks per User Classes to pick from in the Task Picker"""
+        self.dispatcher_class = dispatcher_class
+        """A user dispatcher class that decides how users are spawned, default :class:`UsersDispatcher <locust.dispatch.UsersDispatcher>`"""
 
         self._remove_user_classes_with_weight_zero()
         self._validate_user_class_name_uniqueness()

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -39,7 +39,7 @@ from gevent.event import Event
 from gevent.pool import Group
 
 from . import argument_parser
-from .dispatch import UsersDispatcherType
+from .dispatch import UsersDispatcher
 from .exception import RPCError, RPCReceiveError, RPCSendError
 from .log import greenlet_exception_logger
 from .rpc import (
@@ -121,7 +121,7 @@ class Runner:
         self.target_user_count: int = 0
         self.custom_messages: dict[str, Callable] = {}
 
-        self._users_dispatcher: UsersDispatcherType | None = None
+        self._users_dispatcher: UsersDispatcher | None = None
 
         # set up event listeners for recording requests
         def on_request(request_type, name, response_time, response_length, exception=None, **_kwargs):
@@ -682,7 +682,7 @@ class MasterRunner(DistributedRunner):
             else:
                 raise
 
-        self._users_dispatcher: UsersDispatcherType | None = None
+        self._users_dispatcher: UsersDispatcher | None = None
 
         self.greenlet.spawn(self.heartbeat_worker).link_exception(greenlet_exception_handler)
         self.greenlet.spawn(self.client_listener).link_exception(greenlet_exception_handler)
@@ -1210,7 +1210,7 @@ class WorkerRunner(DistributedRunner):
         self.master_host = master_host
         self.master_port = master_port
         self.worker_cpu_warning_emitted = False
-        self._users_dispatcher: UsersDispatcherType | None = None
+        self._users_dispatcher: UsersDispatcher | None = None
         self.client = rpc.Client(master_host, master_port, self.client_id)
         self.greenlet.spawn(self.worker).link_exception(greenlet_exception_handler)
         self.connect_to_master()

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -3629,7 +3629,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertEqual(
-                                    users_dispatcher.get_user_current_count(user_class.__name__),
+                                    users_dispatcher._get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                     msg=f"{user_class.__name__}, {target_user_count}",
                                 )
@@ -3645,7 +3645,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertNotEqual(
-                                    users_dispatcher.get_user_current_count(user_class.__name__),
+                                    users_dispatcher._get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                 )
 
@@ -3660,7 +3660,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertEqual(
-                                    users_dispatcher.get_user_current_count(user_class.__name__),
+                                    users_dispatcher._get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                 )
 

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -3629,7 +3629,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertEqual(
-                                    users_dispatcher._get_user_current_count(user_class.__name__),
+                                    users_dispatcher.get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                     msg=f"{user_class.__name__}, {target_user_count}",
                                 )
@@ -3645,7 +3645,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertNotEqual(
-                                    users_dispatcher._get_user_current_count(user_class.__name__),
+                                    users_dispatcher.get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                 )
 
@@ -3660,7 +3660,7 @@ class TestRampUpUsersFromZeroWithFixed(unittest.TestCase):
                         for user_class in user_classes:
                             if user_class.fixed_count:
                                 self.assertEqual(
-                                    users_dispatcher._get_user_current_count(user_class.__name__),
+                                    users_dispatcher.get_user_current_count(user_class.__name__),
                                     user_class.fixed_count,
                                 )
 

--- a/locust/test/test_env.py
+++ b/locust/test/test_env.py
@@ -1,7 +1,7 @@
 from locust import (
     constant,
 )
-from locust.dispatch import UsersDispatcher, UsersDispatcherType
+from locust.dispatch import UsersDispatcher
 from locust.env import Environment, LoadTestShape
 from locust.user import (
     User,
@@ -207,7 +207,7 @@ class TestEnvironment(LocustTestCase):
 
         self.assertEqual(environment.dispatcher_class, UsersDispatcher)
 
-        class MyUsersDispatcher(UsersDispatcherType):
+        class MyUsersDispatcher(UsersDispatcher):
             pass
 
         environment = Environment(user_classes=[MyUserWithSameName1], dispatcher_class=MyUsersDispatcher)

--- a/locust/test/test_env.py
+++ b/locust/test/test_env.py
@@ -1,6 +1,7 @@
 from locust import (
     constant,
 )
+from locust.dispatch import UsersDispatcher, UsersDispatcherType
 from locust.env import Environment, LoadTestShape
 from locust.user import (
     User,
@@ -200,6 +201,18 @@ class TestEnvironment(LocustTestCase):
             ValueError, r"instance of LoadTestShape or subclass LoadTestShape", msg="exception message is mismatching"
         ):
             Environment(user_classes=[MyUserWithSameName1], shape_class=SubLoadTestShape)
+
+    def test_dispatcher_class_attribute(self):
+        environment = Environment(user_classes=[MyUserWithSameName1])
+
+        self.assertEqual(environment.dispatcher_class, UsersDispatcher)
+
+        class MyUsersDispatcher(UsersDispatcherType):
+            pass
+
+        environment = Environment(user_classes=[MyUserWithSameName1], dispatcher_class=MyUsersDispatcher)
+
+        self.assertEqual(environment.dispatcher_class, MyUsersDispatcher)
 
     def test_update_user_class(self):
         class MyUser1(User):

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -3,6 +3,7 @@ import functools
 import gc
 import os
 import socket
+import warnings
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
@@ -78,7 +79,9 @@ def create_tls_cert(hostname):
 def clear_all_functools_lru_cache() -> None:
     # Clear all `functools.lru_cache` to ensure that no state are persisted from one test to another.
     # Taken from https://stackoverflow.com/a/50699209.
-    gc.collect()
+    with warnings.catch_warnings():
+        warnings.simplefilter(action="ignore", category=ResourceWarning)
+        gc.collect()
     wrappers = [a for a in gc.get_objects() if isinstance(a, functools._lru_cache_wrapper)]
     assert len(wrappers) > 0
     for wrapper in wrappers:


### PR DESCRIPTION
superseeding #2568, coming from discussion in #2522.

this PR makes it possible to implement custom dispatcher logic and specifying the dispatcher class when creating an `Environment`.

a little unsure and not really satisfied with the name of the "interface" `UserDispatcherType`.
played around with `UserDispatcherBase` (but it's [discouraged](https://softwareengineering.stackexchange.com/questions/422970/does-using-the-word-base-in-a-class-name-indicate-abstraction)to use `Base`). `IUserDispatcher` doesn't feel pythonic. so any suggestion on a better name is welcomed :) my top choice would be to rename `UserDispatcher` to `WeightedUserDispatcher` (or similar) and have the interface changed to `UserDispatcher`, but at the same time I wanted to make as few changes as possible.

some methods and properties in the interface was added to make it easier to [compability] test implementations.

so minor changes in the current dispatcher logic so it uses the interface specified methods and properties.