### PR TITLE
Decide if ipv6 can work

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,10 +1,11 @@
 from locust.exception import RPCError, RPCReceiveError, RPCSendError
 from locust.util.exception_handler import retry
 
+from socket import IPPROTO_TCP, getaddrinfo, has_dualstack_ipv6
+
 import msgpack.exceptions as msgerr
 import zmq.error as zmqerr
 import zmq.green as zmq
-from socket import getaddrinfo, IPPROTO_TCP, has_dualstack_ipv6
 
 from .protocol import Message
 

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -4,19 +4,19 @@ from locust.util.exception_handler import retry
 import msgpack.exceptions as msgerr
 import zmq.error as zmqerr
 import zmq.green as zmq
-from urllib3.util.connection import HAS_IPV6
+from socket import getaddrinfo, IPPROTO_TCP, has_dualstack_ipv6
 
 from .protocol import Message
 
 
 class BaseSocket:
-    def __init__(self, sock_type):
+    def __init__(self, sock_type, ipv4_only):
         context = zmq.Context()
         self.socket = context.socket(sock_type)
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-        if HAS_IPV6:
+        if has_dualstack_ipv6() and not ipv4_only:
             self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()
@@ -60,10 +60,15 @@ class BaseSocket:
     def close(self, linger=None):
         self.socket.close(linger=linger)
 
+    def ipv4_only(self, host, port) -> bool:
+        if str(getaddrinfo(host, port, proto=IPPROTO_TCP)).find("Family.AF_INET6") == -1:
+            return True
+        return False
+
 
 class Server(BaseSocket):
     def __init__(self, host, port):
-        BaseSocket.__init__(self, zmq.ROUTER)
+        BaseSocket.__init__(self, zmq.ROUTER, self.ipv4_only(host, port))
         if port == 0:
             self.port = self.socket.bind_to_random_port(f"tcp://{host}")
         else:
@@ -76,6 +81,6 @@ class Server(BaseSocket):
 
 class Client(BaseSocket):
     def __init__(self, host, port, identity):
-        BaseSocket.__init__(self, zmq.DEALER)
+        BaseSocket.__init__(self, zmq.DEALER, self.ipv4_only(host, port))
         self.socket.setsockopt(zmq.IDENTITY, identity.encode())
         self.socket.connect("tcp://%s:%i" % (host, port))

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -2,6 +2,7 @@ from locust.exception import RPCError, RPCReceiveError, RPCSendError
 from locust.util.exception_handler import retry
 
 import socket as csocket
+from socket import gaierror, has_dualstack_ipv6
 
 import msgpack.exceptions as msgerr
 import zmq.error as zmqerr
@@ -17,7 +18,7 @@ class BaseSocket:
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-        if csocket.has_dualstack_ipv6() and not ipv4_only:
+        if has_dualstack_ipv6() and not ipv4_only:
             self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()
@@ -65,7 +66,7 @@ class BaseSocket:
         try:
             if str(csocket.getaddrinfo(host, port, proto=csocket.IPPROTO_TCP)).find("Family.AF_INET6") == -1:
                 return True
-        except csocket.gaierror as e:
+        except gaierror as e:
             print(f"Error resolving address: {e}")
             return False
         return False

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,11 +1,12 @@
 from locust.exception import RPCError, RPCReceiveError, RPCSendError
 from locust.util.exception_handler import retry
 
-from socket import IPPROTO_TCP, getaddrinfo, has_dualstack_ipv6
+from socket import IPPROTO_TCP, getaddrinfo
 
 import msgpack.exceptions as msgerr
 import zmq.error as zmqerr
 import zmq.green as zmq
+from urllib3.util.connection import HAS_IPV6
 
 from .protocol import Message
 
@@ -17,7 +18,7 @@ class BaseSocket:
 
         self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
         self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-        if has_dualstack_ipv6() and not ipv4_only:
+        if HAS_IPV6 and not ipv4_only:
             self.socket.setsockopt(zmq.IPV6, 1)
 
     @retry()


### PR DESCRIPTION
**Summary of changes:**

Previously IPV6 was enabled if the kernel supported the IPV6 stack.  This was an issue in the distributed scenario when there is a network component between the master and worker nodes that does not support IPV6.  This is the case for example in AWS EKS cluster where the service resource does not support IPV6 even if the pods in the cluster do.  
To avoid attempting to communicate over IPv6 when it is not possible, some basic logic was added  which does the following:

1. Determine as before if the kernel supports IPv6, but uses the socket method, has_dualstack_ipv6().  This does not have the limitations of has_ipv6() of the socket library (and I imagine the reason why it was avoided) since it actually does a syscall to the kernel which will fail if the kernel does not support IPv6.  We chose to switch to this method (from that of urllib3) since we needed other methods from the basic python socket library.
2. Verify if the master hostname can be resolved as an IPv6 address.  This was deemed as a reasonable way to determine if the network environment supports IPv6 (outside of the OS where locust is running).  No admin would configure AAAA DNS records if the network isn't completely IPv6 ready.
3. If IP addresses are used instead of host names (for example in the bind on the server side), then determine if the address is a valid IPv6 address or not. 

The same checks are done independently on the server and client during socket creation and will require no changes in the use of locust.  For example, currently the bind address of '*' will cause the master node to listen on both IPv6 and IPv4 addresses.  This behaves the same as before while setting master_bind_host to an IPv4 address, such as '0.0.0.0', will prevent zmq from enabling IPv6 on the master since it should only listen on an IPv4 interface.