### PR TITLE
Github Actions: Use node 20.x (fix PyPI Release and pre-Release Steps)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,6 +178,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip poetry
@@ -217,6 +221,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
       - run: git rev-parse HEAD^2 2>/dev/null >/dev/null || echo NOT_MERGE_COMMIT=1 | tee -a $GITHUB_ENV
       - name: Install dependencies
         if: ${{ env.NOT_MERGE_COMMIT == '' }}


### PR DESCRIPTION
Use node 20.x for PyPI release and pre-release