### PR TITLE
Correctly set version from Poetry in published builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: echo "TAG=${GITHUB_REF#refs/*/}" | tee -a $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip poetry
+          python -m poetry config virtualenvs.create false
+          python -m poetry self add "poetry-dynamic-versioning[plugin]"
+      - run: echo "TAG=$(poetry version -s)" | tee -a $GITHUB_ENV
       - run: echo "BRANCH=$(git branch -a --contains ${{ env.TAG }} | grep -v HEAD | cut -d '/' -f3)" | tee -a $GITHUB_ENV
       - uses: docker/login-action@v1
         with:
@@ -172,7 +177,7 @@ jobs:
         run: |
           python -m poetry build
           ./rename-wheel.sh
-          echo "TAG=${GITHUB_REF#refs/*/}" | tee -a $GITHUB_ENV
+          echo "TAG=$(poetry version -s)" | tee -a $GITHUB_ENV
       - name: Publish tagged version to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ format-jinja = """
 {%- if distance == 0 -%}
 {{ serialize_pep440(base) }}
 {%- else -%}
-{{ serialize_pep440(base, dev=distance) }}
+{{ serialize_pep440(bump_version(base), dev=distance) }}
 {%- endif -%}
 """
 


### PR DESCRIPTION
## Updating Versioning in Publication Steps

Updates publication-specific build logic to correctly generate tag numbers

### Major
- Utilise `poetry` version number in steps which generate tags for publication
- Always bump the `patch` version number when creating candidate dev build numbers

### Minor
- Allow Pull-Request builds to verify the Docker build (removal of `setuptools_scm`)
