### PR TITLE
Do not call blocking `content` property and lazily load response

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -578,7 +578,10 @@ class ResponseContextManager(FastResponse):
     def __init__(self, response, environment, request_meta):
         # copy data from response to this object
         self.__dict__ = response.__dict__
-        self._cached_content = response.content
+        try:
+            self._cached_content = response._cached_content
+        except AttributeError:
+            pass
         # store reference to locust Environment
         self._environment = environment
         self.request_meta = request_meta


### PR DESCRIPTION
This reverts commit 7ce89a00 and improves it for cases when `stream=True` and `catch_response=True`. Together with #2642, this finally makes handling long-running streaming requests possible and reporting a failure while consuming the response.

The problem is that calling `response.content` triggers a `read` of the whole response eventually, rendering subsequent (streaming) reads pointless.
