### PR TITLE
Web UI Should use Built-In Echarts Time Axis

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -904,18 +904,21 @@ def sort_stats(stats: dict[Any, S]) -> list[S]:
 
 def update_stats_history(runner: Runner) -> None:
     stats = runner.stats
+    timestamp = format_utc_timestamp(time.time())
     current_response_time_percentiles = {
-        f"response_time_percentile_{percentile}": stats.total.get_current_response_time_percentile(percentile) or 0
+        f"response_time_percentile_{percentile}": [
+            timestamp,
+            stats.total.get_current_response_time_percentile(percentile) or 0,
+        ]
         for percentile in PERCENTILES_TO_CHART
     }
 
     r = {
         **current_response_time_percentiles,
-        "time": format_utc_timestamp(time.time()),
-        "current_rps": stats.total.current_rps or 0,
-        "current_fail_per_sec": stats.total.current_fail_per_sec or 0,
-        "total_avg_response_time": proper_round(stats.total.avg_response_time, digits=2),
-        "user_count": runner.user_count or 0,
+        "current_rps": [timestamp, stats.total.current_rps or 0],
+        "current_fail_per_sec": [timestamp, stats.total.current_fail_per_sec or 0],
+        "total_avg_response_time": [timestamp, proper_round(stats.total.avg_response_time, digits=2)],
+        "user_count": [timestamp, runner.user_count or 0],
     }
     stats.history.append(r)
 

--- a/locust/webui/auth.html
+++ b/locust/webui/auth.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./assets/favicon.ico" />
+    <link rel="icon" href="/assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 

--- a/locust/webui/dev.html
+++ b/locust/webui/dev.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./assets/favicon.ico" />
+    <link rel="icon" href="./assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 

