### PR TITLE
Add missing margin between Logo and Host in Navbar

### DIFF
--- a/locust/webui/src/components/Layout/Navbar/Navbar.tsx
+++ b/locust/webui/src/components/Layout/Navbar/Navbar.tsx
@@ -12,11 +12,11 @@ export default function Navbar() {
   return (
     <AppBar position='static'>
       <Container maxWidth='xl'>
-        <Toolbar disableGutters sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Toolbar disableGutters sx={{ display: 'flex', justifyContent: 'space-between', columnGap: 2 }}>
           <Link
             color='inherit'
             href='/'
-            sx={{ display: 'flex', alignItems: 'center', columnGap: 2 }}
+            sx={{ display: 'flex', alignItems: 'center' }}
             underline='none'
           >
             <Logo isDarkMode={isDarkMode} />


### PR DESCRIPTION
Minor change that fixes a UI glitch in Navbar.

Before:
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/99fc2825-87f3-4688-bc52-72d0a1a5f4b2">


After:
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/40e6f2a0-17ae-479f-ab27-6e053e390ca9">
