### PR TITLE
Web UI Remove Scroll to Zoom

### DIFF
--- a/locust/webui/src/components/LineChart/LineChart.types.ts
+++ b/locust/webui/src/components/LineChart/LineChart.types.ts
@@ -18,7 +18,7 @@ export interface ILineChart<ChartType> {
 }
 
 export interface ILineChartZoomEvent {
-  batch?: { start: number; end: number }[];
+  batch?: { start: number; startValue: number; end: number }[];
 }
 
 export interface ILineChartMarkers {

--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -91,13 +91,6 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
   scatterplot,
 }: ILineChart<ChartType>) => ({
   title: { text: title },
-  dataZoom: [
-    {
-      type: 'inside',
-      start: 0,
-      end: 100,
-    },
-  ],
   tooltip: {
     trigger: 'axis',
     formatter: (params?: ILineChartTooltipFormatterParams[] | null) => {
@@ -138,11 +131,11 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
     right: 10,
     feature: {
       dataZoom: {
-        show: true,
         title: {
           zoom: 'Zoom Select',
           back: 'Zoom Reset',
         },
+        yAxisIndex: false,
       },
       saveAsImage: {
         name: title.replace(/\s+/g, '_').toLowerCase() + '_' + new Date().getTime() / 1000,
@@ -176,21 +169,14 @@ export const onChartZoom = (chart: ECharts) => (datazoom: unknown) => {
     return;
   }
 
-  const [{ start, end }] = batch;
-  const isZoomed = start > 0 && end < 100;
+  const [{ start, startValue, end }] = batch;
+  const isZoomed = (start > 0 && end <= 100) || startValue > 0;
 
   chart.setOption({
     dataZoom: [
       {
-        type: 'inside',
-        start,
-        end,
-      },
-      {
         type: 'slider',
         show: isZoomed,
-        start,
-        end,
       },
     ],
   });

--- a/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
+++ b/locust/webui/src/components/LineChart/tests/LineChartUtils.test.tsx
@@ -65,16 +65,10 @@ describe('createOptions', () => {
     expect(options.color).toEqual(['#fff']);
   });
 
-  test('should not apply any default zoom', () => {
+  test('should not apply any scroll zoom by default', () => {
     const options = createOptions<MockChartType>(createOptionsDefaultProps);
 
-    expect(options.dataZoom).toEqual([
-      {
-        type: 'inside',
-        start: 0,
-        end: 100,
-      },
-    ]);
+    expect((options as any).dataZoom).toBe(undefined);
   });
 
   test('xAxis should be formatted as expected', () => {
@@ -255,10 +249,7 @@ describe('onChartZoom', () => {
     });
 
     expect(mockChart.setOption).toHaveBeenCalledWith({
-      dataZoom: [
-        { type: 'inside', start: 10, end: 90 },
-        { type: 'slider', show: true, start: 10, end: 90 },
-      ],
+      dataZoom: [{ type: 'slider', show: true }],
     });
   });
 
@@ -275,16 +266,10 @@ describe('onChartZoom', () => {
     });
 
     expect(mockChart.setOption).nthCalledWith(1, {
-      dataZoom: [
-        { type: 'inside', start: 50, end: 60 },
-        { type: 'slider', show: true, start: 50, end: 60 },
-      ],
+      dataZoom: [{ type: 'slider', show: true }],
     });
     expect(mockChart.setOption).nthCalledWith(2, {
-      dataZoom: [
-        { type: 'inside', start: 0, end: 100 },
-        { type: 'slider', show: false, start: 0, end: 100 },
-      ],
+      dataZoom: [{ type: 'slider', show: false }],
     });
   });
 });


### PR DESCRIPTION
The chart may now only be scrolled using the toolbox. When zoomed a slider is also visible, the slider is then removed when zoom is reset. I could not find a way to have scroll zoom when holding the shift button without the mouse scroll event being locked for the charts