### PR TITLE
Ensure spawning_complete only happens once on workers

### DIFF
--- a/locust/event.py
+++ b/locust/event.py
@@ -162,11 +162,11 @@ class Events:
 
     spawning_complete: EventHook
     """
-    Fired when all simulated users has been spawned.
+    Fired when all simulated users has been spawned. The event is fired on master first, and then distributed to workers.
 
     Event arguments:
 
-    :param user_count: Number of users that were spawned
+    :param user_count: Number of users that were spawned (in total, not per-worker)
     """
 
     quitting: EventHook

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1284,6 +1284,7 @@ class WorkerRunner(DistributedRunner):
         self.spawn_users(user_classes_spawn_count)
         self.stop_users(user_classes_stop_count)
         self.spawning_complete(sum(self.user_classes_count.values()))
+        self.worker_state = STATE_RUNNING
 
     def heartbeat(self) -> NoReturn:
         while True:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1284,6 +1284,7 @@ class WorkerRunner(DistributedRunner):
         self.spawn_users(user_classes_spawn_count)
         self.stop_users(user_classes_stop_count)
         self.spawning_complete(sum(self.user_classes_count.values()))
+        self.update_state(STATE_RUNNING)
         self.worker_state = STATE_RUNNING
 
     def heartbeat(self) -> NoReturn:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -834,7 +834,10 @@ class MasterRunner(DistributedRunner):
         finally:
             timeout.cancel()
 
-        self.environment.events.spawning_complete.fire(user_count=sum(self.target_user_classes_count.values()))
+        user_count = sum(self.target_user_classes_count.values())
+        self.environment.events.spawning_complete.fire(user_count=user_count)
+        # notify workers so they can fire their own event
+        self.send_message("spawning_complete", data={"user_count": user_count})
         self.spawning_completed = True
 
         logger.info(f"{msg_prefix}: {_format_user_classes_count_for_log(self.reported_user_classes_count)}")
@@ -1110,6 +1113,7 @@ class MasterRunner(DistributedRunner):
                     logger.warning(f"Got spawning message from unknown worker {msg.node_id}. Asking worker to quit.")
                     self.server.send_to_client(Message("quit", None, msg.node_id))
             elif msg.type == "spawning_complete":
+                # a worker finished spawning (this happens multiple times during rampup)
                 self.clients[msg.node_id].state = STATE_RUNNING
                 self.clients[msg.node_id].user_classes_count = msg.data["user_classes_count"]
             elif msg.type == "quit":
@@ -1217,20 +1221,6 @@ class WorkerRunner(DistributedRunner):
         self.greenlet.spawn(self.heartbeat_timeout_checker).link_exception(greenlet_exception_handler)
         self.greenlet.spawn(self.stats_reporter).link_exception(greenlet_exception_handler)
 
-        # register listener for when all users have spawned, and report it to the master node
-        def on_spawning_complete(user_count: int) -> None:
-            assert user_count == sum(self.user_classes_count.values())
-            self.client.send(
-                Message(
-                    "spawning_complete",
-                    {"user_classes_count": self.user_classes_count, "user_count": self.user_count},
-                    self.client_id,
-                )
-            )
-            self.worker_state = STATE_RUNNING
-
-        self.environment.events.spawning_complete.add_listener(on_spawning_complete)
-
         # register listener that adds the current number of spawned users to the report that is sent to the master node
         def on_report_to_master(client_id: str, data: dict[str, Any]):
             data["user_classes_count"] = self.user_classes_count
@@ -1250,6 +1240,17 @@ class WorkerRunner(DistributedRunner):
             self.client.send(Message("exception", {"msg": str(exception), "traceback": formatted_tb}, self.client_id))
 
         self.environment.events.user_error.add_listener(on_user_error)
+
+    def spawning_complete(self, user_count):
+        assert user_count == sum(self.user_classes_count.values())
+        self.client.send(
+            Message(
+                "spawning_complete",
+                {"user_classes_count": self.user_classes_count, "user_count": self.user_count},
+                self.client_id,
+            )
+        )
+        self.worker_state = STATE_RUNNING
 
     def start(
         self, user_count: int, spawn_rate: float, wait: bool = False, user_classes: list[type[User]] | None = None
@@ -1282,8 +1283,7 @@ class WorkerRunner(DistributedRunner):
         # can be blocking because of the stop_timeout
         self.spawn_users(user_classes_spawn_count)
         self.stop_users(user_classes_stop_count)
-
-        self.environment.events.spawning_complete.fire(user_count=sum(self.user_classes_count.values()))
+        self.spawning_complete(sum(self.user_classes_count.values()))
 
     def heartbeat(self) -> NoReturn:
         while True:
@@ -1394,6 +1394,9 @@ class WorkerRunner(DistributedRunner):
                 self.last_heartbeat_timestamp = time.time()
             elif msg.type == "update_user_class":
                 self.environment.update_user_class(msg.data)
+            elif msg.type == "spawning_complete":
+                # master says we have finished spawning (happens only once during a normal rampup)
+                self.environment.events.spawning_complete.fire(user_count=msg.data["user_count"])
             elif msg.type in self.custom_messages:
                 logger.debug("Received %s message from master" % msg.type)
                 listener, concurrent = self.custom_messages[msg.type]

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -947,7 +947,7 @@ class TestMasterWorkerRunners(LocustTestCase):
                     name="/",
                     response_time=1337,
                     response_length=666,
-                    exception=AssertionError("Some strange characters \" {'foo':'bar'}"),
+                    exception=None,
                     context={},
                 )
 


### PR DESCRIPTION
Ever since 2.0 the behaviour has been really strange: spawning_complete _on workers_ was fired after every cycle instead of only once.

This restores the functionality by having the masters spawning_complete event send a message to workers. 

Technically a breaking change.