### PR TITLE
Pin python versions to avoid gh caching issue + always Install Dependencies, even when it looks like there was a cache hit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --no-plugins
 
       # Install node and yarn in order to build the front end during packaging  
@@ -180,7 +180,7 @@ jobs:
           path: .venv
           key: venv-tox-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --with test,docs --no-plugins
 
       # Grab the built artifacts to ensure we're testing what we eventually publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,16 +133,16 @@ jobs:
       matrix:
         include:
           # Static analysis and utilities
-          - { name: "Ruff", python: "3.11.9", os: ubuntu-latest, tox: "ruff" }
-          - { name: "Mypy", python: "3.11.9", os: ubuntu-latest, tox: "mypy" }
+          - { name: "Ruff", python: "3.12.5", os: ubuntu-latest, tox: "ruff" }
+          - { name: "Mypy", python: "3.12.5", os: ubuntu-latest, tox: "mypy" }
 
           # Verification of builds and other aspects          
-          - { name: "Docs Build", python: "3.11.9", os: ubuntu-latest, tox: "docs" }
+          - { name: "Docs Build", python: "3.12.5", os: ubuntu-latest, tox: "docs" }
 
           # OS Integration tests 
-          - { name: "Linux", python: "3.11.9", os: ubuntu-latest, tox: fail_fast_test_main_external_package }
-          - { name: "Windows", python: '3.11.9', os: windows-latest, tox: fail_fast_test_main_external_package }
-          - { name: "MacOS", python: '3.11.9', os: macos-latest, tox: fail_fast_test_main_external_package }
+          - { name: "Linux", python: "3.12.5", os: ubuntu-latest, tox: fail_fast_test_main_external_package }
+          - { name: "Windows", python: '3.12.5', os: windows-latest, tox: fail_fast_test_main_external_package }
+          - { name: "MacOS", python: '3.12.5', os: macos-latest, tox: fail_fast_test_main_external_package }
           
           # Unit tests on Python versions
           - { name: "Python 3.12", python: "3.12.5", os: ubuntu-latest, tox: py312 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,22 +133,22 @@ jobs:
       matrix:
         include:
           # Static analysis and utilities
-          - { name: "Ruff", python: "3.11", os: ubuntu-latest, tox: "ruff" }
-          - { name: "Mypy", python: "3.10", os: ubuntu-latest, tox: "mypy" }
+          - { name: "Ruff", python: "3.11.9", os: ubuntu-latest, tox: "ruff" }
+          - { name: "Mypy", python: "3.11.9", os: ubuntu-latest, tox: "mypy" }
 
           # Verification of builds and other aspects          
-          - { name: "Docs Build", python: "3.10", os: ubuntu-latest, tox: "docs" }
+          - { name: "Docs Build", python: "3.11.9", os: ubuntu-latest, tox: "docs" }
 
           # OS Integration tests 
-          - { name: "Linux", python: "3.12", os: ubuntu-latest, tox: fail_fast_test_main_external_package }
-          - { name: "Windows", python: '3.12.5', os: windows-latest, tox: fail_fast_test_main_external_package }
-          - { name: "MacOS", python: '3.12', os: macos-latest, tox: fail_fast_test_main_external_package }
+          - { name: "Linux", python: "3.11.9", os: ubuntu-latest, tox: fail_fast_test_main_external_package }
+          - { name: "Windows", python: '3.11.9', os: windows-latest, tox: fail_fast_test_main_external_package }
+          - { name: "MacOS", python: '3.11.9', os: macos-latest, tox: fail_fast_test_main_external_package }
           
           # Unit tests on Python versions
-          - { name: "Python 3.12", python: "3.12", os: ubuntu-latest, tox: py312 }
-          - { name: "Python 3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
-          - { name: "Python 3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
-          - { name: "Python 3.9", python: "3.9", os: ubuntu-latest, tox: py39 }
+          - { name: "Python 3.12", python: "3.12.5", os: ubuntu-latest, tox: py312 }
+          - { name: "Python 3.11", python: "3.11.9", os: ubuntu-latest, tox: py311 }
+          - { name: "Python 3.10", python: "3.10.14", os: ubuntu-latest, tox: py310 }
+          - { name: "Python 3.9", python: "3.9.20", os: ubuntu-latest, tox: py39 }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
workaround for `/home/runner/work/locust/locust/.venv/bin/tox: /home/runner/work/locust/locust/.venv/bin/python: bad interpreter: No such file or directory`