### PR TITLE
Fix tests on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Windows, python: '3.12', os: windows-latest, tox: fail_fast_test_main}
-          # - {name: Mac, python: '3.12', os: macos-latest, tox: fail_fast_test_main}
-          - { name: "ruff", python: "3.11", os: ubuntu-latest, tox: "ruff" }
-          - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy" }
+          - {name: Windows, python: '3.12', os: windows-latest, tox: fail_fast_test_main, skip_pre_build: "true" }
+          # - {name: Mac, python: '3.12', os: macos-latest, tox: fail_fast_test_main, skip_pre_build: "false" }
+          - { name: "ruff", python: "3.11", os: ubuntu-latest, tox: "ruff", skip_pre_build: "false" }
+          - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy", skip_pre_build: "false" }
           # run some integration tests and abort immediately if they fail, for faster feedback
-          - { name: "Linux", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main }
-          - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312 }
-          - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
-          - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
-          - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39 }
+          - { name: "Linux", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main, skip_pre_build: "false" }
+          - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312, skip_pre_build: "false" }
+          - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311, skip_pre_build: "false" }
+          - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310, skip_pre_build: "false" }
+          - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39, skip_pre_build: "false" }
 
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Install poetry plugin
         run: python -m poetry self add "poetry-dynamic-versioning[plugin]"
       # Install test dependencies (tox) to the root (non-package install)
-      - name: Install dependencies
+      - name: Install test dependencies
         run: |
           python -m poetry install --no-root --only test
       - name: set full Python version in PY env var
@@ -60,11 +60,23 @@ jobs:
       - name: Install Yarn
         run: npm install -g yarn
       # Build and install the package if it's Windows, to service shell-based tests
-      - if: ${{ matrix.os }} == "windows-latest"
+      - name: Install binary on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        env:
+          SKIP_PRE_BUILD: true
+        # Make `locust` available on the Windows shell by installing it with `pip`
+        # before running tests which invoke it in the `cmd` prompt
         run: |
           python -m poetry build
