### PR TITLE
Pin the headers to the top of the window

### DIFF
--- a/locust/webui/src/components/Table/Table.tsx
+++ b/locust/webui/src/components/Table/Table.tsx
@@ -47,7 +47,7 @@ function TableRowContent({ content, formatter, round, markdown }: ITableRowConte
     return <Markdown skipHtml={false}>{content as string}</Markdown>;
   }
 
-  return <>{content}</>;
+  return content;
 }
 
 export default function Table<Row extends Record<string, any> = Record<string, string | number>>({

--- a/locust/webui/src/components/Table/Table.tsx
+++ b/locust/webui/src/components/Table/Table.tsx
@@ -47,7 +47,7 @@ function TableRowContent({ content, formatter, round, markdown }: ITableRowConte
     return <Markdown skipHtml={false}>{content as string}</Markdown>;
   }
 
-  return content;
+  return <>{content}</>;
 }
 
 export default function Table<Row extends Record<string, any> = Record<string, string | number>>({
@@ -62,9 +62,21 @@ export default function Table<Row extends Record<string, any> = Record<string, s
   });
 
   return (
-    <TableContainer component={Paper}>
+    <TableContainer
+      component={Paper}
+      sx={{
+        overflowX: 'visible',
+      }}
+    >
       <MuiTable>
-        <TableHead>
+        <TableHead
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
+            backgroundColor: 'background.paper',
+          }}
+        >
           <TableRow>
             {structure.map(({ title, key }) => (
               <TableCell


### PR DESCRIPTION
# The issue

Currently when you execute a test with a large number of different endpoints the Table Head doesn't scroll when you scroll down, making the analysis and navigation of the HTML Report and the Statistics tab a pain.
closes #2688 


# Changes

- Applied sticky positioning to the TableHead to ensure it remains at the top of the viewport.

- Ensured the TableContainer allows the sticky positioning by setting overflow-X to visible.

# Testing Evidence
<details>
<summary> Statistics Tab </summary>

https://github.com/locustio/locust/assets/107027346/dba3f574-2ffe-46c9-b4d3-59da0c089625

</details>

<details>
<summary> HTML Report </summary>

https://github.com/locustio/locust/assets/107027346/b592dfbc-36e3-4694-a3e0-760b2645aaa9

</details>

