### PR TITLE
Add Exporter as an Option for Locust Stats

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -156,7 +156,7 @@ A full example can be seen `in the auth example <https://github.com/locustio/loc
 Exporting Stats to InfluxDB
 ===========================
 
-You may wish to have more contorl over how the stats are aggregated and displayed. With the `--exporter` flag, Locust will
+You may wish to have more control over how the stats are aggregated and displayed. With the `--exporter` flag, Locust will
 export the stats to InfluxDB. Simply set the environment variables `INFLUXDB_URL`, `INFLUXDB_URL`, and `INFLUXDB_ORG` for your
 InfluxDB instance. For more on InfluxDB, see their `docs <https://docs.influxdata.com/influxdb/v2/>`.
 

--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -153,6 +153,14 @@ authentication to the app should be granted.
 A full example can be seen `in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth.py>`_.
 
 
+Exporting Stats to InfluxDB
+===========================
+
+You may wish to have more contorl over how the stats are aggregated and displayed. With the `--exporter` flag, Locust will
+export the stats to InfluxDB. Simply set the environment variables `INFLUXDB_URL`, `INFLUXDB_URL`, and `INFLUXDB_ORG` for your
+InfluxDB instance. For more on InfluxDB, see their `docs <https://docs.influxdata.com/influxdb/v2/>`.
+
+
 Run a background greenlet
 =========================
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -672,6 +672,12 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
         action="store_true",
         help="Prints the final stats in JSON format to stdout. Useful for parsing the results in other programs/scripts. Use together with --headless and --skip-log for an output only with the json data.",
     )
+    stats_group.add_argument(
+        "--exporter",
+        default=False,
+        action="store_true",
+        help="Exports Locust stats to Influx",
+    )
 
     log_group = parser.add_argument_group("Logging options")
     log_group.add_argument(

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -676,6 +676,7 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
         "--exporter",
         default=False,
         action="store_true",
+        env_var="LOCUST_EXPORTER",
         help="Exports Locust stats to Influx",
     )
 

--- a/locust/env.py
+++ b/locust/env.py
@@ -8,7 +8,7 @@ from configargparse import Namespace
 from .dispatch import UsersDispatcher
 from .event import Events
 from .exception import RunnerAlreadyExistsError
-from .exporter import LocustExporter
+from .exporter import InfluxExporter
 from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
 from .shape import LoadTestShape
 from .stats import RequestStats, StatsCSV
@@ -70,7 +70,7 @@ class Environment:
         """If set, only tasks that are tagged by tags in this list will be executed. Leave this as None to use the one from parsed_options"""
         self.exclude_tags = exclude_tags
         """If set, only tasks that aren't tagged by tags in this list will be executed. Leave this as None to use the one from parsed_options"""
-        self.exporter = LocustExporter(self) if use_exporter else None
+        self.exporter = InfluxExporter(self) if use_exporter else None
         """Reference to LocustExporter instance for use with influxDB"""
         self.stats = RequestStats()
         """Reference to RequestStats instance"""

--- a/locust/env.py
+++ b/locust/env.py
@@ -8,6 +8,7 @@ from configargparse import Namespace
 from .dispatch import UsersDispatcher
 from .event import Events
 from .exception import RunnerAlreadyExistsError
+from .exporter import LocustExporter
 from .runners import LocalRunner, MasterRunner, Runner, WorkerRunner
 from .shape import LoadTestShape
 from .stats import RequestStats, StatsCSV
@@ -37,6 +38,7 @@ class Environment:
         available_shape_classes: dict[str, LoadTestShape] | None = None,
         available_user_tasks: dict[str, list[TaskSet | Callable]] | None = None,
         dispatcher_class: type[UsersDispatcher] = UsersDispatcher,
+        use_exporter: bool = False,
     ):
         self.runner: Runner | None = None
         """Reference to the :class:`Runner <locust.runners.Runner>` instance"""
@@ -68,6 +70,8 @@ class Environment:
         """If set, only tasks that are tagged by tags in this list will be executed. Leave this as None to use the one from parsed_options"""
         self.exclude_tags = exclude_tags
         """If set, only tasks that aren't tagged by tags in this list will be executed. Leave this as None to use the one from parsed_options"""
+        self.exporter = LocustExporter(self) if use_exporter else None
+        """Reference to LocustExporter instance for use with influxDB"""
         self.stats = RequestStats()
         """Reference to RequestStats instance"""
         self.host = host

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -10,9 +10,9 @@ import requests
 from .exception import CatchResponseError
 from .runners import MasterRunner, WorkerRunner
 
