### PR TITLE
Fix: Handle errors caused by invalid hostnames

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -40,7 +40,7 @@ from gevent.pool import Group
 
 from . import argument_parser
 from .dispatch import UsersDispatcher
-from .exception import RPCError, RPCReceiveError, RPCSendError
+from .exception import LocustError, RPCError, RPCReceiveError, RPCSendError
 from .log import greenlet_exception_logger
 from .rpc import (
     Message,
@@ -224,7 +224,11 @@ class Runner:
             n = 0
             new_users: list[User] = []
             while n < spawn_count:
-                new_user = self.user_classes_by_name[user_class](self.environment)
+                try:
+                    new_user = self.user_classes_by_name[user_class](self.environment)
+                except LocustError:
+                    logger.error(f"LocustError occurred while spawning user of class {user_class}", exc_info=True)
+                    sys.exit(1)
                 new_user.start(self.user_greenlets)
                 new_users.append(new_user)
                 n += 1


### PR DESCRIPTION
Fixes #2575 

This catches the errors generated by missing or invalid hostnames, logs them, and exits, thereby stopping the "spamming". 

The change can also be made in one place by logging and exiting here:  https://github.com/locustio/locust/blob/6ce340bc61624d39e3df5dbfdd3e20def3164638/locust/clients.py#L174-L183

but this seemed like more of a core function and perhaps it makes more sense in other cases to re-raise.

Please feel free to let me know if there's a better approach. We've been using `locust` at work (thanks) and wanted to contribute.
