### PR TITLE
refactor: replace deprecated utcfromtimestamp function

### DIFF
--- a/locust/html.py
+++ b/locust/html.py
@@ -39,10 +39,10 @@ def get_html_report(
     stats = environment.runner.stats
 
     start_ts = stats.start_time
-    start_time = datetime.datetime.utcfromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M:%S")
+    start_time = datetime.datetime.fromtimestamp(start_ts, tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
     if end_ts := stats.last_request_timestamp:
-        end_time = datetime.datetime.utcfromtimestamp(end_ts).strftime("%Y-%m-%d %H:%M:%S")
+        end_time = datetime.datetime.fromtimestamp(end_ts, tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     else:
         end_time = start_time
 


### PR DESCRIPTION
Replace deprecated datetime.datetime.utcfromtimestamp function with datetime.datetime.fromtimestamp.
See datetime.datetime.utcfromtimestamp [docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp):


> **Warning:** Because naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing a specific timestamp in UTC is by calling datetime.fromtimestamp(timestamp, tz=timezone.utc).

> Deprecated since version 3.12: Use [datetime.fromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) with [UTC](https://docs.python.org/3/library/datetime.html#datetime.UTC) instead.

It currently generates warning in Locust [CI](https://github.com/locustio/locust/actions/runs/8941881517/job/24563239499#step:9:152).