### PR TITLE
dispatch benchmark test improvements

### DIFF
--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -50,6 +50,7 @@ exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", "--full-benchmark", action="store_true")
+    parser.add_argument("-i", "--include-fixed-users", action="store_true")
     parser.add_argument("-r", "--repeat", default=1, type=int)
     parser.add_argument("-s", "--save-output", action="store_true")
     args = parser.parse_args()
@@ -60,7 +61,8 @@ if __name__ == "__main__":
     user_count_cases = [10_000, 100_000, 1_000_000]
     number_of_user_classes_cases = [1, 30, 1000]
     spawn_rate_cases = [100, 10_000]
-    fixed_count_cases = [False, True]  # [0% fixed_count, 50% fixed_count]
+    fixed_count_cases = [False, True] if args.include_fixed_users else [False]
+    # [0% fixed_count users, 50% fixed_count users] if args.mixed_user_types else [0% fixed_count users]
     repeat_cases = list(range(1, args.repeat + 1))
 
     if not args.full_benchmark:
@@ -191,6 +193,7 @@ if __name__ == "__main__":
         table.align["User Classes"] = "l"
         table.align["Spawn Rate"] = "l"
         table.align["Fixed Users"] = "l"
+        table.align["Iteration"] = "c"
         table.align["Ramp-Up (avg/min/max) (ms)"] = "c"
         table.align["Ramp-Down (avg/min/max) (ms)"] = "c"
         table.add_rows(

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -9,6 +9,7 @@ from locust import User  # noqa: F401 It's used inside exec
 from locust.dispatch import UsersDispatcher
 from locust.runners import WorkerNode
 
+import argparse
 import itertools
 import statistics
 import time
@@ -60,12 +61,23 @@ exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--save-output", action="store_true")
+    parser.add_argument("-f", "--full-benchmark", action="store_true")
+    args = parser.parse_args()
+
     now = time.time()
 
     worker_count_cases = [10, 100, 1000]
     user_count_cases = [1000, 10_000, 100_000, 1_000_000]
     number_of_user_classes_cases = [1, 10, 100]
     spawn_rate_cases = [1, 100, 10_000]
+
+    if not args.full_benchmark:
+        worker_count_cases = [max(worker_count_cases)]
+        user_count_cases = [max(user_count_cases)]
+        number_of_user_classes_cases = [max(number_of_user_classes_cases)]
+        spawn_rate_cases = [max(spawn_rate_cases)]
 
     case_count = (
         len(worker_count_cases) * len(user_count_cases) * len(number_of_user_classes_cases) * len(spawn_rate_cases)
@@ -170,12 +182,11 @@ if __name__ == "__main__":
             ]
         )
         print()
-        print()
-        print()
         print(table)
 
-        with open(f"results-dispatch-benchmarks-{int(now)}.txt", "w") as file:
-            file.write(table.get_string())
+        if args.save_output:
+            with open(f"results-dispatch-benchmarks-{int(now)}.txt", "w") as file:
+                file.write(table.get_string())
 
-        with open(f"results-dispatch-benchmarks-{int(now)}.json", "w") as file:
-            file.write(table.get_json_string())
+            with open(f"results-dispatch-benchmarks-{int(now)}.json", "w") as file:
+                file.write(table.get_json_string())

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -31,31 +31,31 @@ WEIGHTS = [
 # fmt: on
 
 for i, x in enumerate(WEIGHTS):
-    exec(f"class User{i+1}(User): weight = {x}")
+    exec(f"class User{i}(User): weight = {x}")
 
 # Equivalent to:
 #
-# class User1(User):
+# class User0(User):
 #     weight = 5
 #
-# class User2(User):
+# class User1(User):
 #     weight = 55
 # .
 # .
 # .
-# class User100(User):
+# class User99(User):
 #     weight = 69
 
-exec("USER_CLASSES = [" + ",".join(f"User{i+1}" for i in range(len(WEIGHTS))) + "]")
+exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]")
 # Equivalent to:
 #
 # USER_CLASSES = [
+#     User0,
 #     User1,
-#     User2,
 #     .
 #     .
 #     .
-#     User100,
+#     User99,
 # ]
 
 
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 print(f"Skipping user_count = {user_count:,} - spawn_rate = {spawn_rate:,}")
                 continue
 