-INFLUXDB_URL = os.getenv("INFLUXDB_URL")
-INFLUXDB_TOKEN = os.getenv("INFLUXDB_TOKEN")
-INFLUXDB_ORG = os.getenv("INFLUXDB_ORG")
+INFLUXDB_URL = "http://localhost:8086"
+INFLUXDB_TOKEN = "k42NZXHkEvaB_uVASlLCEUCVFizHGVSlChDXU_MlOG-Ig-sGTOajgg2rK_6icr3mCJlt9d-ur8qVn2dFnooDCA=="
+INFLUXDB_ORG = "andrewbaldwin44"
 
 
 class InfluxExporter:
@@ -47,7 +47,7 @@ class InfluxExporter:
 
     def _create_bucket(self):
         buckets_api = self._BucketsApi(self._client)
-        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M")
+        current_time = datetime.now().strftime("%Y-%m-%d_%H:%M")
         bucket_name = f"locust_test_{current_time}"
 
         try:

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -1,0 +1,139 @@
+import atexit
+import csv
+import os
+import sys
+from datetime import datetime
+
+import gevent
+import requests
+from influxdb_client import BucketsApi, InfluxDBClient
+from influxdb_client.client.write_api import SYNCHRONOUS
+
+from .exception import CatchResponseError
+from .runners import MasterRunner, WorkerRunner
+
+INFLUXDB_URL = os.getenv("INFLUXDB_URL")
+INFLUXDB_URL = os.getenv("INFLUXDB_URL")
+INFLUXDB_ORG = os.getenv("INFLUXDB_ORG")
+
+
+class LocustExporter:
+    def __init__(self, environment):
+        if not INFLUXDB_URL or not INFLUXDB_URL or not INFLUXDB_ORG:
+            sys.stderr.write(
+                "Locust was set to export stats but INFLUXDB_URL, INFLUXDB_URL, or INFLUXDB_ORG were not set as env variables. Please ensure the variables are set or remove the exporter flag.\n"
+            )
+            sys.exit(1)
+
+        self._client = InfluxDBClient(
+            url=INFLUXDB_URL,
+            token=INFLUXDB_URL,
+            org=INFLUXDB_ORG,
+        )
+        self.stat_entries = {}
+        self._points = []
+        self._environment = environment
+        self._environment.events.request.add_listener(self.on_request)
+        self._environment.events.test_start.add_listener(self.on_test_start)
+        self._environment.events.test_stop.add_listener(self.on_test_stop)
+        self._write_api = self._client.write_api(write_options=SYNCHRONOUS)
+        self._query_api = self._client.query_api()
+
+        self._greenlets = []
+
+        atexit.register(self.on_exit)
+
+    def _create_bucket(self):
+        buckets_api = BucketsApi(self._client)
+        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M")
+        bucket_name = f"locust_test_{current_time}"
+
+        try:
+            bucket = buckets_api.create_bucket(bucket_name=bucket_name)
+            return bucket.name
+        except Exception as e:
+            print(e)
+            sys.stderr.write(
+                "Could not create InfluxDB bucket. Please ensure the INFLUXDB_URL has access to create new buckets.\n"
+            )
+            sys.exit(1)
+
+    def _queue_point(self, measurement, tags={}, fields={}):
+        point = {"measurement": measurement, "tags": tags, "fields": fields, "time": datetime.utcnow().isoformat()}
+        self._points.append(point)
+
+    def _write_points(self):
+        while True:
+            # Copy and clear queue so only new points are sent each cycle
+            points = self._points.copy()
+            self._points.clear()
+
+            if points:
+                self._write_api.write(record=points, bucket=self._bucket)
+
+            gevent.sleep(0.5)
+
+    def _log_user_count(self):
+        while True:
+            user_count = self._environment.runner.user_count
+
+            self._queue_point(
+                "user_count",
+                fields={"user_count": user_count},
+            )
+
+            gevent.sleep(2)
+
+    def on_exit(self):
+        for greenlet in self._greenlets:
+            greenlet.kill()
+
+    def register(self, stat_entries):
+        self.stat_entries = stat_entries
+
+    def on_test_start(self, environment):
+        self._bucket = self._create_bucket()
+
+        if environment.runner and not isinstance(environment.runner, WorkerRunner):
+            self._greenlets.append(gevent.spawn(self._log_user_count))
+
+        self._greenlets.append(gevent.spawn(self._write_points))
+
+    def on_test_stop(self, environment):
+        self.on_exit()
+
+    def on_request(
+        self,
+        request_type,
+        name,
+        response_time,
+        response_length,
+        exception,
+        context,
+        start_time=None,
+        url=None,
+        **kwargs,
+    ):
+        measurement = "request_failure" if exception else "request_success"
+
+        fields = {
+            "response_time": response_time,
+            "content_length": response_length,
+        }
+
+        if exception:
+            if isinstance(exception, CatchResponseError):
+                fields["exception"] = str(exception)
+            else:
+                try:
+                    fields["exception"] = repr(exception)
+                except AttributeError:
+                    fields["exception"] = f"{exception.__class__} (and it has no string representation)"
+        else:
+            fields["exception"] = None
+
+        self._queue_point(
+            measurement,
+            tags={"name": name, "method": request_type},
+            fields=fields,
+        )

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -13,13 +13,13 @@ from .exception import CatchResponseError
 from .runners import MasterRunner, WorkerRunner
 
 INFLUXDB_URL = os.getenv("INFLUXDB_URL")
