### PR TITLE
Fix RTD versioning with a deep git clone

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ build:
   tools:
     python: "3.11"
   jobs:
+    post_checkout:
+      - git fetch --unshallow || true
     post_create_environment:
       - python -m pip install poetry
       - python -m poetry self add "poetry-dynamic-versioning[plugin]"


### PR DESCRIPTION
# Fixing published Locust version in RTD Docs

Currently the published docs using RTD have the wrong version of Locust during the docs build, because the full Git history isn't there. The `tox` tests previously had this issue when the base checkout didn't pull the whole git history. This results in something like the below:

```
locust -V
locust 0.0.1.dev286 from /usr/local/lib/python3.12/site-packages/locust (Python 3.12.5)
```

This PR updates this based on guidance from RTD's own docs, though it's difficult to actually test that this works without overwriting the current docs 🤔 

RTD docs on this here:
https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone