### PR TITLE
Integrations for Locust Cloud

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -36,9 +36,13 @@ from .user.inspectuser import print_task_ratio, print_task_ratio_json
 from .util.load_locustfile import load_locustfile
 from .util.timespan import parse_timespan
 
+# import external plugins if  installed to allow for registering custom arguments etc
 try:
-    # import locust_plugins if it is installed, to allow it to register custom arguments etc
     import locust_plugins  # pyright: ignore[reportMissingImports]
+except ModuleNotFoundError:
+    pass
+try:
+    import locust_cloud  # pyright: ignore[reportMissingImports]
 except ModuleNotFoundError:
     pass
 

--- a/locust/web.py
+++ b/locust/web.py
@@ -39,6 +39,7 @@ from .runners import STATE_MISSING, STATE_RUNNING, MasterRunner
 from .stats import StatsCSV, StatsCSVFileWriter, StatsErrorDict, sort_stats
 from .user.inspectuser import get_ratio
 from .util.cache import memoize
+from .util.date import format_utc_timestamp
 from .util.timespan import parse_timespan
 
 if TYPE_CHECKING:
@@ -617,6 +618,8 @@ class WebUI:
             else None
         )
 
+        start_time = format_utc_timestamp(stats.start_time)
+
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,
@@ -634,6 +637,7 @@ class WebUI:
                 and not (self.userclass_picker_is_active or self.environment.shape_class.use_common_options)
             ),
             "stats_history_enabled": options and options.stats_history_enabled,
+            "start_time": start_time,
             "tasks": dumps({}),
             "extra_options": extra_options,
             "run_time": options and options.run_time,

--- a/locust/webui/src/redux/slice/swarm.slice.ts
+++ b/locust/webui/src/redux/slice/swarm.slice.ts
@@ -26,6 +26,7 @@ export interface ISwarmState {
   runTime?: string | number;
   showUserclassPicker: boolean;
   spawnRate: number | null;
+  startTime: string;
   state: string;
   statsHistoryEnabled: boolean;
   tasks: string;

--- a/locust/webui/src/test/mocks/swarmState.mock.ts
+++ b/locust/webui/src/test/mocks/swarmState.mock.ts
@@ -22,6 +22,7 @@ export const swarmStateMock = {
   showUserclassPicker: false,
   spawnRate: null,
   state: 'ready',
+  startTime: '',
   percentilesToChart: percentilesToChart,
   statsHistoryEnabled: false,
   tasks: '{}',


### PR DESCRIPTION
### Proposal
- Import the locust cloud module if installed to allow for registering custom arguments
- Return the start time from the swarm arguments to help with querying. This could also be useful for us if we ever want to show how long locust has been running for in the UI