### PR TITLE
Web UI as a Library NPM Release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,6 +220,12 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true
+      - uses: borales/actions-yarn@v5
+        name: Publish package on NPM
+        with:
+          cmd: publish --no-git-tag-version --non-interactive --new-version ${{ github.ref_name }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     # The following is disabled because it has stopped working.
     #   - name: Tweet on release
     #     uses: infraway/tweet-action@v1.0.1
@@ -273,3 +279,11 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true
+      - name: Set locust version tag
+        run: echo "TAG=$(poetry version -s)" | tee -a $GITHUB_ENV
+      - uses: borales/actions-yarn@v5
+        name: Publish package on NPM
+        with:
+          cmd: publish --no-git-tag-version --non-interactive --tag next --new-version ${{ env.TAG }}-next-${{ github.run_id }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/locust/webui/README.md
+++ b/locust/webui/README.md
@@ -6,7 +6,7 @@ The Locust UI is used for viewing stats, reports, and information on your curren
 
 **Using the Locust UI as a library should be considered an experimental feature**
 
-The Locust UI may be extended to fit your needs. If you only need limited extensibility, you may do so in your Locustfile, see the [extend_web_ui example](https://github.com/locustio/locust/blob/master/examples/extend_web_ui.py).
+The Locust UI may be extended to fit your needs. If you only need limited extensibility, you may do so in your Locustfile, see the [extend_web_ui example](https://github.com/locustio/locust/blob/master/examples/extend_web_ui.py). 
 
 However, you may want to further extend certain functionalities. To do so, you may replace the default Locust UI with your own React application. Start by installing the locust-ui in your React application:
 ```sh
@@ -66,7 +66,7 @@ For Locust to be able to pass data to your React frontend, place the following s
 
 To load the favicon, place the link in your head:
 ```html
-<link rel="icon" href="./assets/favicon.ico" />
+<link rel="icon" href="./assets/favicon.png" />
 ```
 
 Lastly, you must configure Locust to point to your own React build output. To achieve this, you can use the flag `--build-path` and provide the **absolute** path to your build directory.
@@ -108,14 +108,17 @@ function App() {
 
 The `tabs` prop allows for complete control of which tabs are rendered. You can then customize which base tabs are shown or where your new tab should be placed:
 ```js
-import LocustUi, { baseTabs } from "locust-ui";
+import LocustUi, { tabConfig } from "locust-ui";
 
-const tabs = [...baseTabs];
-tabs.splice(2, 0, {
-  title: "Custom Tab",
-  key: "custom-tab",
-  component: MyCustomTab,
-});
+const tabs = [
+    tabConfig.stats,
+    tabConfig.charts,
+    {
+        title: "Custom Tab",
+        key: "custom-tab",
+        component: MyCustomTab,
+    },
+]
 
 function App() {
     return (
@@ -164,6 +167,3 @@ function App() {
     tabs={/* Optional array of tabs that will take precedence over extendedTabs */}
 />
 ```
-
-
-

--- a/locust/webui/README.md
+++ b/locust/webui/README.md
@@ -6,7 +6,7 @@ The Locust UI is used for viewing stats, reports, and information on your curren
 
 **Using the Locust UI as a library should be considered an experimental feature**
 
-The Locust UI may be extended to fit your needs. If you only need limited extensibility, you may do so in your Locustfile, see the [extend_web_ui example](https://github.com/locustio/locust/blob/master/examples/extend_web_ui.py). 
+The Locust UI may be extended to fit your needs. If you only need limited extensibility, you may do so in your Locustfile, see the [extend_web_ui example](https://github.com/locustio/locust/blob/master/examples/extend_web_ui.py).
 
 However, you may want to further extend certain functionalities. To do so, you may replace the default Locust UI with your own React application. Start by installing the locust-ui in your React application:
 ```sh

--- a/locust/webui/package.json
+++ b/locust/webui/package.json
@@ -1,6 +1,5 @@
 {
   "name": "locust-ui",
-  "version": "1.0.0",
   "license": "MIT",
   "type": "module",
   "main": "./lib/webui.js",
@@ -14,7 +13,6 @@
     "type": "git",
     "url": "https://github.com/locustio/locust/tree/master/locust/webui"
   },
-  "prepack": "json -f package.json -I -e \"delete this.devDependencies; delete this.dependencies; delete this.scripts\"",
   "scripts": {
     "dev": "vite",
     "watch": "npm-run-all --parallel watch:ui watch:report",
@@ -23,7 +21,7 @@
     "build:report": "vite build --config vite.report.config.ts",
     "watch:ui": "vite build --watch",
     "watch:report": "vite build --config vite.lib.config.ts --watch",
-    "build": "yarn clean && npm-run-all --parallel build:ui build:report build:lib",
+    "build": "yarn clean && npm-run-all --parallel build:ui build:report",
     "clean": "rimraf dist",
     "lint": "eslint './src/**/*.{ts,tsx}'",
     "format": "prettier --write '**/**/*.{ts,tsx}'",

--- a/locust/webui/src/assets/Logo.tsx
+++ b/locust/webui/src/assets/Logo.tsx
@@ -1,10 +1,14 @@
-export default function Logo({
-  isDarkMode,
-  lightModeBackgroundColor = '#15803d',
-}: {
-  isDarkMode: boolean;
-  lightModeBackgroundColor?: string;
-}) {
+import { useTheme } from '@mui/material/styles';
+
+import { THEME_MODE } from 'constants/theme';
+
+export default function Logo({ lightModeBackgroundColor }: { lightModeBackgroundColor?: string }) {
+  const theme = useTheme();
+  const strokeColor =
+    theme.palette.mode === THEME_MODE.DARK
+      ? theme.palette.background.default
+      : lightModeBackgroundColor || theme.palette.primary.main;
+
   return (
     <svg
       aria-label='Locust'
@@ -37,7 +41,7 @@ export default function Logo({
       <path
         d='M11.279 5.80442L10.9321 5.97319L10.8347 6.34649L4.72023 29.7764L4.44626 30.8262H5.53125H6.94682H10.2332H10.8805L11.0442 30.1999L15.3834 13.5938L32.3703 30.5807L32.6158 30.8262H32.963H39.4073H41.4309L40 29.3953L15.1525 4.54779L14.7302 4.12549L14.1931 4.38675L11.279 5.80442Z'
         fill='#B8EE4B'
-        stroke={isDarkMode ? '#0B2406' : lightModeBackgroundColor}
+        stroke={strokeColor}
         strokeWidth='1.67636'
       />
       <path

--- a/locust/webui/src/components/Form/Select.tsx
+++ b/locust/webui/src/components/Form/Select.tsx
@@ -7,6 +7,7 @@ interface ISelect extends SelectProps {
   multiple?: boolean;
   defaultValue?: string | string[];
   sx?: SxProps;
+  onChange?: SelectProps['onChange'];
 }
 
 export default function Select({

--- a/locust/webui/src/components/Layout/Navbar/Navbar.tsx
+++ b/locust/webui/src/components/Layout/Navbar/Navbar.tsx
@@ -4,11 +4,8 @@ import Logo from 'assets/Logo';
 import DarkLightToggle from 'components/Layout/Navbar/DarkLightToggle';
 import SwarmMonitor from 'components/Layout/Navbar/SwarmMonitor';
 import StateButtons from 'components/StateButtons/StateButtons';
-import { useSelector } from 'redux/hooks';
 
 export default function Navbar() {
-  const isDarkMode = useSelector(({ theme }) => theme.isDarkMode);
-
   return (
     <AppBar position='static'>
       <Container maxWidth='xl'>
@@ -19,7 +16,7 @@ export default function Navbar() {
             sx={{ display: 'flex', alignItems: 'center' }}
             underline='none'
           >
-            <Logo isDarkMode={isDarkMode} />
+            <Logo />
           </Link>
           <Box sx={{ display: 'flex', columnGap: 6 }}>
             <SwarmMonitor />

--- a/locust/webui/src/components/Tabs/Tabs.constants.tsx
+++ b/locust/webui/src/components/Tabs/Tabs.constants.tsx
@@ -8,47 +8,59 @@ import SwarmRatios from 'components/SwarmRatios/SwarmRatios';
 import WorkersTable from 'components/WorkersTable/WorkersTable';
 import { LOG_VIEWER_KEY } from 'constants/logs';
 import { IRootState } from 'redux/store';
+import { ITab } from 'types/tab.types';
 
-export const baseTabs = [
-  {
+export const tabConfig = {
+  stats: {
     component: StatsTable,
     key: 'stats',
     title: 'Statistics',
   },
-  {
+  charts: {
     component: SwarmCharts,
     key: 'charts',
     title: 'Charts',
   },
-  {
+  failures: {
     component: FailuresTable,
     key: 'failures',
     title: 'Failures',
   },
-  {
+  exceptions: {
     component: ExceptionsTable,
     key: 'exceptions',
     title: 'Exceptions',
   },
-  {
+  ratios: {
     component: SwarmRatios,
     key: 'ratios',
     title: 'Current Ratio',
   },
-  {
+  reports: {
     component: Reports,
     key: 'reports',
     title: 'Download Data',
   },
-  {
+  logs: {
     component: LogViewer,
     key: LOG_VIEWER_KEY,
     title: 'Logs',
   },
-  {
+  workers: {
     component: WorkersTable,
     key: 'workers',
     title: 'Workers',
     shouldDisplayTab: (state: IRootState) => state.swarm.isDistributed,
   },
+};
+
+export const baseTabs: ITab[] = [
+  tabConfig.stats,
+  tabConfig.charts,
+  tabConfig.failures,
+  tabConfig.exceptions,
+  tabConfig.ratios,
+  tabConfig.reports,
+  tabConfig.logs,
+  tabConfig.workers,
 ];

--- a/locust/webui/src/hooks/tests/useFetchExceptions.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchExceptions.test.tsx
@@ -1,0 +1,40 @@
+import { waitFor } from '@testing-library/react';
+import { SWARM_STATE } from 'lib';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { beforeAll, afterEach, afterAll, describe, expect, test } from 'vitest';
+
+import useFetchExceptions from 'hooks/useFetchExceptions';
+import { TEST_BASE_API } from 'test/constants';
+import { exceptionsResponseMock } from 'test/mocks/statsRequest.mock';
+import { renderWithProvider } from 'test/testUtils';
+
+const server = setupServer(
+  http.get(`${TEST_BASE_API}/exceptions`, () => HttpResponse.json(exceptionsResponseMock)),
+);
+
+function MockHook() {
+  useFetchExceptions();
+
+  return <div />;
+}
+
+describe('useFetchExceptions', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  test('should fetch exceptions and update UI accordingly', async () => {
+    const { store } = renderWithProvider(<MockHook />, {
+      swarm: { state: SWARM_STATE.RUNNING },
+    });
+
+    await waitFor(() => {
+      if (!store.getState().ui.exceptions.length) {
+        throw new Error();
+      }
+    });
+
+    expect(store.getState().ui.exceptions[0]).toEqual(exceptionsResponseMock.exceptions[0]);
+  });
+});

--- a/locust/webui/src/hooks/tests/useFetchStats.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchStats.test.tsx
@@ -4,59 +4,57 @@ import { setupServer } from 'msw/node';
 import { beforeAll, afterEach, afterAll, describe, expect, test, vi } from 'vitest';
 
 import { SWARM_STATE } from 'constants/swarm';
-import useSwarmUi from 'hooks/useSwarmUi';
+import useFetchStats from 'hooks/useFetchStats';
 import { swarmActions } from 'redux/slice/swarm.slice';
 import { TEST_BASE_API } from 'test/constants';
-import {
-  ratiosResponseMock,
-  statsResponseTransformed,
-  statsResponseMock,
-  exceptionsResponseMock,
-  mockDate,
-} from 'test/mocks/statsRequest.mock';
+import { statsResponseTransformed, statsResponseMock } from 'test/mocks/statsRequest.mock';
 import { swarmStateMock } from 'test/mocks/swarmState.mock';
 import { renderWithProvider } from 'test/testUtils';
 import { ICharts } from 'types/ui.types';
 
 const server = setupServer(
   http.get(`${TEST_BASE_API}/stats/requests`, () => HttpResponse.json(statsResponseMock)),
-  http.get(`${TEST_BASE_API}/tasks`, () => HttpResponse.json(ratiosResponseMock)),
-  http.get(`${TEST_BASE_API}/exceptions`, () => HttpResponse.json(exceptionsResponseMock)),
 );
 
 function MockHook() {
-  useSwarmUi();
+  useFetchStats();
 
   return <div />;
 }
 
-describe('useSwarmUi', () => {
+describe('useFetchStats', () => {
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
-  test('should fetch request stats, ratios, and exceptions and update UI accordingly', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(mockDate);
-
-    const { store } = renderWithProvider(<MockHook />);
-
-    waitFor(() => {
-      expect(store.getState().ui).toEqual(statsResponseTransformed);
+  test('should fetch request stats and update UI accordingly', async () => {
+    const { store } = renderWithProvider(<MockHook />, {
+      swarm: { state: SWARM_STATE.RUNNING },
     });
 
-    vi.useRealTimers();
+    await waitFor(() => {
+      if (!store.getState().ui.stats.length) {
+        throw new Error();
+      }
+    });
+
+    expect(store.getState().ui.stats).toEqual(statsResponseTransformed.stats);
   });
 
   test('should add markers to charts between tests', async () => {
     vi.useFakeTimers();
 
-    const testStopTime = new Date().toLocaleTimeString();
+    const testStopTime = new Date().toISOString();
 
     const { store } = renderWithProvider(<MockHook />, {
       swarm: {
         ...swarmStateMock,
         state: SWARM_STATE.STOPPED,
+      },
+      ui: {
+        charts: {
+          time: [testStopTime],
+        },
       },
     });
 
@@ -64,17 +62,12 @@ describe('useSwarmUi', () => {
       store.dispatch(swarmActions.setSwarm({ state: SWARM_STATE.RUNNING }));
     });
 
-    vi.advanceTimersByTime(2000);
-
-    waitFor(() => {
-      const testStartTime = new Date().toLocaleTimeString();
-
-      expect((store.getState().ui.charts as ICharts).markers).toEqual([
-        testStopTime,
-        testStartTime,
-      ]);
-
-      vi.useRealTimers();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
     });
+
+    const testStartTime = new Date().toISOString();
+
+    expect((store.getState().ui.charts as ICharts).markers).toEqual([testStopTime, testStartTime]);
   });
 });

--- a/locust/webui/src/hooks/tests/useFetchTasks.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchTasks.test.tsx
@@ -1,0 +1,36 @@
+import { waitFor } from '@testing-library/react';
+import { SWARM_STATE } from 'lib';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { beforeAll, afterEach, afterAll, describe, expect, test } from 'vitest';
+
+import useFetchTasks from 'hooks/useFetchTasks';
+import { TEST_BASE_API } from 'test/constants';
+import { ratiosResponseMock, tasksResponseTransformed } from 'test/mocks/statsRequest.mock';
+import { renderWithProvider } from 'test/testUtils';
+
+const server = setupServer(
+  http.get(`${TEST_BASE_API}/tasks`, () => HttpResponse.json(ratiosResponseMock)),
+);
+
+function MockHook() {
+  useFetchTasks();
+
+  return <div />;
+}
+
+describe('useFetchTasks', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  test('should fetch ratios and update UI accordingly', async () => {
+    const { store } = renderWithProvider(<MockHook />, {
+      swarm: { state: SWARM_STATE.RUNNING },
+    });
+
+    await waitFor(() => {
+      expect(store.getState().ui.ratios.perClass).toEqual(tasksResponseTransformed.perClass);
+    });
+  });
+});

--- a/locust/webui/src/hooks/useCreateTheme.ts
+++ b/locust/webui/src/hooks/useCreateTheme.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
-import { Theme } from '@mui/material/styles';
 
 import { THEME_MODE } from 'constants/theme';
 import { useSelector } from 'redux/hooks';
 import createTheme from 'styles/theme';
 
-export default function useCreateTheme(extendedTheme?: Theme) {
+export default function useCreateTheme() {
   const isDarkMode = useSelector(({ theme: { isDarkMode } }) => isDarkMode);
 
   const theme = useMemo(
-    () => createTheme(isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT, extendedTheme),
+    () => createTheme(isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT),
     [isDarkMode],
   );
 

--- a/locust/webui/src/hooks/useCreateTheme.ts
+++ b/locust/webui/src/hooks/useCreateTheme.ts
@@ -1,16 +1,17 @@
 import { useMemo } from 'react';
+import { Theme } from '@mui/material/styles';
 
 import { THEME_MODE } from 'constants/theme';
 import { useSelector } from 'redux/hooks';
 import createTheme from 'styles/theme';
 
-export default function useTheme() {
+export default function useCreateTheme(extendedTheme?: Theme) {
   const isDarkMode = useSelector(({ theme: { isDarkMode } }) => isDarkMode);
 
   const theme = useMemo(
-    () => createTheme(isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT),
+    () => createTheme(isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT, extendedTheme),
     [isDarkMode],
   );
 
-  return { theme, isDarkMode };
+  return theme;
 }

--- a/locust/webui/src/hooks/useFetchExceptions.ts
+++ b/locust/webui/src/hooks/useFetchExceptions.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { SWARM_STATE, useInterval } from 'lib';
+
+import { useGetExceptionsQuery } from 'redux/api/swarm';
+import { useAction, useSelector } from 'redux/hooks';
+import { uiActions } from 'redux/slice/ui.slice';
+
+export default function useFetchExceptions() {
+  const { data: exceptionsData, refetch: refetchExceptions } = useGetExceptionsQuery();
+  const setUi = useAction(uiActions.setUi);
+
+  const swarmState = useSelector(({ swarm }) => swarm.state);
+
+  const shouldRunRefetchInterval =
+    swarmState === SWARM_STATE.SPAWNING || swarmState == SWARM_STATE.RUNNING;
+
+  useEffect(() => {
+    if (exceptionsData) {
+      setUi({ exceptions: exceptionsData.exceptions });
+    }
+  }, [exceptionsData]);
+
+  useInterval(refetchExceptions, 5000, {
+    shouldRunInterval: shouldRunRefetchInterval,
+  });
+}

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { SWARM_STATE } from 'constants/swarm';
 import useInterval from 'hooks/useInterval';
-import { useGetExceptionsQuery, useGetStatsQuery, useGetTasksQuery } from 'redux/api/swarm';
+import { useGetStatsQuery } from 'redux/api/swarm';
 import { useAction, useSelector } from 'redux/hooks';
 import { swarmActions } from 'redux/slice/swarm.slice';
 import { uiActions } from 'redux/slice/ui.slice';
@@ -21,8 +21,6 @@ export default function useSwarmUi() {
   const [shouldAddMarker, setShouldAddMarker] = useState(false);
 
   const { data: statsData, refetch: refetchStats } = useGetStatsQuery();
-  const { data: tasksData, refetch: refetchTasks } = useGetTasksQuery();
-  const { data: exceptionsData, refetch: refetchExceptions } = useGetExceptionsQuery();
 
   const shouldRunRefetchInterval =
     swarm.state === SWARM_STATE.SPAWNING || swarm.state == SWARM_STATE.RUNNING;
@@ -106,25 +104,7 @@ export default function useSwarmUi() {
     shouldRunInterval: !!statsData && shouldRunRefetchInterval,
   });
 
-  useEffect(() => {
-    if (tasksData) {
-      setUi({ ratios: tasksData });
-    }
-  }, [tasksData]);
-
-  useEffect(() => {
-    if (exceptionsData) {
-      setUi({ exceptions: exceptionsData.exceptions });
-    }
-  }, [exceptionsData]);
-
   useInterval(refetchStats, STATS_REFETCH_INTERVAL, {
-    shouldRunInterval: shouldRunRefetchInterval,
-  });
-  useInterval(refetchTasks, 5000, {
-    shouldRunInterval: shouldRunRefetchInterval,
-  });
-  useInterval(refetchExceptions, 5000, {
     shouldRunInterval: shouldRunRefetchInterval,
   });
 

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -10,7 +10,7 @@ import { roundToDecimalPlaces } from 'utils/number';
 
 const STATS_REFETCH_INTERVAL = 2000;
 
-export default function useSwarmUi() {
+export default function useFetchStats() {
   const setSwarm = useAction(swarmActions.setSwarm);
   const setUi = useAction(uiActions.setUi);
   const updateCharts = useAction(uiActions.updateCharts);
@@ -25,7 +25,7 @@ export default function useSwarmUi() {
   const shouldRunRefetchInterval =
     swarm.state === SWARM_STATE.SPAWNING || swarm.state == SWARM_STATE.RUNNING;
 
-  const updateStatsUi = () => {
+  const updateStats = () => {
     if (!statsData) {
       return;
     }
@@ -93,14 +93,14 @@ export default function useSwarmUi() {
     if (statsData) {
       if (!hasSetInitStats.current) {
         // handle setting stats on first load
-        updateStatsUi();
+        updateStats();
       }
 
       hasSetInitStats.current = true;
     }
   }, [statsData]);
 
-  useInterval(updateStatsUi, STATS_REFETCH_INTERVAL, {
+  useInterval(updateStats, STATS_REFETCH_INTERVAL, {
     shouldRunInterval: !!statsData && shouldRunRefetchInterval,
   });
 

--- a/locust/webui/src/hooks/useFetchTasks.ts
+++ b/locust/webui/src/hooks/useFetchTasks.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { SWARM_STATE, useInterval } from 'lib';
+
+import { useGetTasksQuery } from 'redux/api/swarm';
+import { useAction, useSelector } from 'redux/hooks';
+import { uiActions } from 'redux/slice/ui.slice';
+
+export default function useFetchTasks() {
+  const { data: tasksData, refetch: refetchTasks } = useGetTasksQuery();
+  const setUi = useAction(uiActions.setUi);
+
+  const swarmState = useSelector(({ swarm }) => swarm.state);
+
+  const shouldRunRefetchInterval =
+    swarmState === SWARM_STATE.SPAWNING || swarmState == SWARM_STATE.RUNNING;
+
+  useEffect(() => {
+    if (tasksData) {
+      setUi({ ratios: tasksData });
+    }
+  }, [tasksData]);
+
+  useInterval(refetchTasks, 5000, {
+    shouldRunInterval: shouldRunRefetchInterval,
+  });
+}

--- a/locust/webui/src/lib.tsx
+++ b/locust/webui/src/lib.tsx
@@ -14,6 +14,12 @@ export { default as useInterval } from 'hooks/useInterval';
 export { roundToDecimalPlaces } from 'utils/number';
 export { SWARM_STATE } from 'constants/swarm';
 export { default as Select } from 'components/Form/Select';
+export { default as SwarmForm } from 'components/SwarmForm/SwarmForm';
+export { default as Tabs } from 'components/Tabs/Tabs';
+export { default as Layout } from 'components/Layout/Layout';
+export { default as useLogViewer } from 'components/LogViewer/useLogViewer';
+export { default as useFetchStats } from 'hooks/useFetchStats';
+
 export type { IRootState } from 'redux/store';
 
 export type { ITab } from 'types/tab.types';

--- a/locust/webui/src/lib.tsx
+++ b/locust/webui/src/lib.tsx
@@ -18,7 +18,12 @@ export { default as SwarmForm } from 'components/SwarmForm/SwarmForm';
 export { default as Tabs } from 'components/Tabs/Tabs';
 export { default as Layout } from 'components/Layout/Layout';
 export { default as useLogViewer } from 'components/LogViewer/useLogViewer';
+export { default as useFetchExceptions } from 'hooks/useFetchExceptions';
+export { default as useFetchTasks } from 'hooks/useFetchTasks';
 export { default as useFetchStats } from 'hooks/useFetchStats';
+export { default as Navbar } from 'components/Layout/Navbar/Navbar';
+export { default as useTheme } from 'hooks/useTheme';
+export { store as locustStore } from 'redux/store';
 
 export type { IRootState } from 'redux/store';
 

--- a/locust/webui/src/lib.tsx
+++ b/locust/webui/src/lib.tsx
@@ -22,7 +22,8 @@ export { default as useFetchExceptions } from 'hooks/useFetchExceptions';
 export { default as useFetchTasks } from 'hooks/useFetchTasks';
 export { default as useFetchStats } from 'hooks/useFetchStats';
 export { default as Navbar } from 'components/Layout/Navbar/Navbar';
-export { default as useTheme } from 'hooks/useTheme';
+export { default as useCreateTheme } from 'hooks/useCreateTheme';
+export { tabConfig } from 'components/Tabs/Tabs.constants';
 export { store as locustStore } from 'redux/store';
 
 export type { IRootState } from 'redux/store';

--- a/locust/webui/src/pages/Auth.tsx
+++ b/locust/webui/src/pages/Auth.tsx
@@ -4,11 +4,11 @@ import { ThemeProvider } from '@mui/material/styles';
 
 import Logo from 'assets/Logo';
 import DarkLightToggle from 'components/Layout/Navbar/DarkLightToggle';
-import useTheme from 'hooks/useTheme';
+import useCreateTheme from 'hooks/useCreateTheme';
 import { IAuthArgs } from 'types/auth.types';
 
 export default function Auth({ authProviders, error, usernamePasswordCallback }: IAuthArgs) {
-  const { theme, isDarkMode } = useTheme();
+  const theme = useCreateTheme();
 
   return (
     <ThemeProvider theme={theme}>
@@ -34,7 +34,7 @@ export default function Auth({ authProviders, error, usernamePasswordCallback }:
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'center', columnGap: 2 }}>
-          <Logo isDarkMode={isDarkMode} lightModeBackgroundColor='#fff' />
+          <Logo lightModeBackgroundColor='#fff' />
         </Box>
         {usernamePasswordCallback && (
           <form action={usernamePasswordCallback}>

--- a/locust/webui/src/pages/Dashboard.tsx
+++ b/locust/webui/src/pages/Dashboard.tsx
@@ -7,7 +7,9 @@ import useLogViewer from 'components/LogViewer/useLogViewer';
 import SwarmForm from 'components/SwarmForm/SwarmForm';
 import Tabs from 'components/Tabs/Tabs';
 import { SWARM_STATE } from 'constants/swarm';
-import useSwarmUi from 'hooks/useSwarmUi';
+import useFetchExceptions from 'hooks/useFetchExceptions';
+import useFetchStats from 'hooks/useFetchStats';
+import useFetchTasks from 'hooks/useFetchTasks';
 import useTheme from 'hooks/useTheme';
 import { IRootState } from 'redux/store';
 import { ITab } from 'types/tab.types';
@@ -21,7 +23,9 @@ interface IDashboard {
 }
 
 function Dashboard({ swarmState, tabs, extendedTabs }: IDashboard) {
-  useSwarmUi();
+  useFetchStats();
+  useFetchExceptions();
+  useFetchTasks();
   useLogViewer();
 
   const { theme } = useTheme();

--- a/locust/webui/src/pages/Dashboard.tsx
+++ b/locust/webui/src/pages/Dashboard.tsx
@@ -7,10 +7,10 @@ import useLogViewer from 'components/LogViewer/useLogViewer';
 import SwarmForm from 'components/SwarmForm/SwarmForm';
 import Tabs from 'components/Tabs/Tabs';
 import { SWARM_STATE } from 'constants/swarm';
+import useCreateTheme from 'hooks/useCreateTheme';
 import useFetchExceptions from 'hooks/useFetchExceptions';
 import useFetchStats from 'hooks/useFetchStats';
 import useFetchTasks from 'hooks/useFetchTasks';
-import useTheme from 'hooks/useTheme';
 import { IRootState } from 'redux/store';
 import { ITab } from 'types/tab.types';
 import { SwarmState } from 'types/ui.types';
@@ -28,7 +28,7 @@ function Dashboard({ swarmState, tabs, extendedTabs }: IDashboard) {
   useFetchTasks();
   useLogViewer();
 
-  const { theme } = useTheme();
+  const theme = useCreateTheme();
 
   return (
     <ThemeProvider theme={theme}>

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -146,7 +146,6 @@ export const statsResponseTransformed = {
       occurrences: 12652,
     },
   ],
-  exceptions: exceptionsResponseMock.exceptions,
   extendedStats: undefined,
   charts: {
     'responseTimePercentile0.5': [[mockDate.toISOString(), 2]],
@@ -157,20 +156,21 @@ export const statsResponseTransformed = {
     totalAvgResponseTime: [[mockDate.toISOString(), 0.41]],
     time: [],
   } as ICharts,
-  ratios: {
-    perClass: {
-      Example: {
-        ratio: 1,
-        tasks: { ExampleTest: { ratio: 1, tasks: { example: { ratio: 1 } } } },
-      },
-    },
-    total: {
-      Example: {
-        ratio: 1,
-        tasks: { ExampleTest: { ratio: 1, tasks: { example: { ratio: 1 } } } },
-      },
-    },
-  },
   userCount: 1,
   workers: undefined,
+};
+
+export const tasksResponseTransformed = {
+  perClass: {
+    Example: {
+      ratio: 1,
+      tasks: { ExampleTest: { ratio: 1, tasks: { example: { ratio: 1 } } } },
+    },
+  },
+  total: {
+    Example: {
+      ratio: 1,
+      tasks: { ExampleTest: { ratio: 1, tasks: { example: { ratio: 1 } } } },
+    },
+  },
 };


### PR DESCRIPTION
### Proposal
- Separate the useSwarmUI hook into three separate hooks. This will improve maintainability, performance, and testability. It will also allow for the hooks to be selectively imported and used in library mode as need be
- Add more exports
- Update logo to reduce hook calls and potentially allow for custom theming in the future
- Add steps to prerelease and release to deploy on NPM (tested in a separate repository so we should see these working as expected
- Export tabs as an object rather than an array in library mode for ease of use
- Add more exports from the locust-ui library
- Update locust-ui README
- Deployed a beta version of the locust UI on NPM: https://www.npmjs.com/package/locust-ui