### PR TITLE
fix: Add more worker info to LocalRunner for parity with others

### DIFF
--- a/examples/custom_messages.py
+++ b/examples/custom_messages.py
@@ -1,5 +1,5 @@
 from locust import HttpUser, between, events, task
-from locust.runners import MasterRunner, WorkerRunner
+from locust.runners import LocalRunner, MasterRunner, WorkerRunner
 
 import gevent
 
@@ -44,8 +44,12 @@ def on_test_start(environment, **_kwargs):
 
         worker_count = environment.runner.worker_count
         chunk_size = int(len(users) / worker_count)
+        if isinstance(environment.runner, LocalRunner):
+            workers = [environment.runner]
+        else:
+            workers = [environment.runner.clients]
 
-        for i, worker in enumerate(environment.runner.clients):
+        for i, worker in enumerate(workers):
             start_index = i * chunk_size
 
             if i + 1 < worker_count:

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -437,6 +437,8 @@ class LocalRunner(Runner):
         # but it makes it easier to write tests that work for both local and distributed runs
         self.worker_index = 0
         self.client_id = socket.gethostname() + "_" + uuid4().hex
+        self.worker_count = 1
+        self.workers = [self]
         # Only when running in standalone mode (non-distributed)
         self._local_worker_node = WorkerNode(id="local")
         self._local_worker_node.user_classes_count = self.user_classes_count

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -438,7 +438,6 @@ class LocalRunner(Runner):
         self.worker_index = 0
         self.client_id = socket.gethostname() + "_" + uuid4().hex
         self.worker_count = 1
-        self.workers = [self]
         # Only when running in standalone mode (non-distributed)
         self._local_worker_node = WorkerNode(id="local")
         self._local_worker_node.user_classes_count = self.user_classes_count


### PR DESCRIPTION
This prevents the `custom_messages` example from failing when running locally with `AttributeError`s for `environment.runner.worker_count` and `environment.runner.clients`.

ref: https://github.com/locustio/locust/blob/7c85b7988c643ee8f688c8bb6919272c38fbcf7b/examples/custom_messages.py#L45-L48