### PR TITLE
Implement pyproject.toml support for Locust configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,7 +24,8 @@ Locust is configured mainly through command line arguments.
 Environment Variables
 =====================
 
-Options can also be set through through environment variables. They are typically the same as the command line argument but capitalized and prefixed with ``LOCUST_``:
+Options can also be set through environment variables. They are typically the same as the command line argument
+but capitalized and prefixed with ``LOCUST_``:
 
 On Linux/macOS:
 
@@ -44,17 +45,23 @@ On Windows:
 Configuration File
 ==================
 
-Options can also be set in a configuration file in the `config file <https://github.com/bw2/ConfigArgParse#config-file-syntax>`_
-format. 
+Options can also be set in a configuration file in the
+`config or TOML file format <https://github.com/bw2/ConfigArgParse#config-file-syntax>`_.
 
-Locust will look for ``~/.locust.conf`` and ``./locust.conf`` by default, and you can specify an 
-additional file using the ``--config`` flag.
+Locust will look for ``~/.locust.conf``, ``./locust.conf`` and ``./pyproject.toml`` by default.
+You can specify an additional file using the ``--config`` flag.
 
-Example:
+.. code-block:: console
 
-.. code-block::
+    $ locust --config custom_config.conf
 
-    # master.conf in current directory
+Here's a quick example of the configuration files supported by Locust:
+
+locust.conf
+--------------
+
+.. code-block:: ini
+
     locustfile = locust_files/my_locust_file.py
     headless = true
     master = true
@@ -63,19 +70,34 @@ Example:
     users = 100
     spawn-rate = 10
     run-time = 10m
-    
+    tags = [Critical, Normal]
 
-.. code-block:: console
+pyproject.toml
+--------------
 
-    $ locust --config master.conf
+When using a TOML file, configuration options should be defined within the ``[tool.locust]`` section.
+
+.. code-block:: toml
+
+    [tool.locust]
+    locustfile = "locust_files/my_locust_file.py"
+    headless = true
+    master = true
+    expect-workers = 5
+    host = "https://target-system"
+    users = 100
+    spawn-rate = 10
+    run-time = "10m"
+    tags = ["Critical", "Normal"]
 
 .. note::
 
-    Configuration values are read (overridden) in the following order:
+    Configuration values are read (and overridden) in the following order:
     
     .. code-block:: console
         
-        ~/locust.conf -> ./locust.conf -> (file specified using --conf) -> env vars -> cmd args
+       ./pyproject.toml -> ~/.locust.conf -> ./locust.conf -> (file specified using --conf) -> env vars -> cmd args
+
 
 All available configuration options
 ===================================

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -96,7 +96,7 @@ When using a TOML file, configuration options should be defined within the ``[to
     
     .. code-block:: console
         
-       ./pyproject.toml -> ~/.locust.conf -> ./locust.conf -> (file specified using --conf) -> env vars -> cmd args
+       ~/.locust.conf -> ./locust.conf -> ./pyproject.toml -> (file specified using --conf) -> env vars -> cmd args
 
 
 All available configuration options

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -23,7 +23,7 @@ import requests
 version = locust.__version__
 
 
-DEFAULT_CONFIG_FILES = ["~/.locust.conf", "locust.conf"]
+DEFAULT_CONFIG_FILES = ("pyproject.toml", "~/.locust.conf", "locust.conf")
 
 
 class LocustArgumentParser(configargparse.ArgumentParser):
@@ -186,6 +186,12 @@ def download_locustfile_from_url(url: str) -> str:
 def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG_FILES) -> LocustArgumentParser:
     parser = LocustArgumentParser(
         default_config_files=default_config_files,
+        config_file_parser_class=configargparse.CompositeConfigParser(
+            [
+                configargparse.TomlConfigParser(["tool.locust"]),
+                configargparse.DefaultConfigFileParser,
+            ]
+        ),
         add_env_var_help=False,
         add_config_file_help=False,
         add_help=add_help,

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -12,9 +12,15 @@ import socket
 import sys
 import tempfile
 import textwrap
+from collections import OrderedDict
 from typing import Any, NamedTuple
 from urllib.parse import urlparse
 from uuid import uuid4
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 import configargparse
 import gevent
@@ -23,7 +29,7 @@ import requests
 version = locust.__version__
 
 
-DEFAULT_CONFIG_FILES = ("pyproject.toml", "~/.locust.conf", "locust.conf")
+DEFAULT_CONFIG_FILES = ("~/.locust.conf", "locust.conf", "pyproject.toml")
 
 
 class LocustArgumentParser(configargparse.ArgumentParser):
@@ -61,6 +67,31 @@ class LocustArgumentParser(configargparse.ArgumentParser):
             for a in self._actions
             if a.dest in self.args_included_in_web_ui and hasattr(a, "is_secret") and a.is_secret
         }
