### PR TITLE
Add JavaScript to MIME types for Windows Operating Systems

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import mimetypes
 import os.path
 from functools import wraps
 from html import escape
@@ -132,6 +133,8 @@ class WebUI:
         self.app.template_folder = BUILD_PATH
         self.app.static_folder = STATIC_PATH
         self.app.static_url_path = "/assets/"
+        # ensures static js files work on Windows
+        mimetypes.add_type("application/javascript", ".js")
 
         if self.web_login:
             self.login_manager = LoginManager()


### PR DESCRIPTION
# Proposal
Some of our users are encountering MIME type issues on Windows operating systems. According to a post on [StackOverflow](https://stackoverflow.com/questions/59355194/python-flask-error-failed-to-load-module-script-strict-mime-type-checking-i), this issue could be related to the operating system. This should fix the issue and ensure the correct MIME type is set.

**Note**: I am currently unable to reproduce this issue and therefore am unable to test that this solves the issue

Fixes #2753 #2633