### PR TITLE
annotate return types of a few functions to enable more mypy check

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -335,7 +335,7 @@ class FastHttpUser(User):
 
     _callstack_regex = re.compile(r'  File "(\/.[^"]*)", line (\d*),(.*)')
 
-    def __init__(self, environment):
+    def __init__(self, environment) -> None:
         super().__init__(environment)
         if self.host is None:
             raise LocustError(

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -596,7 +596,7 @@ class WorkerNode:
 
 
 class WorkerNodes(MutableMapping):
-    def __init__(self):
+    def __init__(self) -> None:
         self._worker_nodes: dict[str, WorkerNode] = {}
 
     def get_by_state(self, state) -> list[WorkerNode]:
@@ -648,7 +648,7 @@ class MasterRunner(DistributedRunner):
     :class:`WorkerRunners <WorkerRunner>` will aggregated.
     """
 
-    def __init__(self, environment, master_bind_host, master_bind_port):
+    def __init__(self, environment, master_bind_host, master_bind_port) -> None:
         """
         :param environment: Environment instance
         :param master_bind_host: Host/interface to use for incoming worker connections

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,6 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy==1.9.0
+    mypy==1.10.0
     types-requests
 commands = mypy locust/


### PR DESCRIPTION
Before (mypy checks in CI):
```
mypy: commands[0]> mypy locust/
locust/stats.py:209: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/stats.py:210: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/runners.py:600: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/runners.py:661: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/runners.py:663: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/runners.py:681: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/contrib/fasthttp.py:345: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/main.py:94: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/test/test_runners.py:947: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```
After:
```
mypy: commands[0]> mypy locust/
locust/stats.py:209: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/stats.py:210: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/main.py:94: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
locust/test/test_runners.py:947: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```
The remaining 4 mypy notes requires more changes than just adding return types. (Fixing annotations inside functions.)