### PR TITLE
Handle task weights

### DIFF
--- a/locust/user/inspectuser.py
+++ b/locust/user/inspectuser.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-from collections import defaultdict
 from json import dumps
 
 from .task import TaskSet
@@ -65,17 +64,14 @@ def get_ratio(user_classes: list[type[User]], user_spawned: dict[str, int], tota
 
 def _get_task_ratio(tasks, total, parent_ratio):
     parent_ratio = parent_ratio if total else 1.0
-    ratio = defaultdict(int)
-    for task in tasks:
-        ratio[task] += 1
-
-    ratio_percent = {t: r * parent_ratio / len(tasks) for t, r in ratio.items()}
+    total_weight = sum(tasks.values())
 
     task_dict = {}
-    for t, r in ratio_percent.items():
+    for task, weight in tasks.items():
+        r = parent_ratio * (weight / total_weight)
         d = {"ratio": r}
-        if inspect.isclass(t) and issubclass(t, TaskSet):
-            d["tasks"] = _get_task_ratio(t.tasks, total, r)
-        task_dict[t.__name__] = d
+        if inspect.isclass(task) and issubclass(task, TaskSet):
+            d["tasks"] = _get_task_ratio(task.tasks, total, r)
+        task_dict[task.__name__] = d
 
     return task_dict

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -121,8 +121,8 @@ def tag(*tags: str) -> Callable[[TaskT], TaskT]:
 
     def decorator_func(decorated):
         if hasattr(decorated, "tasks"):
-            # TODO Tasks should become a dict
-            decorated.tasks = list(map(tag(*tags), decorated.tasks))
+            tagged_tasks = map(tag(*tags), decorated.tasks.keys())
+            decorated.tasks = {task: weight for task, weight in zip(tagged_tasks, decorated.tasks.values())}
         else:
             if "locust_tag_set" not in decorated.__dict__:
                 decorated.locust_tag_set = set()

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -121,6 +121,7 @@ def tag(*tags: str) -> Callable[[TaskT], TaskT]:
 
     def decorator_func(decorated):
         if hasattr(decorated, "tasks"):
+            # TODO Tasks should become a dict
             decorated.tasks = list(map(tag(*tags), decorated.tasks))
         else:
             if "locust_tag_set" not in decorated.__dict__:
@@ -155,6 +156,8 @@ def get_tasks_from_base_classes(bases, class_dict) -> dict[Callable | TaskSet, i
                     new_tasks[task] = count
                 else:
                     new_tasks[task] = 1
+        else:
+            raise ValueError("The 'tasks' attribute can only be set to list or dict")
 
     for item in class_dict.values():
         if "locust_task_weight" in dir(item):
@@ -223,7 +226,7 @@ class TaskSet(metaclass=TaskSetMeta):
     will then continue in the first TaskSet).
     """
 
-    tasks: list[TaskSet | Callable] = []
+    tasks: dict[Callable | TaskSet, int | float] = []
     """
     Collection of python callables and/or TaskSet classes that the User(s) will run.
 

--- a/locust/user/task.py
+++ b/locust/user/task.py
@@ -32,7 +32,7 @@ LOCUST_STATE_RUNNING, LOCUST_STATE_WAITING, LOCUST_STATE_STOPPING = ["running", 
 
 @runtime_checkable
 class TaskHolder(Protocol[TaskT]):
-    tasks: list[TaskT]
+    tasks: dict[TaskT, int | float]
 
 
 @overload
@@ -226,7 +226,7 @@ class TaskSet(metaclass=TaskSetMeta):
     will then continue in the first TaskSet).
     """
 
-    tasks: dict[Callable | TaskSet, int | float] = []
+    tasks: dict[Callable | TaskSet, int | float] = dict()
     """
     Collection of python callables and/or TaskSet classes that the User(s) will run.
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -8,7 +8,6 @@ from locust.user.task import (
     LOCUST_STATE_RUNNING,
     LOCUST_STATE_STOPPING,
     LOCUST_STATE_WAITING,
-    DefaultTaskSet,
     TaskSet,
     get_tasks_from_base_classes,
 )
@@ -145,7 +144,7 @@ class User(metaclass=UserMeta):
     @final
     def run(self):
         self._state = LOCUST_STATE_RUNNING
-        self._taskset_instance = DefaultTaskSet(self)
+        self._taskset_instance = TaskSet(self)
         try:
             # run the TaskSet on_start method, if it has one
             try:

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -88,7 +88,7 @@ class User(metaclass=UserMeta):
     Method that returns the time between the execution of locust tasks in milliseconds
     """
 
-    tasks: list[TaskSet | Callable] = []
+    tasks: dict[TaskSet | Callable, int | float] = {}
     """
     Collection of python callables and/or TaskSet classes that the Locust user(s) will run.
 

--- a/locust/user/users.py
+++ b/locust/user/users.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import accumulate
+
 from locust.clients import HttpSession
 from locust.exception import LocustError, StopUser
 from locust.user.task import (
@@ -120,6 +122,8 @@ class User(metaclass=UserMeta):
         super().__init__()
         self.environment = environment
         """A reference to the :py:class:`Environment <locust.env.Environment>` in which this user is running"""
+        self.task_list = list(self.tasks.keys())
+        self.task_cum_weights = list(accumulate(self.tasks.values()))
         self._state: str | None = None
         self._greenlet: greenlet.Greenlet | None = None
         self._group: Group


### PR DESCRIPTION
Fixes #2651 

`tasks` attribute of `TaskSet`/`User` is now a mapping from tasks to their weights.
All other utility functions, like `tag`, `get_tasks_from_base_classes`, `filter_tasks_by_tags` take this into account in their recursion.

`gen_next_task` now uses `random.choices` to sample the tasks according to weights. Necessary cumulative weights are pre-computed in `__init__`.

The check of whether there are no tasks is now performed at `__init__`, instead of doing it on every call to `gen_next_task`.

Additionally, the `DefaultTaskSet` class is removed because it was only necessary to override two functions where `self.user` should be used instead of `self` when used directly inside a `User.` `User` now uses a `TaskSet` internally, and `TaskSet` now checks if it is being used by the `User` or nested in another `TaskSet` to make the correct choice.

Currently, this is a draft PR because only the backend itself is changed. Please let me know if the changes are understandable so far, and then I will proceed to change the tests and documentation to reflect this.