### PR TITLE
Provide warning for local installs where yarn is not present

### DIFF
--- a/pre_build.py
+++ b/pre_build.py
@@ -1,8 +1,13 @@
 import os
 import subprocess
+from shutil import which
+from sys import exit
 
 
 def build() -> None:
+    if which("yarn") is None:
+        print("Locust requires the yarn binary to be available in this shell to build the web front-end.\nSee: https://docs.locust.io/en/stable/developing-locust.html#making-changes-to-locust-s-web-ui")
+        exit(1)
     if os.environ.get("SKIP_PRE_BUILD", "") == "true":
         print("Skipping front end build...")
         return

--- a/pre_build.py
+++ b/pre_build.py
@@ -5,14 +5,17 @@ from sys import exit
 
 
 def build() -> None:
-    if which("yarn") is None:
-        print("Locust requires the yarn binary to be available in this shell to build the web front-end.\nSee: https://docs.locust.io/en/stable/developing-locust.html#making-changes-to-locust-s-web-ui")
-        exit(1)
     if os.environ.get("SKIP_PRE_BUILD", "") == "true":
         print("Skipping front end build...")
         return
+    if which("yarn") is None:
+        print(
+            "Locust requires the yarn binary to be available in this shell to build the web front-end.\nSee: https://docs.locust.io/en/stable/developing-locust.html#making-changes-to-locust-s-web-ui"
+        )
+        exit(1)
     print("Building front end...")
-    subprocess.run(["make", "frontend_build"])
+    subprocess.run(["yarn", "webui:install"])
+    subprocess.run(["yarn", "webui:build"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Alter prebuild script to avoid `make` and check for `yarn`

This PR makes the pre-build script perform the same steps that the `make` command for building the project does, and provides the same error code where `yarn` is not present.

We try to avoid using `shell=True` and so need to split the command up

![image](https://github.com/locustio/locust/assets/82032454/a0a58ebc-cae2-48c2-8bd3-b214a62bab7f)
