### PR TITLE
Update poetry windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,42 +14,56 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Windows, python: '3.12', os: windows-latest, tox: fail_fast_test_main, skip_pre_build: "true" }
-          # - {name: Mac, python: '3.12', os: macos-latest, tox: fail_fast_test_main, skip_pre_build: "false" }
-          - { name: "ruff", python: "3.11", os: ubuntu-latest, tox: "ruff", skip_pre_build: "false" }
-          - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy", skip_pre_build: "false" }
+          - {name: Windows, python: '3.12', os: windows-latest, tox: fail_fast_test_main }
+          # - {name: Mac, python: '3.12', os: macos-latest, tox: fail_fast_test_main }
+          - { name: "ruff", python: "3.11", os: ubuntu-latest, tox: "ruff" }
+          - { name: "mypy", python: "3.10", os: ubuntu-latest, tox: "mypy" }
           # run some integration tests and abort immediately if they fail, for faster feedback
-          - { name: "Linux", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main, skip_pre_build: "false" }
-          - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312, skip_pre_build: "false" }
-          - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311, skip_pre_build: "false" }
-          - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310, skip_pre_build: "false" }
-          - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39, skip_pre_build: "false" }
+          - { name: "Linux", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main }
+          - { name: "3.12", python: "3.12", os: ubuntu-latest, tox: py312 }
+          - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
+          - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
+          - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39 }
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Set up Python and virtual environment
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Install poetry
+      - name: Make venv
+        run: |
+          python -m venv .venv
+      - name: Activate the virtualenv
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          .venv\Scripts\activate
+      - name: Activate the virtualenv
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          source .venv/bin/activate
+      # Set up poetry and cache for dependencies
+      - name: install poetry
         run: |
           python -m pip install poetry
-      - name: Configure poetry
-        run: |
-          python -m poetry config virtualenvs.in-project true
+          poetry config virtualenvs.create false
+          poetry self add "poetry-dynamic-versioning[plugin]"
       - name: Cache the virtualenv
         uses: actions/cache@v3
         with:
-          path: ./.venv
+          path: .venv
           key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-      - name: Install poetry plugin
-        run: python -m poetry self add "poetry-dynamic-versioning[plugin]"
+      - name: Install versioning plugin
+        run: |
+          python -m pip install poetry-dynamic-versioning[plugin]
       # Install test dependencies (tox) to the root (non-package install)
       - name: Install test dependencies
         run: |
-          python -m poetry install --no-root --only test
+          poetry install --no-root --only test
       - name: set full Python version in PY env var
+        if: ${{ matrix.os != 'windows-latest' }}
         # See https://pre-commit.com/#github-actions-example
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       # Install node and yarn in order to build the front end during packaging  
@@ -59,24 +73,8 @@ jobs:
           node-version: 18.x
       - name: Install Yarn
         run: npm install -g yarn
-      # Build and install the package if it's Windows, to service shell-based tests
-      - name: Install binary on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        env:
-          SKIP_PRE_BUILD: true
-        # Make `locust` available on the Windows shell by installing it with `pip`
-        # before running tests which invoke it in the `cmd` prompt
-        run: |
-          python -m poetry build
-          python -m poetry self add "poetry-plugin-export"
-          python -m poetry export --without-hashes --format=requirements.txt > requirements.txt
-          pip install -r requirements.txt
-          pip install poetry-core>=1.0.0
-          pip install locust --find-links=dist
       - name: Run tox tests
-        env:
-          SKIP_PRE_BUILD: ${{ matrix.skip_pre_build }}
-        run: python -m poetry run tox -e ${{ matrix.tox }}
+        run: poetry run tox -e ${{ matrix.tox }}
 
   lint_typecheck_test_webui:
     runs-on: ubuntu-latest

--- a/pre_build.py
+++ b/pre_build.py
@@ -15,12 +15,8 @@ def build() -> None:
         exit(1)
     print("Building front end...")
     try:
-        if os.name == "nt":
-            subprocess.check_output(" ".join(["yarn", "webui:install"]), shell=True)
-            subprocess.check_output(" ".join(["yarn", "webui:build"]), shell=True)
-        else:
-            subprocess.run(["yarn", "webui:install"])
-            subprocess.run(["yarn", "webui:build"])
+        subprocess.check_output(" ".join(["yarn", "webui:install"]), shell=True)
+        subprocess.check_output(" ".join(["yarn", "webui:build"]), shell=True)
     except subprocess.CalledProcessError as e:
         raise AssertionError(f"Building front end with yarn failed with:\n\n{e.stdout}") from e
 

--- a/pre_build.py
+++ b/pre_build.py
@@ -14,8 +14,15 @@ def build() -> None:
         )
         exit(1)
     print("Building front end...")
-    subprocess.run(["yarn", "webui:install"])
-    subprocess.run(["yarn", "webui:build"])
+    try:
+        if os.name == "nt":
+            subprocess.check_output(" ".join(["yarn", "webui:install"]), shell=True)
+            subprocess.check_output(" ".join(["yarn", "webui:build"]), shell=True)
+        else:
+            subprocess.run(["yarn", "webui:install"])
+            subprocess.run(["yarn", "webui:build"])
+    except subprocess.CalledProcessError as e:
+        raise AssertionError(f"Building front end with yarn failed with:\n\n{e.stdout}") from e
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,6 @@ commands =
 commands = 
     poetry install --with test
     poetry run python -m unittest -f locust.test.test_main
-pass_env =
-    SKIP_PRE_BUILD
 
 [testenv:ruff]
 ; Pin the same version in the .pre-commit-config.yaml file.

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 [testenv:fail_fast_test_main]
 commands = 
     poetry install --with test
+    bash -ec 'if [ "$WINDIR" ]; then pip install .; fi' # ensure locust.exe is written to Scripts folder on Windows
     poetry run python -m unittest -f locust.test.test_main
 
 [testenv:ruff]


### PR DESCRIPTION
### Overview

Rights some wrongs currently in `master` relating to Windows integration tests.

In short - this works around some quirks of Poetry on Windows, with respect to the `PATH` and shell commands.

## Major

- Ensures that Windows tests run the current version of Locust
- Ensures that the prebuild script runs on the Windows shell (such that it can find `yarn`)
- Re-simplifies the test matrix