--- a/locust/webui/package.json
+++ b/locust/webui/package.json
@@ -17,10 +17,12 @@
   "prepack": "json -f package.json -I -e \"delete this.devDependencies; delete this.dependencies; delete this.scripts\"",
   "scripts": {
     "dev": "vite",
-    "dev:watch": "vite build --watch",
+    "watch": "npm-run-all --parallel watch:ui watch:report",
     "build:ui": "vite build",
     "build:lib": "vite build --config vite.lib.config.ts",
     "build:report": "vite build --config vite.report.config.ts",
+    "watch:ui": "vite build --watch",
+    "watch:report": "vite build --config vite.lib.config.ts --watch",
     "build": "yarn clean && npm-run-all --parallel build:ui build:report build:lib",
     "clean": "rimraf dist",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/locust/webui/report.html
+++ b/locust/webui/report.html
@@ -3,7 +3,7 @@
   {% raw %}
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/assets/favicon.png" />
+    <link rel="icon" href="../../assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 

--- a/locust/webui/report.html
+++ b/locust/webui/report.html
@@ -3,7 +3,7 @@
   {% raw %}
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./assets/favicon.ico" />
+    <link rel="icon" href="/assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 

--- a/locust/webui/src/assets/Logo.tsx
+++ b/locust/webui/src/assets/Logo.tsx
@@ -16,19 +16,19 @@ export default function Logo({
       xmlns='http://www.w3.org/2000/svg'
     >
       <path
-        clip-rule='evenodd'
+        clipRule='evenodd'
         d='M36.6942 18.9754L48.9434 6.62621L47.341 5.01205L35.0918 17.3612L36.6942 18.9754Z'
         fill='#B8EE4B'
-        fill-rule='evenodd'
+        fillRule='evenodd'
       />
       <path
-        clip-rule='evenodd'
+        clipRule='evenodd'
         d='M40.954 20.093L53.0301 8.01687L51.4159 6.40271L39.3398 18.4788L40.954 20.093Z'
         fill='#B8EE4B'
         fillRule='evenodd'
       />
       <path
-        clip-rule='evenodd'
+        clipRule='evenodd'
         d='M0 28.1761L39.9453 9.82391L43.7047 9.82392L47.4641 13.5833V19.9629L43.819 23.608L39.2012 18.9279L38.0252 20.0882L47.7932 29.988H41.7525L35.4796 23.7151L20.9615 29.988H0V28.1761Z'
         fill='#B8EE4B'
         fillRule='evenodd'

--- a/locust/webui/src/components/Form/Select.tsx
+++ b/locust/webui/src/components/Form/Select.tsx
@@ -16,6 +16,7 @@ export default function Select({
   multiple = false,
   defaultValue,
   sx,
+  ...inputProps
 }: ISelect) {
   return (
     <FormControl sx={sx}>
@@ -23,6 +24,7 @@ export default function Select({
         {label}
       </InputLabel>
       <MuiSelect
+        {...inputProps}
         defaultValue={defaultValue || (multiple && options) || options[0]}
         id={name}
         label={label}

--- a/locust/webui/src/components/LineChart/LineChart.tsx
+++ b/locust/webui/src/components/LineChart/LineChart.tsx
@@ -71,7 +71,6 @@ export default function LineChart<ChartType extends IBaseChartType>({
     const isChartDataDefined = lines.every(({ key }) => !!charts[key]);
     if (chart && isChartDataDefined) {
       chart.setOption({
-        xAxis: { data: charts.time },
         series: lines.map(({ key, yAxisIndex, ...echartsOptions }, index) => ({
           ...echartsOptions,
           data: charts[key],

--- a/locust/webui/src/components/LineChart/LineChart.tsx
+++ b/locust/webui/src/components/LineChart/LineChart.tsx
@@ -2,11 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { init, dispose, ECharts, connect } from 'echarts';
 
 import { CHART_THEME } from 'components/LineChart/LineChart.constants';
-import {
-  ILineChartTimeAxis,
-  ILineChart,
-  ILineChartMarkers,
-} from 'components/LineChart/LineChart.types';
+import { ILineChart, ILineChartMarkers } from 'components/LineChart/LineChart.types';
 import {
   createMarkLine,
   createOptions,
@@ -15,7 +11,7 @@ import {
 } from 'components/LineChart/LineChart.utils';
 import { useSelector } from 'redux/hooks';
 
-interface IBaseChartType extends ILineChartTimeAxis, ILineChartMarkers {}
+interface IBaseChartType extends ILineChartMarkers {}
 
 export default function LineChart<ChartType extends IBaseChartType>({
   charts,

--- a/locust/webui/src/components/LineChart/LineChart.types.ts
+++ b/locust/webui/src/components/LineChart/LineChart.types.ts
@@ -33,5 +33,5 @@ export interface ILineChartTooltipFormatterParams {
   axisValue: string;
   color: string;
   seriesName: string;
-  value: number;
+  value: string | number | string[];
 }

--- a/locust/webui/src/components/LineChart/LineChart.types.ts
+++ b/locust/webui/src/components/LineChart/LineChart.types.ts
@@ -21,10 +21,6 @@ export interface ILineChartZoomEvent {
   batch?: { start: number; end: number }[];
 }
 
-export interface ILineChartTimeAxis {
-  time: string[];
-}
-
 export interface ILineChartMarkers {
   markers?: string[];
 }
@@ -33,5 +29,5 @@ export interface ILineChartTooltipFormatterParams {
   axisValue: string;
   color: string;
   seriesName: string;
-  value: string | number | string[];
+  value: string | number | [string, number];
 }

--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -8,7 +8,6 @@ import {
 
 import { CHART_THEME } from 'components/LineChart/LineChart.constants';
 import {
-  ILineChartTimeAxis,
   ILineChart,
   ILineChartZoomEvent,
   ILineChartTooltipFormatterParams,
@@ -73,7 +72,7 @@ const renderChartTooltipValue = <ChartType>({
   value,
 }: {
   chartValueFormatter: ILineChart<ChartType>['chartValueFormatter'];
-  value: string | number | string[];
+  value: ILineChartTooltipFormatterParams['value'];
 }) => {
   if (chartValueFormatter) {
     return chartValueFormatter(value);
@@ -82,7 +81,7 @@ const renderChartTooltipValue = <ChartType>({
   return Array.isArray(value) ? value[1] : value;
 };
 
-export const createOptions = <ChartType extends ILineChartTimeAxis>({
+export const createOptions = <ChartType>({
   charts,
   title,
   lines,
@@ -131,7 +130,6 @@ export const createOptions = <ChartType extends ILineChartTimeAxis>({
     axisLabel: {
       formatter: formatTimeAxis,
     },
-    data: charts.time,
   },
   grid: { left: 50, right: 10 },
   yAxis: createYAxis({ splitAxis, yAxisLabels }),

--- a/locust/webui/src/components/LineChart/tests/LineChart.mocks.ts
+++ b/locust/webui/src/components/LineChart/tests/LineChart.mocks.ts
@@ -1,23 +1,36 @@
 import { ICharts } from 'types/ui.types';
 
-export type MockChartType = Pick<ICharts, 'currentRps' | 'currentFailPerSec' | 'time'>;
+export type MockChartType = Pick<ICharts, 'currentRps' | 'currentFailPerSec'>;
 
 export const mockChartLines = [
   { name: 'RPS', key: 'currentRps' as keyof MockChartType },
   { name: 'Failures/s', key: 'currentFailPerSec' as keyof MockChartType },
 ];
 
-export const mockCharts = {
-  currentRps: [3, 3.1, 3.27, 3.62, 4.19],
-  currentFailPerSec: [0, 0, 0, 0, 0],
-  time: [
-    'Tue, 06 Aug 2024 11:33:02 GMT',
-    'Tue, 06 Aug 2024 11:33:08 GMT',
-    'Tue, 06 Aug 2024 11:33:10 GMT',
-    'Tue, 06 Aug 2024 11:33:12 GMT',
-    'Tue, 06 Aug 2024 11:33:14 GMT',
+export const mockCharts: MockChartType = {
+  currentRps: [
+    ['Tue, 06 Aug 2024 11:33:02 GMT', 3],
+    ['Tue, 06 Aug 2024 11:33:08 GMT', 3.1],
+    ['Tue, 06 Aug 2024 11:33:10 GMT', 3.27],
+    ['Tue, 06 Aug 2024 11:33:12 GMT', 3.62],
+    ['Tue, 06 Aug 2024 11:33:14 GMT', 4.19],
+  ],
+  currentFailPerSec: [
+    ['Tue, 06 Aug 2024 11:33:02 GMT', 0],
+    ['Tue, 06 Aug 2024 11:33:08 GMT', 0],
+    ['Tue, 06 Aug 2024 11:33:10 GMT', 0],
+    ['Tue, 06 Aug 2024 11:33:12 GMT', 0],
+    ['Tue, 06 Aug 2024 11:33:14 GMT', 0],
   ],
 };
+
+export const mockTimestamps = [
+  'Tue, 06 Aug 2024 11:33:02 GMT',
+  'Tue, 06 Aug 2024 11:33:08 GMT',
+  'Tue, 06 Aug 2024 11:33:10 GMT',
+  'Tue, 06 Aug 2024 11:33:12 GMT',
+  'Tue, 06 Aug 2024 11:33:14 GMT',
+];
 
 export const mockSeriesData = [
   { type: 'line', name: 'RPS', data: mockCharts.currentRps, symbolSize: 4 },
@@ -34,12 +47,12 @@ export const mockTooltipParams = [
     axisValue: 'Tue, 06 Aug 2024 11:33:02 GMT',
     color: '#ff0',
     seriesName: 'RPS',
-    value: 1,
+    value: ['Tue, 06 Aug 2024 11:33:08 GMT', 1] as [string, number],
   },
   {
     axisValue: 'Tue, 06 Aug 2024 11:33:08 GMT',
     color: '#0ff',
     seriesName: 'User',
-    value: 10,
+    value: ['Tue, 06 Aug 2024 11:33:12 GMT', 10] as [string, number],
   },
 ];

--- a/locust/webui/src/components/LineChart/tests/LineChart.mocks.ts
+++ b/locust/webui/src/components/LineChart/tests/LineChart.mocks.ts
@@ -1,5 +1,4 @@
 import { ICharts } from 'types/ui.types';
-import { formatLocaleTime } from 'utils/date';
 
 export type MockChartType = Pick<ICharts, 'currentRps' | 'currentFailPerSec' | 'time'>;
 
@@ -19,8 +18,6 @@ export const mockCharts = {
     'Tue, 06 Aug 2024 11:33:14 GMT',
   ],
 };
-
-export const mockFormattedTimeAxis = mockCharts.time.map(formatLocaleTime);
 
 export const mockSeriesData = [
   { type: 'line', name: 'RPS', data: mockCharts.currentRps, symbolSize: 4 },

--- a/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
+++ b/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
@@ -15,8 +15,10 @@ import {
   MockChartType,
   mockScatterplotSeriesData,
   mockSeriesData,
+  mockTimestamps,
   mockTooltipParams,
 } from 'components/LineChart/tests/LineChart.mocks';
+import { swarmStateMock } from 'test/mocks/swarmState.mock';
 import { formatLocaleString } from 'utils/date';
 
 const removeWhitespace = (string: string) => string.replace(/\s+/g, '');
@@ -57,7 +59,8 @@ describe('createOptions', () => {
     const options = createOptions<MockChartType>(createOptionsDefaultProps);
 
     expect(options.title.text).toBe('Test Chart');
-    expect(options.xAxis.data).toEqual(mockCharts.time);
+    expect(options.xAxis.type).toBe('time');
+    expect(options.xAxis.startValue).toBe(swarmStateMock.startTime);
     expect(options.yAxis).toEqual(defaultYAxis);
     expect(options.series).toEqual(mockSeriesData);
     expect(options.color).toEqual(['#fff']);
@@ -78,7 +81,15 @@ describe('createOptions', () => {
   test('xAxis should be formatted as expected', () => {
     const options = createOptions<MockChartType>(createOptionsDefaultProps);
 
-    expect(options.xAxis.axisLabel.formatter(mockCharts.time[0])).toBe('07:33:02');
+    const formattedValue = options.xAxis.axisLabel.formatter(mockTimestamps[0]);
+
+    expect(formattedValue.split(':').length).toBe(3);
+
+    const [hours, minutes, seconds] = formattedValue.split(':');
+
+    expect(hours.length).toBe(2);
+    expect(minutes.length).toBe(2);
+    expect(seconds.length).toBe(2);
   });
 
   test('should format the tooltip as expected', () => {
@@ -90,7 +101,7 @@ describe('createOptions', () => {
 
       <br>
       <span style="color:${mockTooltipParams[0].color};">
-        ${mockTooltipParams[0].seriesName}:&nbsp${mockTooltipParams[0].value}
+        ${mockTooltipParams[0].seriesName}:&nbsp${mockTooltipParams[0].value[1]}
       </span>
     `),
     );
@@ -106,11 +117,11 @@ describe('createOptions', () => {
       ${formatLocaleString(mockTooltipParams[0].axisValue)}
       <br>
       <span style="color:${mockTooltipParams[0].color};">
-        ${mockTooltipParams[0].seriesName}:&nbsp${mockTooltipParams[0].value}
+        ${mockTooltipParams[0].seriesName}:&nbsp${mockTooltipParams[0].value[1]}
       </span>
       <br>
       <span style="color:${mockTooltipParams[1].color};">
-        ${mockTooltipParams[1].seriesName}:&nbsp${mockTooltipParams[1].value}
+        ${mockTooltipParams[1].seriesName}:&nbsp${mockTooltipParams[1].value[1]}
       </span>
     `),
     );
@@ -175,8 +186,9 @@ describe('createOptions', () => {
     });
 
     expect(options.title.text).toBe('Test Chart');
-    expect(options.xAxis.data).toEqual(mockCharts.time);
     expect(options.yAxis).toEqual(defaultYAxis);
+    expect(options.xAxis.type).toBe('time');
+    expect(options.xAxis.startValue).toBe(swarmStateMock.startTime);
     expect(options.series).toEqual(mockScatterplotSeriesData);
     expect(options.color).toEqual(['#fff']);
   });
@@ -186,7 +198,7 @@ describe('createMarkLine', () => {
   test('should create a mark line', () => {
     const markChartsWithMarkers = {
       ...mockCharts,
-      markers: [mockCharts.time[1]],
+      markers: [mockTimestamps[1]],
     };
 
     const options = createMarkLine(markChartsWithMarkers, false);
@@ -199,7 +211,7 @@ describe('createMarkLine', () => {
   test('should create multiple mark lines', () => {
     const markChartsWithMarkers = {
       ...mockCharts,
-      markers: [mockCharts.time[1], mockCharts.time[3]],
+      markers: [mockTimestamps[1], mockTimestamps[3]],
     };
 
     const options = createMarkLine(markChartsWithMarkers, false);
@@ -213,7 +225,7 @@ describe('createMarkLine', () => {
   test('should format mark line label', () => {
     const markChartsWithMarkers = {
       ...mockCharts,
-      markers: [mockCharts.time[1]],
+      markers: [mockTimestamps[1]],
     };
     const options = createMarkLine(markChartsWithMarkers, false);
 
@@ -225,7 +237,7 @@ describe('createMarkLine', () => {
   test('should use dark mode when isDarkMode', () => {
     const markChartsWithMarkers = {
       ...mockCharts,
-      markers: [mockCharts.time[1]],
+      markers: [mockTimestamps[1]],
     };
     const options = createMarkLine(markChartsWithMarkers, true);
 

--- a/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
+++ b/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
@@ -17,7 +17,7 @@ import {
   mockSeriesData,
   mockTooltipParams,
 } from 'components/LineChart/tests/LineChart.mocks';
-import { formatLocaleString, formatLocaleTime } from 'utils/date';
+import { formatLocaleString } from 'utils/date';
 
 const removeWhitespace = (string: string) => string.replace(/\s+/g, '');
 
@@ -78,10 +78,7 @@ describe('createOptions', () => {
   test('xAxis should be formatted as expected', () => {
     const options = createOptions<MockChartType>(createOptionsDefaultProps);
 
-    expect(options.xAxis.axisLabel.formatter(mockCharts.time[0])).toBe(
-      formatLocaleTime(mockCharts.time[0]),
-    );
-    expect(options.xAxis.axisLabel.formatter('undefined')).toBe('');
+    expect(options.xAxis.axisLabel.formatter(mockCharts.time[0])).toBe('07:33:02');
   });
 
   test('should format the tooltip as expected', () => {

--- a/locust/webui/src/components/SwarmCharts/SwarmCharts.tsx
+++ b/locust/webui/src/components/SwarmCharts/SwarmCharts.tsx
@@ -14,7 +14,7 @@ const percentilesToChartLines = swarmTemplateArgs.percentilesToChart
   : [];
 
 const percentileColors = [
-  '#eeff00',
+  '#ff9f00',
   '#9966CC',
   '#8A2BE2',
   '#8E4585',

--- a/locust/webui/src/hooks/tests/useSwarmUi.test.tsx
+++ b/locust/webui/src/hooks/tests/useSwarmUi.test.tsx
@@ -37,16 +37,13 @@ describe('useSwarmUi', () => {
 
   test('should fetch request stats, ratios, and exceptions and update UI accordingly', async () => {
     vi.useFakeTimers();
-
     vi.setSystemTime(mockDate);
 
     const { store } = renderWithProvider(<MockHook />);
 
-    await act(async () => {
-      await vi.runAllTimersAsync();
+    waitFor(() => {
+      expect(store.getState().ui).toEqual(statsResponseTransformed);
     });
-
-    expect(store.getState().ui).toEqual(statsResponseTransformed);
 
     vi.useRealTimers();
   });

--- a/locust/webui/src/hooks/useSwarmUi.ts
+++ b/locust/webui/src/hooks/useSwarmUi.ts
@@ -45,7 +45,7 @@ export default function useSwarmUi() {
       totalAvgResponseTime,
     } = statsData;
 
-    const time = new Date().toUTCString();
+    const time = new Date().toISOString();
 
     if (shouldAddMarker) {
       setShouldAddMarker(false);
@@ -56,13 +56,20 @@ export default function useSwarmUi() {
     const totalFailPerSecRounded = roundToDecimalPlaces(totalFailPerSec, 2);
     const totalFailureRatioRounded = roundToDecimalPlaces(failRatio * 100);
 
+    const percentilesWithTime = Object.entries(currentResponseTimePercentiles).reduce(
+      (percentiles, [key, value]) => ({
+        ...percentiles,
+        [key]: [time, value],
+      }),
+      {},
+    );
+
     const newChartEntry = {
-      ...currentResponseTimePercentiles,
-      currentRps: totalRpsRounded,
-      currentFailPerSec: totalFailPerSecRounded,
-      totalAvgResponseTime: roundToDecimalPlaces(totalAvgResponseTime, 2),
-      userCount: userCount,
-      time,
+      ...percentilesWithTime,
+      currentRps: [time, totalRpsRounded],
+      currentFailPerSec: [time, totalFailPerSecRounded],
+      totalAvgResponseTime: [time, roundToDecimalPlaces(totalAvgResponseTime, 2)],
+      userCount: [time, userCount],
     };
 
     setUi({

--- a/locust/webui/src/lib.tsx
+++ b/locust/webui/src/lib.tsx
@@ -13,6 +13,7 @@ export { baseTabs } from 'components/Tabs/Tabs.constants';
 export { default as useInterval } from 'hooks/useInterval';
 export { roundToDecimalPlaces } from 'utils/number';
 export { SWARM_STATE } from 'constants/swarm';
+export { default as Select } from 'components/Form/Select';
 export type { IRootState } from 'redux/store';
 
 export type { ITab } from 'types/tab.types';

--- a/locust/webui/src/redux/slice/tests/ui.slice.test.ts
+++ b/locust/webui/src/redux/slice/tests/ui.slice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import uiSlice, { IUiState, UiAction, uiActions } from 'redux/slice/ui.slice';
-import { percentilesToChart } from 'test/mocks/swarmState.mock';
+import { percentilesToChart, swarmStateMock } from 'test/mocks/swarmState.mock';
 import { ICharts, ISwarmRatios } from 'types/ui.types';
 
 const responseTimePercentileKey1 =
@@ -22,7 +22,6 @@ const initialState = {
     currentFailPerSec: [],
     totalAvgResponseTime: [],
     userCount: [],
-    time: [],
   },
   ratios: {} as ISwarmRatios,
   userCount: 0,
@@ -49,7 +48,6 @@ describe('uiSlice', () => {
       [responseTimePercentileKey1]: 0.4,
       [responseTimePercentileKey2]: 0.2,
       userCount: 2,
-      time: '10:10:10',
     });
 
     const nextState = uiSlice(initialState, action);
@@ -60,7 +58,6 @@ describe('uiSlice', () => {
     expect(charts[responseTimePercentileKey1][0]).toBe(0.4);
     expect(charts[responseTimePercentileKey2][0]).toBe(0.2);
     expect(charts.userCount[0]).toBe(2);
-    expect(charts.time[0]).toBe('10:10:10');
   });
 
   test('should continue to extend the corresponding array of charts in UI state', () => {
@@ -70,7 +67,6 @@ describe('uiSlice', () => {
       [responseTimePercentileKey1]: 0.4,
       [responseTimePercentileKey2]: 0.2,
       userCount: 2,
-      time: '10:10:10',
     });
 
     const updatedState = uiSlice(initialState, action);
@@ -83,7 +79,6 @@ describe('uiSlice', () => {
     expect(charts[responseTimePercentileKey1]).toEqual([0.4, 0.4]);
     expect(charts[responseTimePercentileKey2]).toEqual([0.2, 0.2]);
     expect(charts.userCount).toEqual([2, 2]);
-    expect(charts.time).toEqual(['10:10:10', '10:10:10']);
   });
 
   test('should update chart markers in UI state', () => {
@@ -93,7 +88,6 @@ describe('uiSlice', () => {
         ...initialState,
         charts: {
           ...initialState.charts,
-          time: ['10:10:10'],
         },
       },
       action,
@@ -101,7 +95,7 @@ describe('uiSlice', () => {
 
     const charts = nextState.charts as ICharts;
 
-    expect(charts.markers).toEqual(['10:10:10', '20:20:20']);
+    expect(charts.markers).toEqual([swarmStateMock.startTime, '20:20:20']);
 
     // Add space between runs
     expect(charts.currentRps[0]).toEqual({ value: null });

--- a/locust/webui/src/redux/slice/ui.slice.ts
+++ b/locust/webui/src/redux/slice/ui.slice.ts
@@ -54,7 +54,6 @@ const addSpaceToChartsBetweenTests = (charts: ICharts) => {
     currentFailPerSec: { value: null },
     totalAvgResponseTime: { value: null },
     userCount: { value: null },
-    time: '',
   });
 };
 
@@ -74,7 +73,7 @@ const uiSlice = createSlice({
           ...addSpaceToChartsBetweenTests(state.charts as ICharts),
           markers: (state.charts as ICharts).markers
             ? [...((state.charts as ICharts).markers as string[]), payload]
-            : [(state.charts as ICharts).time[0], payload],
+            : [swarmTemplateArgs.startTime, payload],
         },
       };
     },

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -1,3 +1,5 @@
+import { ICharts } from 'types/ui.types';
+
 export const statsResponseMock = {
   current_response_time_percentiles: {
     'response_time_percentile_0.5': 2,
@@ -153,7 +155,7 @@ export const statsResponseTransformed = {
     currentFailPerSec: [[mockDate.toISOString(), 1932.5]],
     userCount: [[mockDate.toISOString(), 1]],
     totalAvgResponseTime: [[mockDate.toISOString(), 0.41]],
-  },
+  } as ICharts,
   ratios: {
     perClass: {
       Example: {

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -147,13 +147,12 @@ export const statsResponseTransformed = {
   exceptions: exceptionsResponseMock.exceptions,
   extendedStats: undefined,
   charts: {
-    'responseTimePercentile0.5': [2],
-    'responseTimePercentile0.95': [2],
-    currentRps: [1932.5],
-    currentFailPerSec: [1932.5],
-    userCount: [1],
-    totalAvgResponseTime: [0.41],
-    time: [mockDate.toUTCString()],
+    'responseTimePercentile0.5': [[mockDate.toISOString(), 2]],
+    'responseTimePercentile0.95': [[mockDate.toISOString(), 2]],
+    currentRps: [[mockDate.toISOString(), 1932.5]],
+    currentFailPerSec: [[mockDate.toISOString(), 1932.5]],
+    userCount: [[mockDate.toISOString(), 1]],
+    totalAvgResponseTime: [[mockDate.toISOString(), 0.41]],
   },
   ratios: {
     perClass: {

--- a/locust/webui/src/test/mocks/swarmState.mock.ts
+++ b/locust/webui/src/test/mocks/swarmState.mock.ts
@@ -22,7 +22,7 @@ export const swarmStateMock = {
   showUserclassPicker: false,
   spawnRate: null,
   state: 'ready',
-  startTime: '',
+  startTime: '10:10:10',
   percentilesToChart: percentilesToChart,
   statsHistoryEnabled: false,
   tasks: '{}',
@@ -44,10 +44,9 @@ export const swarmReportMock: IReport = {
   responseTimeStatistics: [],
   tasks: {} as ISwarmRatios,
   charts: {
-    currentRps: [0],
-    currentFailPerSec: [0],
-    totalAvgResponseTime: [0],
-    userCount: [0],
-    time: [''],
+    currentRps: [['', 0]],
+    currentFailPerSec: [['', 0]],
+    totalAvgResponseTime: [['', 0]],
+    userCount: [['', 0]],
   },
 };

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -19,14 +19,13 @@ export interface IExtraOptions {
 }
 
 export interface IHistory {
-  currentRps: number;
-  currentFailPerSec: number;
-  userCount: number;
-  time: string;
+  currentRps: [string, number];
+  currentFailPerSec: [string, number];
+  userCount: [string, number];
   currentResponseTimePercentiles: {
-    [key: `responseTimePercentile${number}`]: number | null;
+    [key: `responseTimePercentile${number}`]: [string, number | null];
   };
-  totalAvgResponseTime: number;
+  totalAvgResponseTime: [string, number];
 }
 
 export interface IReport {

--- a/locust/webui/src/types/ui.types.ts
+++ b/locust/webui/src/types/ui.types.ts
@@ -1,4 +1,4 @@
-import { ILineChartTimeAxis, ILineChartMarkers } from 'components/LineChart/LineChart.types';
+import { ILineChartMarkers } from 'components/LineChart/LineChart.types';
 import { SWARM_STATE } from 'constants/swarm';
 
 export type SwarmState = (typeof SWARM_STATE)[keyof typeof SWARM_STATE];
@@ -54,12 +54,12 @@ export interface NullChartValue {
   value: null;
 }
 
-export interface ICharts extends ILineChartTimeAxis, ILineChartMarkers {
-  currentRps: (number | NullChartValue)[];
-  currentFailPerSec: (number | NullChartValue)[];
-  [key: `responseTimePercentile${number}`]: (number | null | NullChartValue)[];
-  totalAvgResponseTime: (number | NullChartValue)[];
-  userCount: (number | NullChartValue)[];
+export interface ICharts extends ILineChartMarkers {
+  currentRps: ((string | number)[] | NullChartValue)[];
+  currentFailPerSec: ([string, number] | NullChartValue)[];
+  [key: `responseTimePercentile${number}`]: ([string, number | null] | NullChartValue)[];
+  totalAvgResponseTime: ([string, number] | NullChartValue)[];
+  userCount: ([string, number] | NullChartValue)[];
 }
 
 export interface IClassRatio {

--- a/locust/webui/src/utils/date.ts
+++ b/locust/webui/src/utils/date.ts
@@ -1,7 +1,4 @@
-const isDate = (timestamp: string) => !isNaN(Date.parse(timestamp));
+const isDate = (timestamp: string) => !isNaN(new Date(timestamp).getTime());
 
 export const formatLocaleString = (utcTimestamp: string) =>
   utcTimestamp && isDate(utcTimestamp) ? new Date(utcTimestamp).toLocaleString() : '';
-
-export const formatLocaleTime = (utcTimestamp: string) =>
-  utcTimestamp && isDate(utcTimestamp) ? new Date(utcTimestamp).toLocaleTimeString() : '';

--- a/locust/webui/src/utils/number.ts
+++ b/locust/webui/src/utils/number.ts
@@ -2,3 +2,6 @@ export const roundToDecimalPlaces = (n: number, decimalPlaces = 0) => {
   const factor = Math.pow(10, decimalPlaces);
   return Math.round(n * factor) / factor;
 };
+
+export const padStart = (n: number, length = 0, padding = '0') =>
+  String(n).padStart(length, padding);


### PR DESCRIPTION
### Proposal
- The webui currently uses the 'category' type for the charts. We should use the built-in 'time' axis type instead, which will give us better looking time intervals, rather than random splits
- Update how chart history recorded is recorded in Locust to be formatted in the way echarts expects for time data ([time, data][] rather than data[])
-  Update tests and types

### Tested
- Ensure the mark line (between multiple test runs) continues to work as expected
- Ensure a chart from recorded history is rendered properly
- Ensure the HTML report is properly rendered

### Screenshots
![image](https://github.com/user-attachments/assets/919ac46f-abf7-4871-bc14-b6949c3aa482)
![image](https://github.com/user-attachments/assets/8deec9da-c166-4980-85f7-296ad6c686c3)
![image](https://github.com/user-attachments/assets/c8b29b21-16ab-4842-9694-a4d4e6d390ed)
