### PR TITLE
code to enable customization of response time precision

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -271,6 +271,8 @@ The list of statistics parameters that can be modified is:
 +-------------------------------------------+--------------------------------------------------------------------------------------+
 | PERCENTILES_TO_STATISTICS                 | List of response time percentiles in the screen of statistics for UI                 |
 +-------------------------------------------+--------------------------------------------------------------------------------------+
+| RESPONSE_TIME_PRECISION                   | Response time precision. 1000 (default) for millisecond or 1000000 for microsecond.  |
++-------------------------------------------+--------------------------------------------------------------------------------------+
 
 Customization of additional static variables
 ============================================

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -33,7 +33,7 @@ class XmlRpcClient(ServerProxy):
                 request_meta["response"] = func(*args, **kwargs)
             except Fault as e:
                 request_meta["exception"] = e
-            request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
+            request_meta["response_time"] = time.perf_counter() - start_perf_counter
             self._request_event.fire(**request_meta)  # This is what makes the request actually get logged in Locust
             return request_meta["response"]
 

--- a/examples/grpc/grpc_user.py
+++ b/examples/grpc/grpc_user.py
@@ -37,7 +37,7 @@ class LocustInterceptor(ClientInterceptor):
         self.env.events.request.fire(
             request_type="grpc",
             name=call_details.method,
-            response_time=(time.perf_counter() - start_perf_counter) * 1000,
+            response_time=time.perf_counter() - start_perf_counter,
             response_length=response_length,
             response=response,
             context=None,

--- a/examples/manual_stats_reporting.py
+++ b/examples/manual_stats_reporting.py
@@ -33,7 +33,7 @@ def _manual_report(name):
         events.request.fire(
             request_type="manual",
             name=name,
-            response_time=(time() - start_time) * 1000,
+            response_time=time() - start_time,
             response_length=0,
             exception=e,
         )
@@ -42,7 +42,7 @@ def _manual_report(name):
         events.request.fire(
             request_type="manual",
             name=name,
-            response_time=(time() - start_time) * 1000,
+            response_time=time() - start_time,
             response_length=0,
             exception=None,
         )

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -190,7 +190,7 @@ class HttpSession(requests.Session):
         start_time = time.time()
         start_perf_counter = time.perf_counter()
         response = self._send_request_safe_mode(method, url, data=data, json=json, **kwargs)
-        response_time = (time.perf_counter() - start_perf_counter) * 1000
+        response_time = time.perf_counter() - start_perf_counter
 
         request_before_redirect = (response.history and response.history[0] or response).request
         url = request_before_redirect.url  # type: ignore

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -242,7 +242,7 @@ class FastHttpSession:
             try:
                 request_meta["response_length"] = len(response.content) if response.content else 0
             except HTTPParseError as e:
-                request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
+                request_meta["response_time"] = time.perf_counter() - start_perf_counter
                 request_meta["exception"] = e
                 self.environment.events.request.fire(**request_meta)
                 return response
@@ -250,7 +250,7 @@ class FastHttpSession:
         # Record the consumed time
         # Note: This is intentionally placed after we record the content_size above, since
         # we'll then trigger fetching of the body (unless stream=True)
-        request_meta["response_time"] = int((time.perf_counter() - start_perf_counter) * 1000)
+        request_meta["response_time"] = time.perf_counter() - start_perf_counter
 
         if catch_response:
             return ResponseContextManager(response, environment=self.environment, request_meta=request_meta)

--- a/locust/event.py
+++ b/locust/event.py
@@ -85,7 +85,7 @@ class EventHook:
         except Exception as e:
             request_meta["exception"] = e
         finally:
-            request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
+            request_meta["response_time"] = time.perf_counter() - start_perf_counter
             self.fire(**request_meta)
 
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -128,6 +128,11 @@ PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 
 PERCENTILES_TO_STATISTICS = [0.95, 0.99]
 PERCENTILES_TO_CHART = [0.95]
 
+"""
+Default response time precision is millisecond.
+Change this to 1,000,000 if needs microsecond precision
+"""
+RESPONSE_TIME_PRECISION = 1000
 
 class RequestStatsAdditionError(Exception):
     pass
@@ -230,7 +235,9 @@ class RequestStats:
     def start_time(self):
         return self.total.start_time
 
-    def log_request(self, method: str, name: str, response_time: int, content_length: int) -> None:
+    def log_request(self, method: str, name: str, response_time: float, content_length: int) -> None:
+        if response_time is not None:
+            response_time = int(response_time * RESPONSE_TIME_PRECISION)
         self.total.log(response_time, content_length)
         self.entries[(name, method)].log(response_time, content_length)
 

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -2430,10 +2430,10 @@ class TestMasterRunner(LocustRunnerTestCase):
             master = self.get_runner()
             server.mocked_send(Message("client_ready", __version__, "fake_client"))
             stats = RequestStats()
-            stats.log_request("GET", "/1", 100, 3546)
-            stats.log_request("GET", "/1", 800, 56743)
+            stats.log_request("GET", "/1", 0.1, 3546)
+            stats.log_request("GET", "/1", 0.8, 56743)
             stats2 = RequestStats()
-            stats2.log_request("GET", "/2", 700, 2201)
+            stats2.log_request("GET", "/2", 0.7, 2201)
             server.mocked_send(
                 Message(
                     "stats",
@@ -2465,11 +2465,11 @@ class TestMasterRunner(LocustRunnerTestCase):
             master = self.get_runner()
             server.mocked_send(Message("client_ready", __version__, "fake_client"))
             stats = RequestStats()
-            stats.log_request("GET", "/1", 100, 3546)
-            stats.log_request("GET", "/1", 800, 56743)
+            stats.log_request("GET", "/1", 0.1, 3546)
+            stats.log_request("GET", "/1", 0.8, 56743)
             stats.log_request("GET", "/1", None, 56743)
             stats2 = RequestStats()
-            stats2.log_request("GET", "/2", 700, 2201)
+            stats2.log_request("GET", "/2", 0.7, 2201)
             stats2.log_request("GET", "/2", None, 2201)
             stats3 = RequestStats()
             stats3.log_request("GET", "/3", None, 2201)
@@ -2521,8 +2521,8 @@ class TestMasterRunner(LocustRunnerTestCase):
                 mocked_time.return_value += 1.0234
                 server.mocked_send(Message("client_ready", __version__, "fake_client"))
                 stats = RequestStats()
-                stats.log_request("GET", "/1", 100, 3546)
-                stats.log_request("GET", "/1", 800, 56743)
+                stats.log_request("GET", "/1", 0.1, 3546)
+                stats.log_request("GET", "/1", 0.8, 56743)
                 server.mocked_send(
                     Message(
                         "stats",
@@ -2537,7 +2537,7 @@ class TestMasterRunner(LocustRunnerTestCase):
                 )
                 mocked_time.return_value += 1
                 stats2 = RequestStats()
-                stats2.log_request("GET", "/2", 400, 2201)
+                stats2.log_request("GET", "/2", 0.4, 2201)
                 server.mocked_send(
                     Message(
                         "stats",
@@ -2557,9 +2557,9 @@ class TestMasterRunner(LocustRunnerTestCase):
                 # let 10 second pass, do some more requests, send it to the master and make
                 # sure the current response time percentiles only accounts for these new requests
                 mocked_time.return_value += 10.10023
-                stats.log_request("GET", "/1", 20, 1)
-                stats.log_request("GET", "/1", 30, 1)
-                stats.log_request("GET", "/1", 3000, 1)
+                stats.log_request("GET", "/1", 0.02, 1)
+                stats.log_request("GET", "/1", 0.03, 1)
+                stats.log_request("GET", "/1", 0.003, 1)
                 server.mocked_send(
                     Message(
                         "stats",

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -46,7 +46,7 @@ class TestRequestStats(unittest.TestCase):
         self.stats = RequestStats()
 
         def log(response_time, size):
-            self.stats.log_request("GET", "test_entry", response_time, size)
+            self.stats.log_request("GET", "test_entry", response_time * 0.001, size)
 
         def log_error(exc):
             self.stats.log_error("GET", "test_entry", exc)
@@ -86,7 +86,7 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(s.median_response_time, 6099)
 
     def test_total_rps(self):
-        self.stats.log_request("GET", "other_endpoint", 1337, 1337)
+        self.stats.log_request("GET", "other_endpoint", 1.337, 1337)
         s2 = self.stats.entries[("other_endpoint", "GET")]
         s2.start_time = 2.0
         s2.last_request_timestamp = 6.0
@@ -327,7 +327,7 @@ class TestStatsPrinting(LocustTestCase):
                     3,
                 ),
             ]:
-                self.stats.log_request(method, name, i, 2000 + i)
+                self.stats.log_request(method, name, i * 0.001, 2000 + i)
                 if i % freq == 0:
                     self.stats.log_error(method, name, RuntimeError(f"{method} error"))
 
@@ -439,7 +439,7 @@ class TestCsvStats(LocustTestCase):
         gevent.sleep(10)
 
         for i in range(10):
-            self.runner.stats.log_request("GET", "/", 10, content_length=666)
+            self.runner.stats.log_request("GET", "/", 0.01, content_length=666)
 
         gevent.sleep(5)
 
@@ -519,7 +519,7 @@ class TestCsvStats(LocustTestCase):
 
             @task
             def t(self):
-                self.environment.runner.stats.log_request("GET", "/", 10, 10)
+                self.environment.runner.stats.log_request("GET", "/", 0.01, 10)
 
         environment = Environment(user_classes=[TestUser])
         stats_writer = StatsCSVFileWriter(environment, PERCENTILES_TO_REPORT, self.STATS_BASE_NAME, full_history=True)

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -123,7 +123,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code)
 
     def test_stats(self):
-        self.stats.log_request("GET", "/<html>", 120, 5612)
+        self.stats.log_request("GET", "/<html>", 0.12, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
 
@@ -139,14 +139,14 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(120, data["stats"][1]["avg_response_time"])
 
     def test_stats_cache(self):
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
         data = json.loads(response.text)
         self.assertEqual(2, len(data["stats"]))  # one entry plus Aggregated
 
         # add another entry
-        self.stats.log_request("GET", "/test2", 120, 5612)
+        self.stats.log_request("GET", "/test2", 0.12, 5612)
         data = json.loads(requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).text)
         self.assertEqual(2, len(data["stats"]))  # old value should be cached now
 
@@ -156,8 +156,8 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(3, len(data["stats"]))  # this should no longer be cached
 
     def test_stats_rounding(self):
-        self.stats.log_request("GET", "/test", 1.39764125, 2)
-        self.stats.log_request("GET", "/test", 999.9764125, 1000)
+        self.stats.log_request("GET", "/test", 0.00139764125, 2)
+        self.stats.log_request("GET", "/test", 0.9999764125, 1000)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
 
@@ -166,13 +166,13 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(1000, data["stats"][0]["max_response_time"])
 
     def test_request_stats_csv(self):
-        self.stats.log_request("GET", "/test2", 120, 5612)
+        self.stats.log_request("GET", "/test2", 0.12, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
         self._check_csv_headers(response.headers, "requests")
 
     def test_request_stats_full_history_csv_not_present(self):
-        self.stats.log_request("GET", "/test2", 120, 5612)
+        self.stats.log_request("GET", "/test2", 0.12, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests_full_history/csv" % self.web_port)
         self.assertEqual(404, response.status_code)
 
@@ -203,7 +203,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
 
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         self.stats.log_error("GET", "/", Exception("Error1337"))
 
         response = requests.get("http://127.0.0.1:%i/stats/reset" % self.web_port)
@@ -921,7 +921,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertNotIn("http://example.com", response.content.decode("utf-8"))
 
     def test_report_page(self):
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         r = requests.get("http://127.0.0.1:%i/stats/report" % self.web_port)
 
         d = pq(r.content.decode("utf-8"))
@@ -937,7 +937,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual(200, r.status_code)
 
     def test_report_download(self):
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         r = requests.get("http://127.0.0.1:%i/stats/report?download=1" % self.web_port)
 
         d = pq(r.content.decode("utf-8"))
@@ -948,7 +948,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
 
     def test_report_host(self):
         self.environment.host = "http://test.com"
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         r = requests.get("http://127.0.0.1:%i/stats/report" % self.web_port)
 
         d = pq(r.content.decode("utf-8"))
@@ -966,7 +966,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
 
         self.environment.host = None
         self.environment.user_classes = [MyUser]
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         r = requests.get("http://127.0.0.1:%i/stats/report" % self.web_port)
 
         d = pq(r.content.decode("utf-8"))
@@ -981,7 +981,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
             tb = e.__traceback__
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             self.runner.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
-        self.stats.log_request("GET", "/test", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.12, 5612)
         r = requests.get("http://127.0.0.1:%i/stats/report" % self.web_port)
 
         d = pq(r.content.decode("utf-8"))
@@ -1231,9 +1231,9 @@ class TestWebUIFullHistory(LocustTestCase, _HeaderCheckMixin):
         self.remove_file_if_exists(self.STATS_BASE_DIR)
 
     def test_request_stats_full_history_csv(self):
-        self.stats.log_request("GET", "/test", 1.39764125, 2)
-        self.stats.log_request("GET", "/test", 999.9764125, 1000)
-        self.stats.log_request("GET", "/test2", 120, 5612)
+        self.stats.log_request("GET", "/test", 0.00139764125, 2)
+        self.stats.log_request("GET", "/test", 0.9999764125, 1000)
+        self.stats.log_request("GET", "/test2", 0.12, 5612)
 
         greenlet = gevent.spawn(self.stats_csv_writer.stats_writer)
         gevent.sleep(0.01)


### PR DESCRIPTION
this is to enable the customization of response time prevision.

1. removed all hard coded * 1000, which assume milli-second 
2. added logic to handle precision in stats.py
3. adjusted all test code data
4. updated document