-INFLUXDB_URL = os.getenv("INFLUXDB_URL")
+INFLUXDB_TOKEN = os.getenv("INFLUXDB_TOKEN")
 INFLUXDB_ORG = os.getenv("INFLUXDB_ORG")
 
 
-class LocustExporter:
+class InfluxExporter:
     def __init__(self, environment):
-        if not INFLUXDB_URL or not INFLUXDB_URL or not INFLUXDB_ORG:
+        if not INFLUXDB_URL or not INFLUXDB_TOKEN or not INFLUXDB_ORG:
             sys.stderr.write(
                 "Locust was set to export stats but INFLUXDB_URL, INFLUXDB_URL, or INFLUXDB_ORG were not set as env variables. Please ensure the variables are set or remove the exporter flag.\n"
             )
@@ -27,7 +27,7 @@ class LocustExporter:
 
         self._client = InfluxDBClient(
             url=INFLUXDB_URL,
-            token=INFLUXDB_URL,
+            token=INFLUXDB_TOKEN,
             org=INFLUXDB_ORG,
         )
         self.stat_entries = {}

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -121,7 +121,11 @@ class InfluxExporter:
             "content_length": response_length,
         }
 
+        success = True
+
         if exception:
+            success = False
+
             if isinstance(exception, CatchResponseError):
                 fields["exception"] = str(exception)
             else:
@@ -134,6 +138,6 @@ class InfluxExporter:
 
         self._queue_point(
             "request",
-            tags={"name": name, "method": request_type},
+            tags={"name": name, "method": request_type, "success": success},
             fields=fields,
         )

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -116,8 +116,6 @@ class InfluxExporter:
         url=None,
         **kwargs,
     ):
-        measurement = "request_failure" if exception else "request_success"
-
         fields = {
             "response_time": response_time,
             "content_length": response_length,
@@ -135,7 +133,7 @@ class InfluxExporter:
             fields["exception"] = None
 
         self._queue_point(
-            measurement,
+            "request",
             tags={"name": name, "method": request_type},
             fields=fields,
         )

--- a/locust/exporter.py
+++ b/locust/exporter.py
@@ -6,8 +6,6 @@ from datetime import datetime
 
 import gevent
 import requests
-from influxdb_client import BucketsApi, InfluxDBClient
-from influxdb_client.client.write_api import SYNCHRONOUS
 
 from .exception import CatchResponseError
 from .runners import MasterRunner, WorkerRunner
@@ -25,11 +23,15 @@ class InfluxExporter:
             )
             sys.exit(1)
 
+        from influxdb_client import BucketsApi, InfluxDBClient
+        from influxdb_client.client.write_api import SYNCHRONOUS
+
         self._client = InfluxDBClient(
             url=INFLUXDB_URL,
             token=INFLUXDB_TOKEN,
             org=INFLUXDB_ORG,
         )
+        self._BucketsApi = BucketsApi
         self.stat_entries = {}
         self._points = []
         self._environment = environment
@@ -44,7 +46,7 @@ class InfluxExporter:
         atexit.register(self.on_exit)
 
     def _create_bucket(self):
-        buckets_api = BucketsApi(self._client)
+        buckets_api = self._BucketsApi(self._client)
         current_time = datetime.now().strftime("%Y-%m-%d_%H-%M")
         bucket_name = f"locust_test_{current_time}"
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -62,6 +62,7 @@ def create_environment(
     available_user_classes=None,
     available_shape_classes=None,
     available_user_tasks=None,
+    use_exporter=False,
 ):
     """
     Create an Environment instance from options
@@ -77,6 +78,7 @@ def create_environment(
         available_user_classes=available_user_classes,
         available_shape_classes=available_shape_classes,
         available_user_tasks=available_user_tasks,
+        use_exporter=use_exporter,
     )
 
 
@@ -351,6 +353,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         available_user_classes=available_user_classes,
         available_shape_classes=available_shape_classes,
         available_user_tasks=available_user_tasks,
+        use_exporter=options.exporter,
     )
 
     if options.config_users:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ version_tuple = __version_tuple__
 """
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.9,<4.0"
 
 gevent = ">=22.10.2"
 flask = ">=2.0.0"
@@ -131,6 +131,7 @@ pre-commit = "^3.7.1"
 ruff = "0.3.7"
 tox = "^4.16.0"
 twine = "^5.1.1"
+influxdb-client = "^1.44.0"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
### Proposal
1. Add a new module `LocustExporter`, which will export stats to a given InfluxDB instance
2. Add a new flag `--exporter`, which will export the stats when active
3. Add documentation to explain the usage