### PR TITLE
Optimize `SequentialTaskSet`

### DIFF
--- a/docs/tasksets.rst
+++ b/docs/tasksets.rst
@@ -148,7 +148,8 @@ SequentialTaskSet class
 =======================
 
 :py:class:`SequentialTaskSet <locust.SequentialTaskSet>` is a TaskSet whose tasks will be executed 
-in the order that they are declared. It is possible to nest SequentialTaskSets 
+in the order that they are declared. If the  *<Task : int>* dictionary is used, each task will be repeated by the amount
+given by the integer at the point of declaration. It is possible to nest SequentialTaskSets
 within a TaskSet and vice versa.
 
 For example, the following code will request URLs /1-/4 in order, and then repeat.
@@ -164,8 +165,9 @@ For example, the following code will request URLs /1-/4 in order, and then repea
             self.client.get("/1")
             self.client.get("/2")
         
-        # you can still use the tasks attribute to specify a list of tasks
+        # you can still use the tasks attribute to specify a list or dict of tasks
         tasks = [function_task]
+        # tasks = {function_task: 1}
         
         @task
         def last_task(self):

--- a/locust/test/test_sequential_taskset.py
+++ b/locust/test/test_sequential_taskset.py
@@ -34,6 +34,26 @@ class TestTaskSet(LocustTestCase):
         self.assertRaises(RescheduleTask, lambda: l.run())
         self.assertEqual([1, 2, 3], log)
 
+    def test_task_sequence_with_dictionary(self):
+        log = []
+
+        def t1(self):
+            log.append(1)
+
+        def t2(self):
+            log.append(2)
+
+        def t3(self):
+            log.append(3)
+            self.interrupt(reschedule=False)
+
+        class MyTaskSequence(SequentialTaskSet):
+            tasks = {t1: 3, t2: 2, t3: 1}
+
+        l = MyTaskSequence(self.locust)
+        self.assertRaises(RescheduleTask, lambda: l.run())
+        self.assertEqual([1, 1, 1, 2, 2, 3], log)
+
     def test_task_sequence_with_methods(self):
         log = []
 

--- a/locust/user/sequential_taskset.py
+++ b/locust/user/sequential_taskset.py
@@ -1,6 +1,6 @@
 from locust.exception import LocustError
 
-import logging
+from itertools import cycle
 
 from .task import TaskSet, TaskSetMeta
 
@@ -56,13 +56,11 @@ class SequentialTaskSet(TaskSet, metaclass=SequentialTaskSetMeta):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._task_index = 0
+        self._task_cycle = cycle(self.tasks)
 
     def get_next_task(self):
         if not self.tasks:
             raise LocustError(
                 "No tasks defined. Use the @task decorator or set the 'tasks' attribute of the SequentialTaskSet"
             )
-        task = self.tasks[self._task_index % len(self.tasks)]
-        self._task_index += 1
-        return task
+        return next(self._task_cycle)

--- a/locust/user/sequential_taskset.py
+++ b/locust/user/sequential_taskset.py
@@ -26,8 +26,12 @@ class SequentialTaskSetMeta(TaskSetMeta):
                 # compared to methods declared with @task
                 if isinstance(value, list):
                     new_tasks.extend(value)
+                elif isinstance(value, dict):
+                    for task, weight in value.items():
+                        for _ in range(weight):
+                            new_tasks.append(task)
                 else:
-                    raise ValueError("On SequentialTaskSet the task attribute can only be set to a list")
+                    raise ValueError("The 'tasks' attribute can only be set to list or dict")
 
             if "locust_task_weight" in dir(value):
                 # method decorated with @task


### PR DESCRIPTION
Fixes #2739 
Fixes #2740 

As explained in respective issues,`SequentialTaskSet` now allows task repetition if `tasks` is a dictionary with weight, and `itertools.cycle` is used to iterate over tasks in a cycle.

So far only a draft of backend changes.

Let me know if changes are OK and then I will update also tests and docs.