### PR TITLE
Web UI Github Action Publish steps must Build lib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,7 @@ jobs:
         run: |
           yarn webui:install
           yarn webui:build
+          yarn webui:build:lib
       - name: Build + set TAG env var for later use
         run: |
           SKIP_PRE_BUILD=true python -m poetry build
@@ -278,6 +279,7 @@ jobs:
         run: |
           yarn webui:install
           yarn webui:build
+          yarn webui:build:lib
       - name: Build
         if: ${{ env.NOT_MERGE_COMMIT == '' }}
         run: |


### PR DESCRIPTION
The publish and pre-publish steps need to build the library explicitly before publishing