### PR TITLE
CLI argument for selecting `UserClasses` to run

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -208,7 +208,7 @@ Usage: locust [options]
 
     locust -f my_test.py -H https://www.example.com
 
-    locust --headless -u 100 -t 20m --processes 4 --run-users MyHttpUser AnotherUser
+    locust --headless -u 100 -t 20m --processes 4 --user-classes MyHttpUser AnotherUser
 
 See documentation for more details, including how to set options using a file or environment variables: https://docs.locust.io/en/stable/configuration.html""",
     )
@@ -421,7 +421,7 @@ def setup_parser_arguments(parser):
         env_var="LOCUST_CONFIG_USERS",
     )
     parser.add_argument(
-        "--run-users",
+        "--user-classes",
         nargs="*",
         help="List of User classes to be used (available User classes can be listed with --list). LOCUST_USER_CLASSES environment variable can also be used to specify User classes. Default is to use all available User classes",
         default=os.environ.get("LOCUST_USER_CLASSES", "").split(),
@@ -749,7 +749,7 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
     )
 
     user_classes_group = parser.add_argument_group("User classes")
-    user_classes_group.add_argument("user_classes", nargs="*")
+    user_classes_group.add_argument("old_user_classes", nargs="*")
 
 
 def get_parser(default_config_files=DEFAULT_CONFIG_FILES) -> LocustArgumentParser:

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -201,14 +201,14 @@ def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG
         usage=configargparse.SUPPRESS,
         description=textwrap.dedent(
             """
-Usage: locust [options] [UserClass ...]
+Usage: locust [options]
         """
         ),
         epilog="""Examples:
 
     locust -f my_test.py -H https://www.example.com
 
-    locust --headless -u 100 -t 20m --processes 4 MyHttpUser AnotherUser
+    locust --headless -u 100 -t 20m --processes 4 --run-users MyHttpUser AnotherUser
 
 See documentation for more details, including how to set options using a file or environment variables: https://docs.locust.io/en/stable/configuration.html""",
     )
@@ -419,6 +419,12 @@ def setup_parser_arguments(parser):
         nargs="*",
         help="User configuration as a JSON string or file. A list of arguments or an Array of JSON configuration may be provided",
         env_var="LOCUST_CONFIG_USERS",
+    )
+    parser.add_argument(
+        "--run-users",
+        nargs="*",
+        help="List of User classes to be used (available User classes can be listed with --list). LOCUST_USER_CLASSES environment variable can also be used to specify User classes. Default is to use all available User classes",
+        default=os.environ.get("LOCUST_USER_CLASSES", "").split(),
     )
 
     web_ui_group = parser.add_argument_group("Web UI options")
@@ -743,13 +749,7 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
     )
 
     user_classes_group = parser.add_argument_group("User classes")
-    user_classes_group.add_argument(
-        "user_classes",
-        nargs="*",
-        metavar="<UserClass1 UserClass2>",
-        help="At the end of the command line, you can list User classes to be used (available User classes can be listed with --list). LOCUST_USER_CLASSES environment variable can also be used to specify User classes. Default is to use all available User classes",
-        default=os.environ.get("LOCUST_USER_CLASSES", "").split(),
-    )
+    user_classes_group.add_argument("user_classes", nargs="*")
 
 
 def get_parser(default_config_files=DEFAULT_CONFIG_FILES) -> LocustArgumentParser:

--- a/locust/main.py
+++ b/locust/main.py
@@ -316,7 +316,7 @@ def main():
             logger.error(f"Unknown User(s): {', '.join(missing)}\n")
             sys.exit(1)
         else:
-            names |= set(options.run_users) & set(user_classes.keys())
+            names |= set(options.run_users)
     if options.user_classes:
         # TODO deprecate in future release
         # warnings.warn(
@@ -327,7 +327,7 @@ def main():
             logger.error(f"Unknown User(s): {', '.join(missing)}\n")
             sys.exit(1)
         else:
-            names |= set(options.user_classes) & set(user_classes.keys())
+            names |= set(options.user_classes)
     if not (options.run_users or options.user_classes):
         names = set(user_classes.keys())
     user_classes = [user_classes[n] for n in names]

--- a/locust/main.py
+++ b/locust/main.py
@@ -13,7 +13,6 @@ import signal
 import sys
 import time
 import traceback
-import warnings
 
 import gevent
 
@@ -319,10 +318,11 @@ def main():
         else:
             names |= set(options.run_users) & set(user_classes.keys())
     if options.user_classes:
