### PR TITLE
Option to Skip Monkey Patching with LOCUST_SKIP_MONKEY_PATCH

### DIFF
--- a/docs/use-as-lib.rst
+++ b/docs/use-as-lib.rst
@@ -49,6 +49,11 @@ to view the stats, and to control the runner (e.g. start and stop load tests):
     env.create_web_ui()
     env.web_ui.greenlet.join()
 
+Skipping monkey patching
+========================
+
+Some packages such as boto3 may have incompatibility when using Locust as a library, where monkey patching is already applied. In this case monkey patching may be disabled by setting ``LOCUST_SKIP_MONKEY_PATCH=1`` as env variable.
+
 Full example
 ============
 

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -12,7 +12,8 @@ if os.getenv("LOCUST_PLAYWRIGHT", None):
 
 from gevent import monkey
 
-monkey.patch_all()
+if not os.getenv("LOCUST_SKIP_MONKEY_PATCH", None):
+    monkey.patch_all()
 
 from ._version import version as __version__
 from .contrib.fasthttp import FastHttpUser


### PR DESCRIPTION
### Proposal
1. Add a condition to the `__init__.py` that will skip monkey patching when `LOCUST_SKIP_MONKEY_PATCH` is set
2. Update `use-as-lib` to document disabling monkey patching

### Tested
Tested using Locust as a lib with boto3

Fixes #2250