### PR TITLE
Add Logging to download_locustfile_from_master

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -6,7 +6,6 @@ from locust.rpc import Message, zmqrpc
 
 import ast
 import atexit
-import logging
 import os
 import platform
 import socket
@@ -29,7 +28,7 @@ import gevent
 import requests
 
 version = locust.__version__
-logger = logging.getLogger(__name__)
+
 
 DEFAULT_CONFIG_FILES = ("~/.locust.conf", "locust.conf", "pyproject.toml")
 
@@ -243,9 +242,9 @@ def download_locustfile_from_master(master_host: str, master_port: int) -> str:
             gevent.sleep(1)
 
     def log_warning():
-        gevent.sleep(0.1)
+        gevent.sleep(10)
         while not got_reply:
-            logger.warning("Waiting to connect to master to receive locustfile...")
+            sys.stderr.write("Waiting to connect to master to receive locustfile...\n")
             gevent.sleep(60)
 
     def wait_for_reply():

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -6,6 +6,7 @@ from locust.rpc import Message, zmqrpc
 
 import ast
 import atexit
+import logging
 import os
 import platform
 import socket
@@ -28,7 +29,7 @@ import gevent
 import requests
 
 version = locust.__version__
-
+logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_FILES = ("~/.locust.conf", "locust.conf", "pyproject.toml")
 
@@ -241,10 +242,18 @@ def download_locustfile_from_master(master_host: str, master_port: int) -> str:
             tempclient.send(Message("locustfile", None, client_id))
             gevent.sleep(1)
 
+    def log_warning():
+        gevent.sleep(0.1)
+        while not got_reply:
+            logger.warning("Waiting to connect to master to receive locustfile...")
+            gevent.sleep(60)
+
     def wait_for_reply():
         return tempclient.recv()
 
     gevent.spawn(ask_for_locustfile)
+    gevent.spawn(log_warning)
+
     try:
         # wait same time as for client_ready ack. not that it is really relevant...
         msg = gevent.spawn(wait_for_reply).get(timeout=runners.CONNECT_TIMEOUT * runners.CONNECT_RETRY_COUNT)


### PR DESCRIPTION
### Explanation

This one is a bit tricky, the argument parser happens before the log setup, so we don't have access to the same log levels as we would in the rest of the application. I also didn't want to have tons of messages logging for no reason, so I placed the messaging outside of the while loop. 

The problem with having the message outside of the while loop, is that we don't yet know if connecting to master failed or not (so it shouldn't _really_ be a warning). However, without logging being setup it seems we only have warning level logs. So the warning level is a bit of a lie, but it does at least provide some feedback that the master needs to be connected in order for the worker to start

Fixes #2748