### PR TITLE
Fix Extend Webui Example

### DIFF
--- a/examples/web_ui_cache_stats.py
+++ b/examples/web_ui_cache_stats.py
@@ -112,8 +112,6 @@ def locust_init(environment, **kwargs):
             """
             # ensure the template_args are up to date before using them
             environment.web_ui.update_template_args()
-            # set the static paths to use the modern ui
-            environment.web_ui.set_static_modern_ui()
 
             return render_template(
                 "index.html",


### PR DESCRIPTION
### Proposal

After removing the legacy webui, we no longer have to set the static assets for the modern ui. This change should be reflected in the example