### PR TITLE
Web UI Remove Using Start Time

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -618,8 +618,6 @@ class WebUI:
             else None
         )
 
-        start_time = format_utc_timestamp(stats.start_time)
-
         self.template_args = {
             "locustfile": self.environment.locustfile,
             "state": self.environment.runner.state,
@@ -637,7 +635,6 @@ class WebUI:
                 and not (self.userclass_picker_is_active or self.environment.shape_class.use_common_options)
             ),
             "stats_history_enabled": options and options.stats_history_enabled,
-            "start_time": start_time,
             "tasks": dumps({}),
             "extra_options": extra_options,
             "run_time": options and options.run_time,

--- a/locust/webui/src/hooks/useSwarmUi.ts
+++ b/locust/webui/src/hooks/useSwarmUi.ts
@@ -70,6 +70,7 @@ export default function useSwarmUi() {
       currentFailPerSec: [time, totalFailPerSecRounded],
       totalAvgResponseTime: [time, roundToDecimalPlaces(totalAvgResponseTime, 2)],
       userCount: [time, userCount],
+      time: time,
     };
 
     setUi({

--- a/locust/webui/src/redux/slice/swarm.slice.ts
+++ b/locust/webui/src/redux/slice/swarm.slice.ts
@@ -26,7 +26,6 @@ export interface ISwarmState {
   runTime?: string | number;
   showUserclassPicker: boolean;
   spawnRate: number | null;
-  startTime: string;
   state: string;
   statsHistoryEnabled: boolean;
   tasks: string;

--- a/locust/webui/src/redux/slice/tests/ui.slice.test.ts
+++ b/locust/webui/src/redux/slice/tests/ui.slice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import uiSlice, { IUiState, UiAction, uiActions } from 'redux/slice/ui.slice';
-import { percentilesToChart, swarmStateMock } from 'test/mocks/swarmState.mock';
+import { percentilesToChart } from 'test/mocks/swarmState.mock';
 import { ICharts, ISwarmRatios } from 'types/ui.types';
 
 const responseTimePercentileKey1 =
@@ -22,6 +22,7 @@ const initialState = {
     currentFailPerSec: [],
     totalAvgResponseTime: [],
     userCount: [],
+    time: [],
   },
   ratios: {} as ISwarmRatios,
   userCount: 0,
@@ -88,6 +89,7 @@ describe('uiSlice', () => {
         ...initialState,
         charts: {
           ...initialState.charts,
+          time: ['10:10:10'],
         },
       },
       action,
@@ -95,7 +97,7 @@ describe('uiSlice', () => {
 
     const charts = nextState.charts as ICharts;
 
-    expect(charts.markers).toEqual([swarmStateMock.startTime, '20:20:20']);
+    expect(charts.markers).toEqual(['10:10:10', '20:20:20']);
 
     // Add space between runs
     expect(charts.currentRps[0]).toEqual({ value: null });

--- a/locust/webui/src/redux/slice/ui.slice.ts
+++ b/locust/webui/src/redux/slice/ui.slice.ts
@@ -54,6 +54,7 @@ const addSpaceToChartsBetweenTests = (charts: ICharts) => {
     currentFailPerSec: { value: null },
     totalAvgResponseTime: { value: null },
     userCount: { value: null },
+    time: '',
   });
 };
 
@@ -73,7 +74,7 @@ const uiSlice = createSlice({
           ...addSpaceToChartsBetweenTests(state.charts as ICharts),
           markers: (state.charts as ICharts).markers
             ? [...((state.charts as ICharts).markers as string[]), payload]
-            : [swarmTemplateArgs.startTime, payload],
+            : [state.charts.time[0], payload],
         },
       };
     },

--- a/locust/webui/src/test/mocks/swarmState.mock.ts
+++ b/locust/webui/src/test/mocks/swarmState.mock.ts
@@ -22,7 +22,6 @@ export const swarmStateMock = {
   showUserclassPicker: false,
   spawnRate: null,
   state: 'ready',
-  startTime: '10:10:10',
   percentilesToChart: percentilesToChart,
   statsHistoryEnabled: false,
   tasks: '{}',
@@ -48,5 +47,6 @@ export const swarmReportMock: IReport = {
     currentFailPerSec: [['', 0]],
     totalAvgResponseTime: [['', 0]],
     userCount: [['', 0]],
+    time: [],
   },
 };

--- a/locust/webui/src/types/ui.types.ts
+++ b/locust/webui/src/types/ui.types.ts
@@ -60,6 +60,7 @@ export interface ICharts extends ILineChartMarkers {
   [key: `responseTimePercentile${number}`]: ([string, number | null] | NullChartValue)[];
   totalAvgResponseTime: ([string, number] | NullChartValue)[];
   userCount: ([string, number] | NullChartValue)[];
+  time: string[];
 }
 
 export interface IClassRatio {


### PR DESCRIPTION
### Issue
Receiving the actual start time from the backend doesn't work because the frontend fetches the template arguments when first loaded. This means the start time will never line up with the actual start of the test (provided autorun isn't used) 