### PR TITLE
Add publishing dependency on build package step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -270,7 +270,7 @@ jobs:
 
   publish:
     name: Publish prerelease on merge commit to master
-    needs: [tox_tests, lint_typecheck_test_webui, test_docker_image]
+    needs: [tox_tests, lint_typecheck_test_webui, test_docker_image, build_package]
     if: github.repository_owner == 'locustio' && ( github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags') )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Overview

Adds a dependency on the build package step, from the POV of the publishing step.

Apparently, transitive dependencies are not acceptable for Github Actions job outputs, but there's no warning thrown about this during parsing, fun!