### PR TITLE
fix: update `parsed_options` `run_time`

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -215,11 +215,14 @@ class WebUI:
             for key, value in request.form.items():
                 if key == "user_count":  # if we just renamed this field to "users" we wouldn't need this
                     user_count = int(value)
+                    parsed_options_dict["users"] = user_count
                 elif key == "spawn_rate":
                     spawn_rate = float(value)
+                    parsed_options_dict[key] = spawn_rate
                 elif key == "host":
                     # Replace < > to guard against XSS
                     environment.host = str(request.form["host"]).replace("<", "").replace(">", "")
+                    parsed_options_dict[key] = environment.host
                 elif key == "user_classes":
                     # Set environment.parsed_options.user_classes to the selected user_classes
                     parsed_options_dict[key] = request.form.getlist("user_classes")

--- a/locust/web.py
+++ b/locust/web.py
@@ -228,6 +228,7 @@ class WebUI:
                         continue
                     try:
                         run_time = parse_timespan(value)
+                        parsed_options_dict[key] = run_time
                     except ValueError:
                         err_msg = "Valid run_time formats are : 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc."
                         logger.error(err_msg)


### PR DESCRIPTION
# Description
Hit a bug where, by using a custom `LoadTestShape` with `use_common_options` (as described [here](https://docs.locust.io/en/stable/custom-load-shape.html#reusing-command-line-parameters-in-custom-shapes)) noticed that the `run_time` set through the web UI is **not** persisted to `parsed_options` (which I'd be accessing from my custom shape class' `self.runner.environment.parsed_options.run_time`). This value was thus always grabbing the initial value set through config / cli options, which is pretty unexpected to me. I understand the intended use case here, as specified in the docs, is to "reuse command line parameters", but since the web UI still allows changing this value updates should IMO reflect everywhere they're referenced downstream.

# Changes
Persist this value to `parsed_options_dict` on the `swarm` endpoint handler. It'd make even more sense to me to do this for all values though, by changing the `elif` condition on current line 235 to `if`, not sure why it's done that way and why not all values are persisted/propagated.

Thanks!