-        warnings.warn(
-            "Specifying users at the end of the command is deprecated. Use --run-users parameter instead",
-            DeprecationWarning,
-        )
+        # TODO deprecate in future release
+        # warnings.warn(
+        #    "Specifying users at the end of the command is deprecated. Use --run-users parameter instead",
+        #     DeprecationWarning,
+        # )
         if missing := set(options.user_classes) - set(user_classes.keys()):
             logger.error(f"Unknown User(s): {', '.join(missing)}\n")
             sys.exit(1)

--- a/locust/main.py
+++ b/locust/main.py
@@ -311,24 +311,24 @@ def main():
 
     # make sure specified User exists
     names = set()
-    if options.run_users:
-        if missing := set(options.run_users) - set(user_classes.keys()):
-            logger.error(f"Unknown User(s): {', '.join(missing)}\n")
-            sys.exit(1)
-        else:
-            names |= set(options.run_users)
     if options.user_classes:
-        # TODO deprecate in future release
-        # warnings.warn(
-        #    "Specifying users at the end of the command is deprecated. Use --run-users parameter instead",
-        #     DeprecationWarning,
-        # )
         if missing := set(options.user_classes) - set(user_classes.keys()):
             logger.error(f"Unknown User(s): {', '.join(missing)}\n")
             sys.exit(1)
         else:
             names |= set(options.user_classes)
-    if not (options.run_users or options.user_classes):
+    if options.old_user_classes:
+        # TODO deprecate in future release
+        # warnings.warn(
+        #    "Specifying users at the end of the command is deprecated. Use --run-users parameter instead",
+        #     DeprecationWarning,
+        # )
+        if missing := set(options.old_user_classes) - set(user_classes.keys()):
+            logger.error(f"Unknown User(s): {', '.join(missing)}\n")
+            sys.exit(1)
+        else:
+            names |= set(options.old_user_classes)
+    if not (options.old_user_classes or options.user_classes):
         names = set(user_classes.keys())
     user_classes = [user_classes[n] for n in names]
 

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -166,9 +166,8 @@ class TestLoadLocustfile(LocustTestCase):
             textwrap.dedent(
                 """
             host = localhost  # With "="
-            u 100             # Short form
-            spawn-rate 5      # long form
-                              # boolean
+            users 100
+            spawn-rate 5
             headless
             # (for some reason an inline comment makes boolean values fail in configargparse nowadays)
         """

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1087,7 +1087,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                         "5",
                         "-r",
                         "10",
-                        "--run-users",
+                        "--user-classes",
                         "User2",
                         "User3",
                     ]
@@ -2203,6 +2203,7 @@ class AnyUser(HttpUser):
                     "4",
                     "-L",
                     "DEBUG",
+                    "--user-classes",
                     "UserThatDoesntExist",
                 ],
                 stdout=PIPE,

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -75,7 +75,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             timeout=5,
             text=True,
         ).strip()
-        self.assertTrue(output.startswith("Usage: locust [options] [UserClass"))
+        self.assertTrue(output.startswith("Usage: locust [options]"))
         self.assertIn("Common options:", output)
         self.assertIn("-f <filename>, --locustfile <filename>", output)
         self.assertIn("Logging options:", output)
@@ -1087,6 +1087,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                         "5",
                         "-r",
                         "10",
+                        "--run-users",
                         "User2",
                         "User3",
                     ]

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -111,6 +111,7 @@ class TestArgumentParser(LocustTestCase):
                 "--reset-stats",
                 "--stop-timeout",
                 "5",
+                "--user-classes",
                 "MyUserClass",
             ]
         )
@@ -140,7 +141,7 @@ class TestArgumentParser(LocustTestCase):
         self.assertEqual("5m", options.run_time)
         self.assertTrue(options.reset_stats)
         self.assertEqual("5", options.stop_timeout)
-        self.assertEqual(["MyUserClass"], options.run_users)
+        self.assertEqual(["MyUserClass"], options.user_classes)
         # check default arg
         self.assertEqual(8089, options.web_port)
 
@@ -167,6 +168,7 @@ class TestArgumentParser(LocustTestCase):
                     "--reset-stats",
                     "--stop-timeout",
                     "5",
+                    "--user-classes",
                     "MyUserClass",
                 ]
             )

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -140,7 +140,7 @@ class TestArgumentParser(LocustTestCase):
         self.assertEqual("5m", options.run_time)
         self.assertTrue(options.reset_stats)
         self.assertEqual("5", options.stop_timeout)
-        self.assertEqual(["MyUserClass"], options.user_classes)
+        self.assertEqual(["MyUserClass"], options.run_users)
         # check default arg
         self.assertEqual(8089, options.web_port)
 


### PR DESCRIPTION
Fixes #2745 

Argument parser now has an argument `--run-users` that is a list of UserClasses to choose.
Old version (simply listing classes without an arg) is still supported, even in the same call, but issues a warning that this method is deprecated