### PR TITLE
Update Stats History on HTML Report

### DIFF
--- a/locust/html.py
+++ b/locust/html.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from . import stats as stats_module
 from .runners import STATE_STOPPED, STATE_STOPPING, MasterRunner
-from .stats import sort_stats
+from .stats import sort_stats, update_stats_history
 from .user.inspectuser import get_ratio
 
 PERCENTILES_FOR_HTML_REPORT = [0.50, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0]
@@ -54,6 +54,7 @@ def get_html_report(
         {**exc, "nodes": ", ".join(exc["nodes"])} for exc in environment.runner.exceptions.values()
     ]
 
+    update_stats_history(environment.runner)
     history = stats.history
 
     static_js = []


### PR DESCRIPTION
### The Issue

Because of `HISTORY_STATS_INTERVAL_SEC`, we will only have history starting after 5 seconds of run time. Unlike `request_stats` in `web.py`, we rely on history to display the charts in the HTML report. This is why the dashboard shows the results correctly in the dashboard but not in the report

### Proposal

Expose a new function `update_stats_history` that can be called when generating the HTML report. This will ensure that the stats history list is up to date before returning the report

![image](https://github.com/locustio/locust/assets/59211596/42ad8c6d-a013-4cc2-9e90-d54f1815c7b5)

Fixes #2706 