### PR TITLE
Add functionality to run listener functions for `custom_messages` concurrently

### DIFF
--- a/docs/running-distributed.rst
+++ b/docs/running-distributed.rst
@@ -131,7 +131,20 @@ order to coordinate the test. This can be easily accomplished with custom messag
             environment.runner.send_message('test_users', users)  
 
 Note that when running locally (i.e. non-distributed), this functionality will be preserved; 
-the messages will simply be handled by the runner that sends them.  
+the messages will simply be handled by the runner that sends them.
+
+.. note::
+    Using the default options while registering a message handler will run the listener function
+    in a **blocking** way, resulting in the heartbeat and other messages being delayed for the amount
+    of the execution.
+    If it is known that the listener function will handle time-intensive tasks, it is possible to register the
+    function as **concurrent** (as a separate greenlet).
+
+    .. code-block::
+        environment.runner.register_message('test_users', setup_test_users, concurrent=True)
+
+    Please use this feature with care, as otherwise it could result in greenlets running and influencing
+    the running loadtest.
 
 For more details, see the `complete example <https://github.com/locustio/locust/tree/master/examples/custom_messages.py>`_.
 

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -1,17 +1,28 @@
 from locust import HttpUser, between, events, task
 from locust.runners import MasterRunner, WorkerRunner
 
+import gevent
+
 usernames = []
 
 
 def setup_test_users(environment, msg, **kwargs):
     # Fired when the worker receives a message of type 'test_users'
     usernames.extend(map(lambda u: u["name"], msg.data))
+    # Even though "acknowledge_concurrent_users" was sent first, "acknowledge_users"
+    # will print its statement first, as "acknowledge_concurrent_users" was registered
+    # running concurrently, and therefore not blocking other messages.
+    environment.runner.send_message("concurrent_message", "This is a non blocking message")
     environment.runner.send_message("acknowledge_users", f"Thanks for the {len(msg.data)} users!")
 
 
 def on_acknowledge(msg, **kwargs):
     # Fired when the master receives a message of type 'acknowledge_users'
+    print(msg.data)
+
+
+def on_concurrent_message(msg, **kwargs):
+    gevent.sleep(10)
     print(msg.data)
 
 
@@ -21,6 +32,10 @@ def on_locust_init(environment, **_kwargs):
         environment.runner.register_message("test_users", setup_test_users)
     if not isinstance(environment.runner, WorkerRunner):
         environment.runner.register_message("acknowledge_users", on_acknowledge)
+        environment.runner.register_message("concurrent_message",
+                                            on_concurrent_message,
+                                            concurrent=True)
+
 
 
 @events.test_start.add_listener

--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -32,10 +32,7 @@ def on_locust_init(environment, **_kwargs):
         environment.runner.register_message("test_users", setup_test_users)
     if not isinstance(environment.runner, WorkerRunner):
         environment.runner.register_message("acknowledge_users", on_acknowledge)
-        environment.runner.register_message("concurrent_message",
-                                            on_concurrent_message,
-                                            concurrent=True)
-
+        environment.runner.register_message("concurrent_message", on_concurrent_message, concurrent=True)
 
 
 @events.test_start.add_listener

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -119,7 +119,7 @@ class Runner:
         self.target_user_classes_count: dict[str, int] = {}
         # target_user_count is set before the ramp-up/ramp-down occurs.
         self.target_user_count: int = 0
-        self.custom_messages: dict[str, tuple[Callable, Boolean]] = {}
+        self.custom_messages: dict[str, tuple[Callable, bool]] = {}
 
         self._users_dispatcher: UsersDispatcher | None = None
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -630,6 +630,7 @@ class TestLocustRunner(LocustRunnerTestCase):
         gevent.sleep(0.5)
         self.assertTrue(test_custom_msg[0])
         self.assertEqual(123, test_custom_msg_data[0]["test_data"])
+
     def test_undefined_custom_message(self):
         class MyUser(User):
             wait_time = constant(1)

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -606,6 +606,30 @@ class TestLocustRunner(LocustRunnerTestCase):
         self.assertTrue(test_custom_msg[0])
         self.assertEqual(123, test_custom_msg_data[0]["test_data"])
 
+    def test_concurrent_custom_message(self):
+        class MyUser(User):
+            wait_time = constant(1)
+
+            @task
+            def my_task(self):
+                pass
+
+        test_custom_msg = [False]
+        test_custom_msg_data = [{}]
+
+        def on_custom_msg(msg, **kw):
+            test_custom_msg[0] = True
+            test_custom_msg_data[0] = msg.data
+
+        environment = Environment(user_classes=[MyUser])
+        runner = LocalRunner(environment)
+
+        runner.register_message("test_custom_msg", on_custom_msg, concurrent=True)
+        runner.send_message("test_custom_msg", {"test_data": 123})
+
+        gevent.sleep(0.5)
+        self.assertTrue(test_custom_msg[0])
+        self.assertEqual(123, test_custom_msg_data[0]["test_data"])
     def test_undefined_custom_message(self):
         class MyUser(User):
             wait_time = constant(1)


### PR DESCRIPTION
This MR adds the functionality to `Runners.register_message` to register a `concurrent` function.

Issue #2608 explains this PR in more detail.