-            workers = [WorkerNode(str(i + 1)) for i in range(worker_count)]
+            workers = [WorkerNode(str(i)) for i in range(worker_count)]
 
             ts = time.perf_counter()
             users_dispatcher = UsersDispatcher(

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -95,26 +95,26 @@ if __name__ == "__main__":
 
             workers = [WorkerNode(str(i)) for i in range(worker_count)]
 
-            ts = time.perf_counter()
+            ts = time.process_time()
             users_dispatcher = UsersDispatcher(
                 worker_nodes=workers,
                 user_classes=USER_CLASSES[:number_of_user_classes],  # noqa: F821 (Undefined name `USER_CLASSES`) -> It's created inside "exec"
             )
-            instantiate_duration = time.perf_counter() - ts
+            instantiate_duration = time.process_time() - ts
 
             # Ramp-up
-            ts = time.perf_counter()
+            ts = time.process_time()
             users_dispatcher.new_dispatch(target_user_count=user_count, spawn_rate=spawn_rate)
-            new_dispatch_ramp_up_duration = time.perf_counter() - ts
+            new_dispatch_ramp_up_duration = time.process_time() - ts
             assert len(users_dispatcher.dispatch_iteration_durations) == 0
             users_dispatcher._wait_between_dispatch = 0
             all_dispatched_users_ramp_up = list(users_dispatcher)
             dispatch_iteration_durations_ramp_up = users_dispatcher.dispatch_iteration_durations[:]
 
             # Ramp-down
-            ts = time.perf_counter()
+            ts = time.process_time()
             users_dispatcher.new_dispatch(target_user_count=0, spawn_rate=spawn_rate)
-            new_dispatch_ramp_down_duration = time.perf_counter() - ts
+            new_dispatch_ramp_down_duration = time.process_time() - ts
             assert len(users_dispatcher.dispatch_iteration_durations) == 0
             users_dispatcher._wait_between_dispatch = 0
             all_dispatched_users_ramp_down = list(users_dispatcher)

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -5,7 +5,7 @@ for calculating the distribution of users on each worker. This benchmark is to b
 by people working on Locust's development.
 """
 
-from locust import User  # noqa: F401 It's used inside exec
+from locust import User
 from locust.dispatch import UsersDispatcher
 from locust.runners import WorkerNode
 
@@ -16,20 +16,9 @@ import time
 
 from prettytable import PrettyTable
 
-# fmt: off
-WEIGHTS = [
-     5, 55, 37,  2, 97, 41, 33, 19, 19, 34,
-    78, 76, 28, 62, 69,  5, 55, 37,  2, 97,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-     5, 55, 37,  2, 97, 41, 33, 19, 19, 34,
-    78, 76, 28, 62, 69,  5, 55, 37,  2, 97,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-    41, 33, 19, 19, 34, 78, 76, 28, 62, 69,
-]
-# fmt: on
+NUMBER_OF_USER_CLASSES: int = 1000
+USER_CLASSES: list[type[User]] = []
+WEIGHTS = list(range(1, NUMBER_OF_USER_CLASSES + 1))
 
 for i, x in enumerate(WEIGHTS):
     exec(f"class User{i}(User): weight = {x}")
@@ -44,8 +33,6 @@ for i, x in enumerate(WEIGHTS):
 # .
 # .
 # .
-# class User99(User):
-#     weight = 69
 
 exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]")
 # Equivalent to:
@@ -56,7 +43,6 @@ exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]
 #     .
 #     .
 #     .
-#     User99,
 # ]
 
 
@@ -70,8 +56,8 @@ if __name__ == "__main__":
 
     worker_count_cases = [10, 100, 1000]
     user_count_cases = [1000, 10_000, 100_000, 1_000_000]
-    number_of_user_classes_cases = [1, 10, 100]
-    spawn_rate_cases = [1, 100, 10_000]
+    number_of_user_classes_cases = [1, 10, 100, 1000]
+    spawn_rate_cases = [100, 10_000]
 
     if not args.full_benchmark:
         worker_count_cases = [max(worker_count_cases)]
@@ -89,16 +75,12 @@ if __name__ == "__main__":
         for case_index, (worker_count, user_count, number_of_user_classes, spawn_rate) in enumerate(
             itertools.product(worker_count_cases, user_count_cases, number_of_user_classes_cases, spawn_rate_cases)
         ):
-            if user_count / spawn_rate > 1000:
-                print(f"Skipping user_count = {user_count:,} - spawn_rate = {spawn_rate:,}")
-                continue
-
             workers = [WorkerNode(str(i)) for i in range(worker_count)]
 
             ts = time.process_time()
             users_dispatcher = UsersDispatcher(
                 worker_nodes=workers,
-                user_classes=USER_CLASSES[:number_of_user_classes],  # noqa: F821 (Undefined name `USER_CLASSES`) -> It's created inside "exec"
+                user_classes=USER_CLASSES[:number_of_user_classes],
             )
             instantiate_duration = time.process_time() - ts
 

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -1,11 +1,11 @@
 """
 This file contains a benchmark to validate the performance of Locust itself.
 More precisely, the performance of the `UsersDispatcher` class which is responsible
-for calculating the distribution of users on each workers. This benchmark is to be used
+for calculating the distribution of users on each worker. This benchmark is to be used
 by people working on Locust's development.
 """
 
-from locust import User
+from locust import User  # noqa: F401 It's used inside exec
 from locust.dispatch import UsersDispatcher
 from locust.runners import WorkerNode
 
@@ -62,10 +62,10 @@ exec("USER_CLASSES = [" + ",".join(f"User{i+1}" for i in range(len(WEIGHTS))) + 
 if __name__ == "__main__":
     now = time.time()
 
-    worker_count_cases = [10, 100, 500, 1000, 5000, 10_000, 15_000, 20_000]
-    user_count_cases = [10, 100, 1000, 10_000, 50_000, 100_000, 500_000]
-    number_of_user_classes_cases = [1, 10, 40, 60, 80, 100]
-    spawn_rate_cases = [1, 10, 100, 500, 1000, 2500, 5000, 10_000, 20_000, 25_000]
+    worker_count_cases = [10, 100, 1000]
+    user_count_cases = [1000, 10_000, 100_000, 1_000_000]
+    number_of_user_classes_cases = [1, 10, 100]
+    spawn_rate_cases = [1, 100, 10_000]
 
     case_count = (
         len(worker_count_cases) * len(user_count_cases) * len(number_of_user_classes_cases) * len(spawn_rate_cases)

--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -49,10 +49,15 @@ exec("USER_CLASSES = [" + ",".join(f"User{i}" for i in range(len(WEIGHTS))) + "]
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--full-benchmark", action="store_true")
-    parser.add_argument("-i", "--include-fixed-users", action="store_true")
-    parser.add_argument("-r", "--repeat", default=1, type=int)
-    parser.add_argument("-s", "--save-output", action="store_true")
+    parser.add_argument("-f", "--full-benchmark", action="store_true", help="run benchmark on full test matrix")
+    parser.add_argument(
+        "-i",
+        "--include-fixed-users",
+        action="store_true",
+        help="add test cases when 50 percent of users use User.fixed_count instead of User.weight",
+    )
+    parser.add_argument("-r", "--repeat", default=1, type=int, help="number of test cases with the same parameters")
+    parser.add_argument("-s", "--save-output", action="store_true", help="save test results to files")
     args = parser.parse_args()
 
     now = time.time()


### PR DESCRIPTION
Various improvements to the benchmark to make testing changes easier.

Main changes:
- Disable garbage collector during benchmark.
- Use time.process_time instead of time.perf_counter.
- Run only test case with the highest values by default. Run full test matrix with CL flag. 
- Add possibility to test both: fixed_count Users and weight Users.
- Add possibility to run test cases multiple time with the same arguments.
- Make saving result files optional.

>python benchmarks/dispatch.py --help
```
usage: dispatch.py [-h] [-f] [-i] [-r REPEAT] [-s]

options:
  -h, --help            show this help message and exit
  -f, --full-benchmark  run benchmark on full test matrix
  -i, --include-fixed-users
                        add test cases when 50 percent of users use User.fixed_count instead of User.weight
  -r REPEAT, --repeat REPEAT
                        number of test cases with the same parameters
  -s, --save-output     save test results to files
```
Sample output:
> python benchmarks/dispatch.py --repeat 3 -i
```
0001/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 97.862ms - new_dispatch (ramp-up/ramp-down): 12.023ms/18.046ms - cpu_ramp_up: 35.146/26.435/210.435ms - cpu_ramp_down: 17.677/16.491/21.115ms
0002/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 100.659ms - new_dispatch (ramp-up/ramp-down): 12.148ms/12.109ms - cpu_ramp_up: 36.371/19.666/224.432ms - cpu_ramp_down: 8.613/7.935/10.415ms
0003/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 74.954ms - new_dispatch (ramp-up/ramp-down): 11.812ms/13.974ms - cpu_ramp_up: 27.423/17.807/222.145ms - cpu_ramp_down: 8.601/7.928/14.957ms
0004/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 76.153ms - new_dispatch (ramp-up/ramp-down): 12.257ms/12.327ms - cpu_ramp_up: 25.409/17.397/191.678ms - cpu_ramp_down: 8.495/7.844/10.994ms
0005/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 76.443ms - new_dispatch (ramp-up/ramp-down): 12.252ms/12.080ms - cpu_ramp_up: 27.196/17.533/192.777ms - cpu_ramp_down: 8.860/8.057/13.826ms
0006/0006 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 76.852ms - new_dispatch (ramp-up/ramp-down): 12.895ms/12.093ms - cpu_ramp_up: 27.088/17.711/186.650ms - cpu_ramp_down: 8.363/7.826/13.615ms

+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| Workers | Users     | User Classes | Spawn Rate | Fixed Users | Iteration | Ramp-Up (avg/min/max) (ms) | Ramp-Down (avg/min/max) (ms) |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     1     |   35.146/26.435/210.435    |     17.677/16.491/21.115     |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     2     |   36.371/19.666/224.432    |      8.613/7.935/10.415      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     3     |   27.423/17.807/222.145    |      8.601/7.928/14.957      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     1     |   25.409/17.397/191.678    |      8.495/7.844/10.994      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     2     |   27.196/17.533/192.777    |      8.860/8.057/13.826      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     3     |   27.088/17.711/186.650    |      8.363/7.826/13.615      |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
```