### PR TITLE
Modern UI - Fix Hide Common Options

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -645,6 +645,8 @@ class WebUI:
                 self.environment.shape_class
                 and not (self.userclass_picker_is_active or self.environment.shape_class.use_common_options)
             ),
+            "shape_use_common_options": self.environment.shape_class
+            and self.environment.shape_class.use_common_options,
             "stats_history_enabled": options and options.stats_history_enabled,
             "tasks": dumps({}),
             "extra_options": extra_options,

--- a/locust/webui/src/components/Form/NumericField.tsx
+++ b/locust/webui/src/components/Form/NumericField.tsx
@@ -19,5 +19,12 @@ export default function NumericField(textFieldProps: TextFieldProps) {
     setValue(event.target.value.replace(/[^0-9.]/g, ''));
   };
 
-  return <TextField {...textFieldProps} onInput={filterNonNumeric} value={value} />;
+  return (
+    <TextField
+      {...textFieldProps}
+      defaultValue={undefined}
+      onChange={filterNonNumeric}
+      value={value}
+    />
+  );
 }

--- a/locust/webui/src/components/Form/NumericField.tsx
+++ b/locust/webui/src/components/Form/NumericField.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TextField, TextFieldProps } from '@mui/material';
 
-export default function NumericField(textFieldProps: TextFieldProps) {
-  const [value, setValue] = useState<string>((textFieldProps.defaultValue as string) || '');
+export default function NumericField({ defaultValue, ...textFieldProps }: TextFieldProps) {
+  const [value, setValue] = useState<string>((defaultValue as string) || '');
 
   const filterNonNumeric = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (textFieldProps.onChange) {
@@ -19,12 +19,9 @@ export default function NumericField(textFieldProps: TextFieldProps) {
     setValue(event.target.value.replace(/[^0-9.]/g, ''));
   };
 
-  return (
-    <TextField
-      {...textFieldProps}
-      defaultValue={undefined}
-      onChange={filterNonNumeric}
-      value={value}
-    />
-  );
+  useEffect(() => {
+    setValue(defaultValue as string);
+  }, [defaultValue]);
+
+  return <TextField {...textFieldProps} onChange={filterNonNumeric} value={value} />;
 }

--- a/locust/webui/src/components/Form/NumericField.tsx
+++ b/locust/webui/src/components/Form/NumericField.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { TextField, TextFieldProps } from '@mui/material';
+
+export default function NumericField(textFieldProps: TextFieldProps) {
+  const [value, setValue] = useState<string>((textFieldProps.defaultValue as string) || '');
+
+  const filterNonNumeric = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (textFieldProps.onChange) {
+      textFieldProps.onChange(event);
+    }
+
+    const currentValue = event.target.value;
+    const decimalPoints = (currentValue.match(/\./g) || []).length;
+
+    if (decimalPoints > 1) {
+      return;
+    }
+
+    setValue(event.target.value.replace(/[^0-9.]/g, ''));
+  };
+
+  return <TextField {...textFieldProps} onInput={filterNonNumeric} value={value} />;
+}

--- a/locust/webui/src/components/StateButtons/EditButton.tsx
+++ b/locust/webui/src/components/StateButtons/EditButton.tsx
@@ -1,17 +1,30 @@
 import { useState } from 'react';
-import { Button } from '@mui/material';
+import { Box, Button, Tooltip } from '@mui/material';
 
 import Modal from 'components/Modal/Modal';
 import SwarmForm, { ISwarmFormProps } from 'components/SwarmForm/SwarmForm';
+import { useSelector } from 'redux/hooks';
 
 export default function EditButton(swarmFormProps: ISwarmFormProps) {
   const [open, setOpen] = useState(false);
+  const { hideCommonOptions } = useSelector(({ swarm }) => swarm);
 
   return (
     <>
-      <Button color='secondary' onClick={() => setOpen(true)} type='button' variant='contained'>
-        Edit
-      </Button>
+      <Tooltip title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}>
+        <Box>
+          <Button
+            color='secondary'
+            disabled={!!hideCommonOptions}
+            onClick={() => setOpen(true)}
+            sx={{ minHeight: '100%' }}
+            type='button'
+            variant='contained'
+          >
+            Edit
+          </Button>
+        </Box>
+      </Tooltip>
       <Modal onClose={() => setOpen(false)} open={open}>
         <SwarmForm {...swarmFormProps} isEditSwarm onFormSubmit={() => setOpen(false)} />
       </Modal>

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   Container,
+  SelectChangeEvent,
   TextField,
   Typography,
 } from '@mui/material';
@@ -49,6 +50,7 @@ interface ISwarmForm
       | 'availableUserClasses'
       | 'extraOptions'
       | 'hideCommonOptions'
+      | 'shapeUseCommonOptions'
       | 'host'
       | 'overrideHostWarning'
       | 'runTime'
@@ -65,6 +67,7 @@ function SwarmForm({
   host,
   extraOptions,
   hideCommonOptions,
+  shapeUseCommonOptions,
   numUsers,
   userCount,
   overrideHostWarning,
@@ -115,6 +118,15 @@ function SwarmForm({
     }
   };
 
+  const onShapeClassChange = (event: SelectChangeEvent<unknown>) => {
+    if (!shapeUseCommonOptions) {
+      const hasSelectedShapeClass = event.target.value !== availableShapeClasses[0];
+      setSwarm({
+        hideCommonOptions: hasSelectedShapeClass,
+      });
+    }
+  };
+
   return (
     <Container maxWidth='md' sx={{ my: 2 }}>
       <Typography component='h2' noWrap variant='h6'>
@@ -140,7 +152,12 @@ function SwarmForm({
           }}
         >
           {!isEditSwarm && showUserclassPicker && (
-            <Select label='Shape Class' name='shapeClass' options={availableShapeClasses} />
+            <Select
+              label='Shape Class'
+              name='shapeClass'
+              onChange={onShapeClassChange}
+              options={availableShapeClasses}
+            />
           )}
           <NumericField
             defaultValue={(hideCommonOptions && '0') || userCount || numUsers || 1}
@@ -168,7 +185,6 @@ function SwarmForm({
                     : ''
                 }`}
                 name='host'
-                required
               />
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -207,6 +223,7 @@ const storeConnector = ({
     availableUserClasses,
     extraOptions,
     hideCommonOptions,
+    shapeUseCommonOptions,
     host,
     numUsers,
     userCount,
@@ -220,6 +237,7 @@ const storeConnector = ({
   availableUserClasses,
   extraOptions,
   hideCommonOptions,
+  shapeUseCommonOptions,
   host,
   overrideHostWarning,
   showUserclassPicker,

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -15,6 +15,7 @@ import { AlertColor } from '@mui/material/Alert';
 import { connect } from 'react-redux';
 
 import Form from 'components/Form/Form';
+import NumericField from 'components/Form/NumericField';
 import Select from 'components/Form/Select';
 import CustomParameters from 'components/SwarmForm/SwarmCustomParameters';
 import SwarmUserClassPicker from 'components/SwarmForm/SwarmUserClassPicker';
@@ -92,8 +93,8 @@ function SwarmForm({
         state: SWARM_STATE.RUNNING,
         host: inputData.host || host,
         runTime: inputData.runTime,
-        spawnRate: Number(inputData.spawnRate) || 0,
-        userCount: Number(inputData.userCount) || 0,
+        spawnRate: inputData.spawnRate,
+        userCount: inputData.userCount,
       });
     } else {
       setErrorMessage(data ? data.message : 'An unknown error occured.');
@@ -141,18 +142,20 @@ function SwarmForm({
           {!isEditSwarm && showUserclassPicker && (
             <Select label='Shape Class' name='shapeClass' options={availableShapeClasses} />
           )}
-          <TextField
+          <NumericField
             defaultValue={(hideCommonOptions && '0') || userCount || numUsers || 1}
             disabled={!!hideCommonOptions}
             label='Number of users (peak concurrency)'
             name='userCount'
+            required
             title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}
           />
-          <TextField
+          <NumericField
             defaultValue={(hideCommonOptions && '0') || spawnRate || 1}
             disabled={!!hideCommonOptions}
             label='Ramp up (users started/second)'
             name='spawnRate'
+            required
             title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}
           />
           {!isEditSwarm && (
@@ -165,6 +168,7 @@ function SwarmForm({
                     : ''
                 }`}
                 name='host'
+                required
               />
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -47,7 +47,7 @@ interface ISwarmForm
       | 'availableShapeClasses'
       | 'availableUserClasses'
       | 'extraOptions'
-      | 'isShape'
+      | 'hideCommonOptions'
       | 'host'
       | 'overrideHostWarning'
       | 'runTime'
@@ -63,7 +63,7 @@ function SwarmForm({
   availableUserClasses,
   host,
   extraOptions,
-  isShape,
+  hideCommonOptions,
   numUsers,
   userCount,
   overrideHostWarning,
@@ -92,8 +92,8 @@ function SwarmForm({
         state: SWARM_STATE.RUNNING,
         host: inputData.host || host,
         runTime: inputData.runTime,
-        spawnRate: Number(inputData.spawnRate) || null,
-        userCount: Number(inputData.userCount),
+        spawnRate: Number(inputData.spawnRate) || 0,
+        userCount: Number(inputData.userCount) || 0,
       });
     } else {
       setErrorMessage(data ? data.message : 'An unknown error occured.');
@@ -142,17 +142,18 @@ function SwarmForm({
             <Select label='Shape Class' name='shapeClass' options={availableShapeClasses} />
           )}
           <TextField
-            defaultValue={(isShape && '-') || userCount || numUsers || 1}
-            disabled={!!isShape}
+            defaultValue={(hideCommonOptions && '0') || userCount || numUsers || 1}
+            disabled={!!hideCommonOptions}
             label='Number of users (peak concurrency)'
             name='userCount'
+            title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}
           />
           <TextField
-            defaultValue={(isShape && '-') || spawnRate || 1}
-            disabled={!!isShape}
+            defaultValue={(hideCommonOptions && '0') || spawnRate || 1}
+            disabled={!!hideCommonOptions}
             label='Ramp up (users started/second)'
             name='spawnRate'
-            title='Disabled for tests using LoadTestShape class'
+            title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}
           />
           {!isEditSwarm && (
             <>
@@ -164,7 +165,6 @@ function SwarmForm({
                     : ''
                 }`}
                 name='host'
-                title='Disabled for tests using LoadTestShape class'
               />
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -173,9 +173,11 @@ function SwarmForm({
                 <AccordionDetails>
                   <TextField
                     defaultValue={runTime}
+                    disabled={!!hideCommonOptions}
                     label='Run time (e.g. 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.)'
                     name='runTime'
                     sx={{ width: '100%' }}
+                    title={hideCommonOptions ? 'Disabled for tests using LoadTestShape class' : ''}
                   />
                 </AccordionDetails>
               </Accordion>
@@ -200,7 +202,7 @@ const storeConnector = ({
     availableShapeClasses,
     availableUserClasses,
     extraOptions,
-    isShape,
+    hideCommonOptions,
     host,
     numUsers,
     userCount,
@@ -213,7 +215,7 @@ const storeConnector = ({
   availableShapeClasses,
   availableUserClasses,
   extraOptions,
-  isShape,
+  hideCommonOptions,
   host,
   overrideHostWarning,
   showUserclassPicker,

--- a/locust/webui/src/components/SwarmForm/tests/SwarmForm.test.tsx
+++ b/locust/webui/src/components/SwarmForm/tests/SwarmForm.test.tsx
@@ -46,7 +46,7 @@ describe('SwarmForm', () => {
     });
   });
 
-  test.only('should edit all inputs in the form', async () => {
+  test('should edit all inputs in the form', async () => {
     const { getByText, getByLabelText, getByRole } = renderWithProvider(<SwarmForm />, {
       swarm: {
         showUserclassPicker: true,
@@ -94,7 +94,7 @@ describe('SwarmForm', () => {
   });
 
   test('should allow selected user classes to be modified', async () => {
-    const { getByText, getAllByRole } = renderWithProvider(<SwarmForm />, {
+    const { getAllByRole, getByRole } = renderWithProvider(<SwarmForm />, {
       swarm: {
         showUserclassPicker: true,
         availableUserClasses: ['Class1', 'Class2'],
@@ -121,7 +121,7 @@ describe('SwarmForm', () => {
       fireEvent.click(getAllByRole('checkbox')[2]);
     });
     act(() => {
-      fireEvent.click(getByText('Start'));
+      fireEvent.click(getByRole('button', { name: 'Start' }));
     });
 
     await waitFor(async () => {

--- a/locust/webui/src/components/SwarmForm/tests/SwarmForm.test.tsx
+++ b/locust/webui/src/components/SwarmForm/tests/SwarmForm.test.tsx
@@ -46,8 +46,8 @@ describe('SwarmForm', () => {
     });
   });
 
-  test('should edit all inputs in the form', async () => {
-    const { getByText, getByLabelText } = renderWithProvider(<SwarmForm />, {
+  test.only('should edit all inputs in the form', async () => {
+    const { getByText, getByLabelText, getByRole } = renderWithProvider(<SwarmForm />, {
       swarm: {
         showUserclassPicker: true,
         availableUserClasses: ['Class1'],
@@ -61,16 +61,16 @@ describe('SwarmForm', () => {
       fireEvent.change(getByLabelText('Shape Class'), {
         target: { value: 'Shape1' },
       });
-      fireEvent.change(getByLabelText('Number of users (peak concurrency)'), {
+      fireEvent.change(getByRole('textbox', { name: 'Number of users (peak concurrency)' }), {
         target: { value: '15' },
       });
-      fireEvent.change(getByLabelText('Ramp up (users started/second)'), {
+      fireEvent.change(getByRole('textbox', { name: 'Ramp up (users started/second)' }), {
         target: { value: '20' },
       });
       fireEvent.change(getByLabelText('Run time (e.g. 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.)'), {
         target: { value: '2h' },
       });
-      fireEvent.change(getByLabelText('Host'), {
+      fireEvent.change(getByRole('textbox', { name: 'Host' }), {
         target: { value: 'https://localhost:5000' },
       });
 

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -50,6 +50,7 @@ export interface ISwarmState {
   host: string;
   isDistributed: boolean;
   hideCommonOptions?: boolean | null;
+  shapeUseCommonOptions?: boolean | null;
   locustfile: string;
   numUsers: number | null;
   overrideHostWarning: boolean;

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -49,7 +49,7 @@ export interface ISwarmState {
   history: IHistory[];
   host: string;
   isDistributed: boolean;
-  isShape: boolean | null;
+  hideCommonOptions?: boolean | null;
   locustfile: string;
   numUsers: number | null;
   overrideHostWarning: boolean;


### PR DESCRIPTION
Fixes #2924

### Proposal
1. Remove reference to `isShape` and replace with `hideCommonOptions`
2. Disable runtime input if `hideCommonOptions` (setting the field has no effect)
3. Disable edit swarm button if `hideCommonOptions` is true, as the only fields that can be edited will have no effect
4. Make user count, ramp up, and host as required fields, and ensure user count and ramp up are using correct formats