+
+
+class LocustTomlConfigParser(configargparse.TomlConfigParser):
+    def parse(self, stream):
+        try:
+            config = tomllib.loads(stream.read())
+        except Exception as e:
+            raise configargparse.ConfigFileParserException(f"Couldn't parse TOML file: {e}")
+
+        # convert to dict and filter based on section names
+        result = OrderedDict()
+
+        for section in self.sections:
+            data = configargparse.get_toml_section(config, section)
+            if data:
+                for key, value in data.items():
+                    if isinstance(value, list):
+                        result[key] = value
+                    elif value is None:
+                        pass
+                    else:
+                        result[key] = str(value)
+                break
+
+        return result
 
 
 def _is_package(path):
@@ -188,7 +219,7 @@ def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG
         default_config_files=default_config_files,
         config_file_parser_class=configargparse.CompositeConfigParser(
             [
-                configargparse.TomlConfigParser(["tool.locust"]),
+                LocustTomlConfigParser(["tool.locust"]),
                 configargparse.DefaultConfigFileParser,
             ]
         ),

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -15,6 +15,8 @@ from random import randint
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 
+import toml
+
 from .mock_locustfile import mock_locustfile
 from .testcases import LocustTestCase
 
@@ -38,17 +40,53 @@ class TestParser(unittest.TestCase):
         opts = self.parser.parse_args(args)
         self.assertEqual(opts.skip_log_setup, True)
 
-    def test_parameter_parsing(self):
-        with NamedTemporaryFile(mode="w") as file:
-            os.environ["LOCUST_LOCUSTFILE"] = "locustfile_from_env"
-            file.write("host host_from_config\nweb-host webhost_from_config")
+    def test_parse_options_from_conf_file(self):
+        with NamedTemporaryFile(mode="w", suffix=".conf") as file:
+            config_data = """\
+            locustfile = ./test_locustfile.py
+            web-host = 127.0.0.1
+            web-port = 45787
+            headless
+            tags = [Critical, Normal]
+            """
+
+            file.write(config_data)
             file.flush()
             parser = get_parser(default_config_files=[file.name])
-            options = parser.parse_args(["-H", "host_from_args"])
-            del os.environ["LOCUST_LOCUSTFILE"]
-        self.assertEqual(options.web_host, "webhost_from_config")
-        self.assertEqual(options.locustfile, "locustfile_from_env")
-        self.assertEqual(options.host, "host_from_args")  # overridden
+            options = parser.parse_args(["-H", "https://example.com"])
+
+        self.assertEqual("./test_locustfile.py", options.locustfile)
+        self.assertEqual("127.0.0.1", options.web_host)
+        self.assertEqual(45787, options.web_port)
+        self.assertTrue(options.headless)
+        self.assertEqual(["Critical", "Normal"], options.tags)
+        self.assertEqual("https://example.com", options.host)
+
+    def test_parse_options_from_toml_file(self):
+        with NamedTemporaryFile(mode="w", suffix=".toml") as file:
+            config_data = {
+                "tool": {
+                    "locust": {
+                        "locustfile": "./test_locustfile.py",
+                        "web-host": "127.0.0.1",
+                        "web-port": 45787,
+                        "headless": True,
+                        "tags": ["Critical", "Normal"],
+                    }
+                }
+            }
+
+            file.write(toml.dumps(config_data))
+            file.flush()
+            parser = get_parser(default_config_files=[file.name])
+            options = parser.parse_args(["-H", "https://example.com"])
+
+        self.assertEqual("./test_locustfile.py", options.locustfile)
+        self.assertEqual("127.0.0.1", options.web_host)
+        self.assertEqual(45787, options.web_port)
+        self.assertTrue(options.headless)
+        self.assertEqual(["Critical", "Normal"], options.tags)
+        self.assertEqual("https://example.com", options.host)
 
 
 class TestArgumentParser(LocustTestCase):

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -15,8 +15,6 @@ from random import randint
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 
-import toml
-
 from .mock_locustfile import mock_locustfile
 from .testcases import LocustTestCase
 
