### PR TITLE
Small cleanup: mypy type-ignore and dev deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.7
+    rev: v0.3.7  # Pin the same version in the tox.ini file.
     hooks:
       # Run the linter.
       - id: ruff

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -566,19 +566,19 @@ if __name__ == "__main__":
             all_dispatched_users_ramp_down = list(users_dispatcher)
             dispatch_iteration_durations_ramp_down = users_dispatcher.dispatch_iteration_durations[:]
 
-            cpu_ramp_up = "{:3.3f}/{:3.3f}/{:3.3f}".format(
+            cpu_ramp_up = "{:3.3f}/{:3.3f}/{:3.3f}".format(  # noqa: UP032
                 1000 * statistics.mean(dispatch_iteration_durations_ramp_up),
                 1000 * min(dispatch_iteration_durations_ramp_up),
                 1000 * max(dispatch_iteration_durations_ramp_up),
-            )
-            cpu_ramp_down = "{:3.3f}/{:3.3f}/{:3.3f}".format(
+            )  # noqa: UP032
+            cpu_ramp_down = "{:3.3f}/{:3.3f}/{:3.3f}".format(  # noqa: UP032
                 1000 * statistics.mean(dispatch_iteration_durations_ramp_down),
                 1000 * min(dispatch_iteration_durations_ramp_down),
                 1000 * max(dispatch_iteration_durations_ramp_down),
             )
 
             print(
-                "{:04.0f}/{:04.0f} - {:,} workers - {:,} users - {} user classes - {:,} users/s - instantiate: {:.3f}ms - new_dispatch (ramp-up/ramp-down): {:.3f}ms/{:.3f}ms - cpu_ramp_up: {}ms - cpu_ramp_down: {}ms".format(
+                "{:04.0f}/{:04.0f} - {:,} workers - {:,} users - {} user classes - {:,} users/s - instantiate: {:.3f}ms - new_dispatch (ramp-up/ramp-down): {:.3f}ms/{:.3f}ms - cpu_ramp_up: {}ms - cpu_ramp_down: {}ms".format(  # noqa: UP032
                     case_index + 1,
                     case_count,
                     worker_count,

--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -100,8 +100,7 @@ class UsersDispatcher(Iterator):
         self._no_user_to_spawn = False
 
     def get_current_user_count(self) -> int:
-        # need to ignore type due to https://github.com/python/mypy/issues/1507
-        return sum(map(sum, map(dict.values, self._users_on_workers.values())))  # type: ignore
+        return sum(map(sum, map(dict.values, self._users_on_workers.values())))
 
     @property
     def dispatch_in_progress(self):
@@ -449,5 +448,4 @@ class UsersDispatcher(Iterator):
         The implementation was profiled and compared to other implementations such as dict-comprehensions
         and the one below is the most efficient.
         """
-        # type is ignored due to: https://github.com/python/mypy/issues/1507
-        return dict(zip(users_on_workers.keys(), map(dict.copy, users_on_workers.values())))  # type: ignore
+        return dict(zip(users_on_workers.keys(), map(dict.copy, users_on_workers.values())))

--- a/locust/rpc/protocol.py
+++ b/locust/rpc/protocol.py
@@ -5,7 +5,7 @@ import datetime
 import msgpack
 
 try:
-    from bson import ObjectId  # type: ignore
+    from bson import ObjectId
 except ImportError:
 
     class ObjectId:  # type: ignore

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -345,10 +345,10 @@ class Runner:
                 return
             elif self.shape_last_tick != current_tick:
                 if len(current_tick) == 2:
-                    user_count, spawn_rate = current_tick  # type: ignore
+                    user_count, spawn_rate = current_tick
                     user_classes = None
                 else:
-                    user_count, spawn_rate, user_classes = current_tick  # type: ignore
+                    user_count, spawn_rate, user_classes = current_tick
                 logger.info("Shape test updating to %d users at %.2f spawn rate" % (user_count, spawn_rate))
                 # TODO: This `self.start()` call is blocking until the ramp-up is completed. This can leads
                 #       to unexpected behaviours such as the one in the following example:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1453,7 +1453,7 @@ class WorkerRunner(DistributedRunner):
 
 
 def _format_user_classes_count_for_log(user_classes_count: dict[str, int]) -> str:
-    return "{} ({} total users)".format(
+    return "{} ({} total users)".format(  # noqa: UP032
         json.dumps(dict(sorted(user_classes_count.items(), key=itemgetter(0)))),
         sum(user_classes_count.values()),
     )

--- a/locust/test/mock_locustfile.py
+++ b/locust/test/mock_locustfile.py
@@ -1,9 +1,7 @@
 import os
 import random
 import time
-
 from contextlib import contextmanager
-
 
 MOCK_LOCUSTFILE_CONTENT = '''
 """This is a mock locust file for unit testing"""

--- a/locust/test/test_dispatch.py
+++ b/locust/test/test_dispatch.py
@@ -4129,7 +4129,7 @@ def _aggregate_dispatched_users(d: dict[str, dict[str, int]]) -> dict[str, int]:
 
 
 def _user_count(d: dict[str, dict[str, int]]) -> int:
-    return sum(map(sum, map(dict.values, d.values())))  # type: ignore
+    return sum(map(sum, map(dict.values, d.values())))
 
 
 def _user_count_on_worker(d: dict[str, dict[str, int]], worker_node_id: str) -> int:

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,8 @@ commands =
     python -m unittest -f locust.test.test_main
 
 [testenv:ruff]
-deps = ruff==0.3.0
+deps = ruff==0.3.7
+; Pin the same version in the .pre-commit-config.yaml file.
 commands = 
     ruff check .
     ruff format --check


### PR DESCRIPTION
1. Removing deprecated mypy "# type: ignore" comments.
2. Pinning the same version of ruff in .pre-commit-config.yaml and tox.ini files.
3. Ruff 0.3.7 compatibility.