### PR TITLE
Update User Classes in Distributed Mode

### DIFF
--- a/locust/env.py
+++ b/locust/env.py
@@ -198,6 +198,9 @@ class Environment:
         return self.web_ui
 
     def update_user_class(self, user_settings):
+        if isinstance(self.runner, MasterRunner):
+            self.runner.send_message("update_user_class", user_settings)
+
         user_class_name = user_settings.get("user_class_name")
         user_class = self.available_user_classes[user_class_name]
         user_tasks = self.available_user_tasks[user_class_name]

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1395,6 +1395,8 @@ class WorkerRunner(DistributedRunner):
                 self.reset_connection()
             elif msg.type == "heartbeat":
                 self.last_heartbeat_timestamp = time.time()
+            elif msg.type == "update_user_class":
+                self.environment.update_user_class(msg.data)
             elif msg.type in self.custom_messages:
                 logger.debug("Received %s message from master" % msg.type)
                 listener, concurrent = self.custom_messages[msg.type]

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -1351,3 +1351,32 @@ class TestModernWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertTrue(d("#root"))
         self.assertIn('"locustfile": "locust.py"', str(d))
         self.assertIn('"host": "http://localhost"', str(d))
+
+    def test_update_user(self):
+        class MyUser1(User):
+            @task
+            def my_task(self):
+                pass
+
+            @task
+            def my_task_2(self):
+                pass
+
+        class MyUser2(User):
+            @task
+            def my_task(self):
+                pass
+
+        self.environment.user_classes = [MyUser1, MyUser2]
+        self.environment.available_user_classes = {"User1": MyUser1, "User2": MyUser2}
+        self.environment.available_user_tasks = {"User1": MyUser1.tasks, "User2": MyUser2.tasks}
+
+        requests.post(
+            "http://127.0.0.1:%i/user" % self.web_port,
+            json={"user_class_name": "User1", "host": "http://localhost", "tasks": ["my_task_2"]},
+        )
+
+        self.assertEqual(
+            self.environment.available_user_classes["User1"].json(),
+            {"host": "http://localhost", "tasks": ["my_task_2"], "fixed_count": 0, "weight": 1},
+        )


### PR DESCRIPTION
### Proposal
When updating the user class, send a message to workers (if in distributed mode) to update their user classes as well

### Tested
In distributed mode
<img width="1511" alt="image" src="https://github.com/locustio/locust/assets/59211596/e3ed8ccc-45ab-4ebd-843e-804b7be913ae">

fixes #2657
