### PR TITLE
Webui Allow changing select input size

### DIFF
--- a/locust/webui/src/components/Form/Select.tsx
+++ b/locust/webui/src/components/Form/Select.tsx
@@ -16,11 +16,12 @@ export default function Select({
   options,
   multiple = false,
   defaultValue,
+  size = 'medium',
   sx,
   ...inputProps
 }: ISelect) {
   return (
-    <FormControl sx={sx}>
+    <FormControl size={size} sx={sx}>
       <InputLabel htmlFor={name} shrink>
         {label}
       </InputLabel>

--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -125,7 +125,7 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
   },
   xAxis: {
     type: 'time',
-    startValue: charts.time[0],
+    startValue: (charts.time || [''])[0],
     axisLabel: {
       formatter: formatTimeAxis,
     },

--- a/locust/webui/src/redux/slice/ui.slice.ts
+++ b/locust/webui/src/redux/slice/ui.slice.ts
@@ -76,7 +76,7 @@ const uiSlice = createSlice({
           ...addSpaceToChartsBetweenTests(state.charts as ICharts),
           markers: (state.charts as ICharts).markers
             ? [...((state.charts as ICharts).markers as string[]), payload]
-            : [state.charts.time[0], payload],
+            : [(state.charts.time || [''])[0], payload],
         },
       };
     },


### PR DESCRIPTION
### Proposal
1. Allow the select input size to be controlled
2. Safeguard charts.time, which is possibly undefined when using the Charts component as a library