### PR TITLE
Allow worker process to run with --run-time specified, just log a warning

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -433,8 +433,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
     if options.run_time:
         if options.worker:
-            logger.error("--run-time should be specified on the master node, and not on worker nodes")
-            sys.exit(1)
+            logger.info("--run-time specified for a worker node will be ignored.")
         try:
             options.run_time = parse_timespan(options.run_time)
         except ValueError:

--- a/locust/util/timespan.py
+++ b/locust/util/timespan.py
@@ -2,7 +2,7 @@ import re
 from datetime import timedelta
 
 
-def parse_timespan(time_str):
+def parse_timespan(time_str) -> int:
     """
     Parse a string representing a time span and return the number of seconds.
     Valid formats are: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.

--- a/locust/util/timespan.py
+++ b/locust/util/timespan.py
@@ -18,8 +18,7 @@ def parse_timespan(time_str) -> int:
     parts = timespan_regex.match(time_str)
     if not parts:
         raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
-    parts = parts.groupdict()
-    time_params = {name: int(value) for name, value in parts.items() if value}
+    time_params = {name: int(value) for name, value in parts.groupdict().items() if value}
     if not time_params:
         raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
     return int(timedelta(**time_params).total_seconds())


### PR DESCRIPTION
As discussed [here](https://github.com/locustio/locust/issues/2683)