### PR TITLE
Fix Login Manager Error Message

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -135,6 +135,11 @@ class WebUI:
         # ensures static js files work on Windows
         mimetypes.add_type("application/javascript", ".js")
 
+        if self.web_login:
+            self._login_manager = LoginManager()
+            self._login_manager.init_app(self.app)
+            self._login_manager.login_view = "login"
+
         if environment.runner:
             self.update_template_args()
         if not delayed_start:
@@ -516,12 +521,13 @@ class WebUI:
     @property
     def login_manager(self):
         if self.web_login:
-            login_manager = LoginManager()
-            login_manager.init_app(self.app)
-            login_manager.login_view = "login"
-            return login_manager
+            return self._login_manager
 
         raise AttributeError("The login_manager is only available with --web-login.\n")
+
+    @login_manager.setter
+    def login_manager(self, value):
+        self._login_manager = value
 
     def start(self):
         self.greenlet = gevent.spawn(self.start_server)


### PR DESCRIPTION
When the `--web-login` flag is used without a login_manager, we should pass the error from flask_login to communicate that a user or request loader must be set

### Before Fix
`Locust auth exception: 'Flask' object has no attribute 'login_manager' See https://docs.locust.io/en/stable/extending-locust.html#adding-authentication-to-the-web-ui for configuring authentication.`

### After Fix
`Locust auth exception: Missing user_loader or request_loader. Refer to http://flask-login.readthedocs.io/#how-it-works for more info. See https://docs.locust.io/en/stable/extending-locust.html#adding-authentication-to-the-web-ui for configuring authentication.`