### PR TITLE
Correct types for form select

### DIFF
--- a/locust/webui/src/components/Form/Select.tsx
+++ b/locust/webui/src/components/Form/Select.tsx
@@ -1,14 +1,13 @@
 import { SxProps, FormControl, InputLabel, Select as MuiSelect, SelectProps } from '@mui/material';
 
-interface ISelect extends SelectProps {
+type ISelect = SelectProps & {
   label: string;
   name: string;
   options: string[];
   multiple?: boolean;
   defaultValue?: string | string[];
   sx?: SxProps;
-  onChange?: SelectProps['onChange'];
-}
+};
 
 export default function Select({
   label,


### PR DESCRIPTION
Use an intersection rather than interface extension for the select input, such that the MUI select prop types will be properly received