### PR TITLE
Simplify fixed_count Users generation in UsersDispatcher._user_gen

### DIFF
--- a/locust/dispatch.py
+++ b/locust/dispatch.py
@@ -18,15 +18,6 @@ if TYPE_CHECKING:
     from locust.runners import WorkerNode
 
 
-# To profile line-by-line, uncomment the code below (i.e. `import line_profiler ...`) and
-# place `@profile` on the functions/methods you wish to profile. Then, in the unit test you are
-# running, use `from locust.dispatch import profile; profile.print_stats()` at the end of the unit test.
-# Placing it in a `finally` block is recommended.
-# import line_profiler
-#
-# profile = line_profiler.LineProfiler()
-
-
 def _kl_generator(users: list[tuple[type[User], float]]) -> Iterator[str | None]:
     """Generator based on Kullback-Leibler divergence
 


### PR DESCRIPTION
- simplify fixed_count Users generation in UsersDispatcher._user_gen
- minor _kl_generator improvements

Performance impact.
> python benchmarks/dispatch.py --repeat 5 --include-fixed-users

Branch:
```
0001/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 85.078ms - new_dispatch (ramp-up/ramp-down): 9.811ms/10.554ms - cpu_ramp_up: 28.760/21.637/164.883ms - cpu_ramp_down: 15.035/14.403/18.000ms
0002/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 86.416ms - new_dispatch (ramp-up/ramp-down): 10.846ms/10.935ms - cpu_ramp_up: 30.362/16.584/180.464ms - cpu_ramp_down: 7.042/6.700/9.677ms
0003/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.248ms - new_dispatch (ramp-up/ramp-down): 11.091ms/11.202ms - cpu_ramp_up: 23.607/15.694/182.486ms - cpu_ramp_down: 7.008/6.795/7.561ms
0004/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.911ms - new_dispatch (ramp-up/ramp-down): 11.363ms/11.015ms - cpu_ramp_up: 22.040/15.563/162.627ms - cpu_ramp_down: 7.206/6.905/10.022ms
0005/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.523ms - new_dispatch (ramp-up/ramp-down): 11.195ms/11.141ms - cpu_ramp_up: 22.718/15.751/160.470ms - cpu_ramp_down: 7.185/6.907/9.216ms
0006/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 76.760ms - new_dispatch (ramp-up/ramp-down): 11.239ms/11.097ms - cpu_ramp_up: 22.466/15.317/156.380ms - cpu_ramp_down: 7.579/7.161/12.646ms
0007/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 75.061ms - new_dispatch (ramp-up/ramp-down): 11.419ms/10.746ms - cpu_ramp_up: 23.106/15.112/189.741ms - cpu_ramp_down: 7.115/6.659/8.779ms
0008/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 76.720ms - new_dispatch (ramp-up/ramp-down): 11.458ms/11.087ms - cpu_ramp_up: 22.599/14.941/176.954ms - cpu_ramp_down: 7.458/6.918/11.218ms
0009/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 82.464ms - new_dispatch (ramp-up/ramp-down): 12.387ms/11.012ms - cpu_ramp_up: 25.070/15.467/186.743ms - cpu_ramp_down: 7.079/6.749/9.923ms
0010/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.731ms - new_dispatch (ramp-up/ramp-down): 11.202ms/11.114ms - cpu_ramp_up: 21.855/15.329/157.158ms - cpu_ramp_down: 7.175/6.821/11.927ms

+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| Workers | Users     | User Classes | Spawn Rate | Fixed Users | Iteration | Ramp-Up (avg/min/max) (ms) | Ramp-Down (avg/min/max) (ms) |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     1     |   28.760/21.637/164.883    |     15.035/14.403/18.000     |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     2     |   30.362/16.584/180.464    |      7.042/6.700/9.677       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     3     |   23.607/15.694/182.486    |      7.008/6.795/7.561       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     4     |   22.040/15.563/162.627    |      7.206/6.905/10.022      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     5     |   22.718/15.751/160.470    |      7.185/6.907/9.216       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     1     |   22.466/15.317/156.380    |      7.579/7.161/12.646      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     2     |   23.106/15.112/189.741    |      7.115/6.659/8.779       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     3     |   22.599/14.941/176.954    |      7.458/6.918/11.218      |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     4     |   25.070/15.467/186.743    |      7.079/6.749/9.923       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     5     |   21.855/15.329/157.158    |      7.175/6.821/11.927      |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
```
Master:
```
0001/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 75.528ms - new_dispatch (ramp-up/ramp-down): 9.553ms/10.452ms - cpu_ramp_up: 29.407/22.157/162.929ms - cpu_ramp_down: 15.183/14.334/16.468ms
0002/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 89.007ms - new_dispatch (ramp-up/ramp-down): 11.085ms/10.838ms - cpu_ramp_up: 30.008/17.511/178.876ms - cpu_ramp_down: 7.052/6.787/7.663ms
0003/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 74.069ms - new_dispatch (ramp-up/ramp-down): 11.185ms/10.865ms - cpu_ramp_up: 22.999/15.368/182.183ms - cpu_ramp_down: 7.092/6.752/7.832ms
0004/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 74.092ms - new_dispatch (ramp-up/ramp-down): 11.219ms/11.110ms - cpu_ramp_up: 21.769/15.464/160.748ms - cpu_ramp_down: 7.250/6.785/8.847ms
0005/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 73.615ms - new_dispatch (ramp-up/ramp-down): 11.588ms/11.077ms - cpu_ramp_up: 22.166/15.469/158.951ms - cpu_ramp_down: 7.080/6.816/7.582ms
0006/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 75.625ms - new_dispatch (ramp-up/ramp-down): 11.573ms/11.229ms - cpu_ramp_up: 22.240/15.041/158.717ms - cpu_ramp_down: 6.909/6.582/7.859ms
0007/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.724ms - new_dispatch (ramp-up/ramp-down): 11.216ms/11.135ms - cpu_ramp_up: 22.641/15.074/186.758ms - cpu_ramp_down: 6.940/6.657/7.793ms
0008/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 70.960ms - new_dispatch (ramp-up/ramp-down): 11.244ms/10.928ms - cpu_ramp_up: 22.043/14.842/175.701ms - cpu_ramp_down: 7.039/6.625/7.774ms
0009/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 73.015ms - new_dispatch (ramp-up/ramp-down): 11.274ms/10.966ms - cpu_ramp_up: 22.833/14.788/179.695ms - cpu_ramp_down: 6.963/6.698/7.672ms
0010/0010 - 1,000 workers - 1,000,000 users - 1000 user classes - 10,000 users/s - instantiate: 72.586ms - new_dispatch (ramp-up/ramp-down): 11.159ms/11.204ms - cpu_ramp_up: 21.533/15.026/157.305ms - cpu_ramp_down: 7.265/7.055/7.995ms

+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| Workers | Users     | User Classes | Spawn Rate | Fixed Users | Iteration | Ramp-Up (avg/min/max) (ms) | Ramp-Down (avg/min/max) (ms) |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     1     |   29.407/22.157/162.929    |     15.183/14.334/16.468     |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     2     |   30.008/17.511/178.876    |      7.052/6.787/7.663       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     3     |   22.999/15.368/182.183    |      7.092/6.752/7.832       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     4     |   21.769/15.464/160.748    |      7.250/6.785/8.847       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 0%          |     5     |   22.166/15.469/158.951    |      7.080/6.816/7.582       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     1     |   22.240/15.041/158.717    |      6.909/6.582/7.859       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     2     |   22.641/15.074/186.758    |      6.940/6.657/7.793       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     3     |   22.043/14.842/175.701    |      7.039/6.625/7.774       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     4     |   22.833/14.788/179.695    |      6.963/6.698/7.672       |
| 1,000   | 1,000,000 | 1000         | 10,000     | 50%         |     5     |   21.533/15.026/157.305    |      7.265/7.055/7.995       |
+---------+-----------+--------------+------------+-------------+-----------+----------------------------+------------------------------+
```