### PR TITLE
Avoid deadlock in gevent/urllib3 connection pool (fixes occasional worker heartbeat timeouts)

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -10,10 +10,16 @@ if os.getenv("LOCUST_PLAYWRIGHT", None):
         # dont show a massive callstack if trio is not installed
         os._exit(1)
 
-from gevent import monkey
-
 if not os.getenv("LOCUST_SKIP_MONKEY_PATCH", None):
+    from gevent import monkey, queue
+
     monkey.patch_all()
+
+    if not os.getenv("LOCUST_SKIP_URLLIB3_PATCH", None):
+        import urllib3
+
+        urllib3.connectionpool.ConnectionPool.QueueCls = queue.LifoQueue
+        # https://github.com/locustio/locust/issues/2812
 
 from ._version import version as __version__
 from .contrib.fasthttp import FastHttpUser


### PR DESCRIPTION
Fixes #2812
I tested it only with the newest versions of locust and its dependencies.

Currently, I don't know use cases of `os.getenv("LOCUST_SKIP_URLLIB3_PATCH", None)`.
However, this PR touches implementation details of urllib3 and gevent, so I want to provide possibility to opt-out.
(For example, it may fail with future release of urllib3.)

PR is based on this [answer](https://github.com/gevent/gevent/issues/1957#issuecomment-1902063299).