### PR TITLE
Update pyproject.toml to fix errors in installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ content-type = "text/markdown"
 zip-safe = false
 license-files = ["LICENSE"]
 include-package-data = false
+py-modules = []
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
Following error pops up while installing locust in editable mode -

_error: Multiple top-level packages discovered in a flat-layout: ['lib', 'lib64', 'share', 'locust', 'include']._