### PR TITLE
update github actions to get rid of deprecation warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
           - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39 }
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Update pip
@@ -36,7 +36,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('pyproject.toml') }}
@@ -49,7 +49,7 @@ jobs:
   lint_typecheck_test_webui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set Node.js 18.x
         uses: actions/setup-node@v3
         with:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' # PR build doesnt get proper version, so dont try to build it
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: docker/login-action@v1
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags') && github.repository_owner == 'locustio'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: echo "TAG=${GITHUB_REF#refs/*/}" | tee -a $GITHUB_ENV
@@ -136,11 +136,11 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags') && github.repository_owner == 'locustio'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -172,11 +172,11 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.repository_owner == 'locustio'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - run: git rev-parse HEAD^2 2>/dev/null >/dev/null || echo NOT_MERGE_COMMIT=1 | tee -a $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,22 +53,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: borales/actions-yarn@v3
+      - uses: borales/actions-yarn@v5
         with:
           cmd: webui:install
-      - uses: borales/actions-yarn@v3
+      - uses: borales/actions-yarn@v5
         with:
           cmd: webui:build
-      - uses: borales/actions-yarn@v3
+      - uses: borales/actions-yarn@v5
         with:
           cmd: webui:test
-      - uses: borales/actions-yarn@v3
+      - uses: borales/actions-yarn@v5
         with:
           cmd: webui:lint
-      - uses: borales/actions-yarn@v3
+      - uses: borales/actions-yarn@v5
         with:
           cmd: webui:type-check
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
@@ -43,6 +44,7 @@ jobs:
       - name: set full Python version in PY env var
         # See https://pre-commit.com/#github-actions-example
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        shell: bash
       - run: python -m pip install tox
       - run: python -m tox -e ${{ matrix.tox }}
 


### PR DESCRIPTION
update versions to get rid of:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

also includes `actions/setup-node@v3` and `borales/actions-yarn@v3`

with `actions/cache@v3` on windows image there would be an error, but the step wouldn't fail:
```
[Windows](https://github.com/mgor/locust/actions/runs/9692188762/job/26745040620#step:6:14)
Input required and not supplied: path
```

when updating to `actions/cache@v4` the step would also fail. to fix this the shell for the steps that redirects output to `$GITHUB_{OUTPUT,ENV}` was set to `bash`. since the default shell for windows runners is powershell, and `echo ... >> ...` isn't crossplatform compatible, and `bash` is available on the windows images.