-          pip install --find-links=dist locust
-      - run: python -m poetry run tox -e ${{ matrix.tox }}
+          python -m poetry self add "poetry-plugin-export"
+          python -m poetry export --without-hashes --format=requirements.txt > requirements.txt
+          pip install -r requirements.txt
+          pip install poetry-core>=1.0.0
+          pip install locust --find-links=dist
+      - name: Run tox tests
+        env:
+          SKIP_PRE_BUILD: ${{ matrix.skip_pre_build }}
+        run: python -m poetry run tox -e ${{ matrix.tox }}
 
   lint_typecheck_test_webui:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ release: build
 	twine upload dist/*
 
 setup_docs_dependencies:
-	poetry install --with docs
+	SKIP_PRE_BUILD=true poetry install --with docs
 
 build_docs: setup_docs_dependencies
 	sphinx-build -b html docs/ docs/_build/

--- a/docs/developing-locust.rst
+++ b/docs/developing-locust.rst
@@ -11,19 +11,22 @@ Install Locust for development
 
 Fork Locust on `GitHub <https://github.com/locustio/locust/>`_ and then run
 
+.. note::
+    To build the Locust web UI, you must have `node` and `yarn` installed - see the *Making changes to Locust's Web UI* section below
+
 .. code-block:: sh
 
     # clone the repo
     $ git clone git://github.com/<YourName>/locust.git
 
     # install the poetry build system
-    $ pip3 install poetry 
+    $ python -m pip install poetry 
 
     # install the dynamic versioning plugin for poetry
-    $ pip3 -m poetry self add "poetry-dynamic-versioning[plugin]"
+    $ python -m poetry self add "poetry-dynamic-versioning[plugin]"
 
     # perform an editable install of the "locust" package
-    $ pip3 -m poetry install --with dev
+    $ python -m poetry install --with dev,test
 
 Now the ``locust`` command will run *your* code with no need for reinstalling after making changes.
 
@@ -40,8 +43,7 @@ We use `tox <https://tox.readthedocs.io/en/stable/>`_ to automate tests across m
 
 .. code-block:: console
 
-    $ pip3 install tox
-    $ tox
+    $ python -m poetry run tox
     ...
     py39: install_deps> python -I -m pip install cryptography mock pyquery retry
     py39: commands[0]> python3 -m pip install .
@@ -53,7 +55,7 @@ To only run a specific suite or specific test you can call `pytest <https://docs
 
 .. code-block:: console
 
-    $ pytest locust/test/test_main.py::DistributedIntegrationTests::test_distributed_tags
+    $ python -m pytest locust/test/test_main.py::DistributedIntegrationTests::test_distributed_tags
 
 Formatting and linting
 ======================
@@ -62,15 +64,14 @@ Locust uses `ruff <https://github.com/astral-sh/ruff/>`_ for formatting and lint
 
 .. code-block:: console
 
-    $ pip3 install ruff
-    $ python -m ruff --fix <file_or_folder_to_be_formatted>
-    $ python -m ruff format <file_or_folder_to_be_formatted>
+    $ python -m poetry run ruff --fix <file_or_folder_to_be_formatted>
+    $ python -m poetry run ruff format <file_or_folder_to_be_formatted>
 
 You can validate the whole project using tox:
 
 .. code-block:: console
 
-    $ tox -e ruff
+    $ python -m poetry run tox -e ruff
     ruff: install_deps> python -I -m pip install ruff==0.1.13
     ruff: commands[0]> ruff check .
     ruff: commands[1]> ruff format --check
@@ -87,7 +88,7 @@ The documentation source is in the `docs/ <https://github.com/locustio/locust/tr
 
     .. code-block:: console
 
-        $ pip3 -m poetry install --with docs
+        $ python -m poetry install --with docs
 
 #. Build the documentation locally:
 

--- a/docs/developing-locust.rst
+++ b/docs/developing-locust.rst
@@ -23,10 +23,10 @@ Fork Locust on `GitHub <https://github.com/locustio/locust/>`_ and then run
     $ python -m pip install poetry 
 
     # install the dynamic versioning plugin for poetry
-    $ python -m poetry self add "poetry-dynamic-versioning[plugin]"
+    $ poetry self add "poetry-dynamic-versioning[plugin]"
 
     # perform an editable install of the "locust" package
-    $ python -m poetry install --with dev,test
+    $ poetry install --with dev,test
 
 Now the ``locust`` command will run *your* code with no need for reinstalling after making changes.
 
@@ -43,7 +43,7 @@ We use `tox <https://tox.readthedocs.io/en/stable/>`_ to automate tests across m
 
 .. code-block:: console
 
-    $ python -m poetry run tox
+    $ poetry run tox
     ...
     py39: install_deps> python -I -m pip install cryptography mock pyquery retry
     py39: commands[0]> python3 -m pip install .
@@ -55,7 +55,7 @@ To only run a specific suite or specific test you can call `pytest <https://docs
 
 .. code-block:: console
 
-    $ python -m pytest locust/test/test_main.py::DistributedIntegrationTests::test_distributed_tags
+    $ pytest locust/test/test_main.py::DistributedIntegrationTests::test_distributed_tags
 
 Formatting and linting
 ======================
@@ -64,14 +64,14 @@ Locust uses `ruff <https://github.com/astral-sh/ruff/>`_ for formatting and lint
 
 .. code-block:: console
 
-    $ python -m poetry run ruff --fix <file_or_folder_to_be_formatted>
-    $ python -m poetry run ruff format <file_or_folder_to_be_formatted>
+    $ poetry run ruff --fix <file_or_folder_to_be_formatted>
+    $ poetry run ruff format <file_or_folder_to_be_formatted>
 
 You can validate the whole project using tox:
 
 .. code-block:: console
 
-    $ python -m poetry run tox -e ruff
+    $ poetry run tox -e ruff
     ruff: install_deps> python -I -m pip install ruff==0.1.13
     ruff: commands[0]> ruff check .
     ruff: commands[1]> ruff format --check
@@ -88,7 +88,7 @@ The documentation source is in the `docs/ <https://github.com/locustio/locust/tr
 
     .. code-block:: console
 
-        $ python -m poetry install --with docs
+        $ poetry install --with docs
 
 #. Build the documentation locally:
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ commands =
 commands = 
     poetry install --with test
     poetry run python -m unittest -f locust.test.test_main
-setenv =
-    SKIP_PRE_BUILD = true
+pass_env =
+    SKIP_PRE_BUILD
 
 [testenv:ruff]
 ; Pin the same version in the .pre-commit-config.yaml file.


### PR DESCRIPTION
## Ensuring Windows test runs use the correct version

Updates the GH Action tests for Windows/Linux, aiming to produce predictable failures of tests in controlled scenarios (i.e. using the correct Windows package).

Would recommend trying this out though, I still think there's some weird behaviour of some of these process-based tests, where the Windows vs. Linux tests do not operate or fail identically, perhaps this is intended.

I suspect this can be fixed more cleanly by sorting the `venv` mess in the pipeline and having the windows GH Action runner be in the correct, activated `venv` instead of doing this, so will raise a separate issue for that.

Addresses https://github.com/locustio/locust/issues/2796

Some testing of the breaking changes submitted in the issue by @andrewbaldwin44 
- Pass https://github.com/mquinnfd/locust/actions/runs/9889338165
- Fail https://github.com/mquinnfd/locust/actions/runs/9889352748
- Fail https://github.com/mquinnfd/locust/actions/runs/9889369296
- Pass https://github.com/mquinnfd/locust/actions/runs/9889376225

![image](https://github.com/locustio/locust/assets/82032454/be620577-d99d-4235-bd0c-9b24f2e6b95d)

### Major
- Update the Windows-only step to create and install a binary version of the package, to use in the `tox`-based tests
- Add GH Actions matrix test value to allow front end build skipping for certain envs
- Pass the front end build skip env var to `tox` for fail fast tests

### Minor
- Updated steps in Developing Locust docs to correctly invoke `python`, not `pip3`
- Updated Developing Locust docs to be more consistent