### PR TITLE
Webui Remove chart initial data fetch

### DIFF
--- a/locust/webui/src/hooks/tests/useFetchStats.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchStats.test.tsx
@@ -1,4 +1,4 @@
-import { act, waitFor } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { beforeAll, afterEach, afterAll, describe, expect, test, vi } from 'vitest';
@@ -23,27 +23,32 @@ function MockHook() {
 }
 
 describe('useFetchStats', () => {
-  beforeAll(() => server.listen());
+  beforeAll(() => {
+    server.listen();
+    vi.useFakeTimers();
+  });
   afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  afterAll(() => {
+    server.close();
+    vi.useRealTimers();
+  });
 
   test('should fetch request stats and update UI accordingly', async () => {
     const { store } = renderWithProvider(<MockHook />, {
       swarm: { state: SWARM_STATE.RUNNING },
     });
 
-    await waitFor(() => {
-      if (!store.getState().ui.stats.length) {
-        throw new Error();
-      }
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
     });
 
     expect(store.getState().ui.stats).toEqual(statsResponseTransformed.stats);
   });
 
   test('should add markers to charts between tests', async () => {
-    vi.useFakeTimers();
-
     const testStopTime = new Date().toISOString();
 
     const { store } = renderWithProvider(<MockHook />, {
@@ -62,6 +67,9 @@ describe('useFetchStats', () => {
       store.dispatch(swarmActions.setSwarm({ state: SWARM_STATE.RUNNING }));
     });
 
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -17,7 +17,6 @@ export default function useFetchStats() {
   const updateChartMarkers = useAction(uiActions.updateChartMarkers);
   const swarm = useSelector(({ swarm }) => swarm);
   const previousSwarmState = useRef(swarm.state);
-  const hasSetInitStats = useRef(false);
   const [shouldAddMarker, setShouldAddMarker] = useState(false);
 
   const { data: statsData, refetch: refetchStats } = useGetStatsQuery();
@@ -88,17 +87,6 @@ export default function useFetchStats() {
       setSwarm({ state: statsData.state });
     }
   }, [statsData && statsData.state]);
-
-  useEffect(() => {
-    if (statsData) {
-      if (!hasSetInitStats.current) {
-        // handle setting stats on first load
-        updateStats();
-      }
-
-      hasSetInitStats.current = true;
-    }
-  }, [statsData]);
 
   useInterval(updateStats, STATS_REFETCH_INTERVAL, {
     shouldRunInterval: !!statsData && shouldRunRefetchInterval,


### PR DESCRIPTION
Fixes #2870 

### Issue
The issue was introduced when we switched the x-axis to type time. On each reload the current timestamp is recorded, causing it to appear as data is still being collected, even after a test stop