### PR TITLE
Upgrade Sphinx to latest version (7.3.7)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
-sphinx==4.3.2
-sphinx-rtd-theme==0.5.2
+sphinx==7.3.7
+sphinx-rtd-theme==2.0.0
 readthedocs-sphinx-search==0.3.2
 Sphinx-Substitution-Extensions==2020.9.30.0
 Pygments==2.16.1
-alabaster==0.7.13
+alabaster==0.7.16
 babel==2.13.0
-docutils==0.16
+docutils==0.20.1
 imagesize==1.4.1
 snowballstemmer==2.2.0
 sphinx-prompt==1.5.0
@@ -14,4 +14,4 @@ sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.10


### PR DESCRIPTION
Upgrade Sphinx to something current.

I skimmed through the Sphinx changelog from 4.3.2 to 7.3.7 and didn't find anything particular noteworthy that might require project changes. 

I also clicked around the docs build with the new versions, and things looked ok.

Doesn't look like I need to update anything else to get this merged, but if there is please let me know. 