@@ -64,19 +62,16 @@ class TestParser(unittest.TestCase):
 
     def test_parse_options_from_toml_file(self):
         with NamedTemporaryFile(mode="w", suffix=".toml") as file:
-            config_data = {
-                "tool": {
-                    "locust": {
-                        "locustfile": "./test_locustfile.py",
-                        "web-host": "127.0.0.1",
-                        "web-port": 45787,
-                        "headless": True,
-                        "tags": ["Critical", "Normal"],
-                    }
-                }
-            }
+            config_data = """\
+            [tool.locust]
+            locustfile = "./test_locustfile.py"
+            web-host = "127.0.0.1"
+            web-port = 45787
+            headless = true
+            tags = ["Critical", "Normal"]
+            """
 
-            file.write(toml.dumps(config_data))
+            file.write(config_data)
             file.flush()
             parser = get_parser(default_config_files=[file.name])
             options = parser.parse_args(["-H", "https://example.com"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ dependencies = [
     "pyzmq >=25.0.0",
     "geventhttpclient >=2.0.11",
     "ConfigArgParse >=1.5.5",
-    "toml >=0.10.2",
+    "tomli >=1.1.0; python_version<'3.11'",
     "psutil >=5.9.1",
     "Flask-Login >=0.6.3",
     "Flask-Cors >=3.0.10",
     "roundrobin >=0.0.2",
-    "pywin32;platform_system=='Windows'",
+    "pywin32; platform_system=='Windows'",
 ]
 classifiers = [
     "Topic :: Software Development :: Testing :: Traffic Generation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyzmq >=25.0.0",
     "geventhttpclient >=2.0.11",
     "ConfigArgParse >=1.5.5",
+    "toml >=0.10.2",
     "psutil >=5.9.1",
     "Flask-Login >=0.6.3",
     "Flask-Cors >=3.0.10",

--- a/tox.ini
+++ b/tox.ini
@@ -41,5 +41,4 @@ commands =
 deps =
     mypy==1.8.0
     types-requests
-    types-toml
 commands = mypy locust/

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,5 @@ commands =
 deps =
     mypy==1.8.0
     types-requests
+    types-toml
 commands = mypy locust/


### PR DESCRIPTION
**Issue Addressed:**

This PR implements support for TOML files as configuration files and sets [pyproject.toml](https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-toml-spec) as the default. It addresses the #2298 issue.

**Implementation Details:**
1. Used the built-in `CompositeConfigParser` with `TomlConfigParser` and `DefaultConfigFileParser`, which allow the [configargparse](https://github.com/bw2/ConfigArgParse) lib to automatically parse options from defined `.conf` and `.toml` files. 
2. Added `pyproject.toml` to `DEFAULT_CONFIG_FILES`. 
3. Introduced a new project dependency - [toml](https://github.com/uiri/toml), which is required for the `configargparse` TOML parser to work. 
4. Added tests to check the correct parsing of `.conf` and `.toml` configuration files.
5. Reworked the [Configuration File](https://github.com/uiri/toml) documentation section.