### PR TITLE
Web UI - Fix Line Chart

### DIFF
--- a/locust/webui/src/components/ExceptionsTab/ExceptionsTab.tsx
+++ b/locust/webui/src/components/ExceptionsTab/ExceptionsTab.tsx
@@ -1,0 +1,8 @@
+import ExceptionsTable from 'components/ExceptionsTable/ExceptionsTable';
+import useFetchExceptions from 'hooks/useFetchExceptions';
+
+export default function ExceptionsTab() {
+  useFetchExceptions();
+
+  return <ExceptionsTable />;
+}

--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -118,7 +118,8 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
   },
   xAxis: {
     type: 'time',
-    startValue: (charts.time || [''])[0],
+    min: (charts.time || [new Date().toISOString()])[0],
+    startValue: (charts.time || [])[0],
     axisLabel: {
       formatter: formatTimeAxis,
     },

--- a/locust/webui/src/components/SwarmRatiosTab/SwarmRatiosTab.tsx
+++ b/locust/webui/src/components/SwarmRatiosTab/SwarmRatiosTab.tsx
@@ -1,0 +1,8 @@
+import SwarmRatios from 'components/SwarmRatios/SwarmRatios';
+import useFetchTasks from 'hooks/useFetchTasks';
+
+export default function SwarmRatiosTab() {
+  useFetchTasks();
+
+  return <SwarmRatios />;
+}

--- a/locust/webui/src/components/Tabs/Tabs.constants.tsx
+++ b/locust/webui/src/components/Tabs/Tabs.constants.tsx
@@ -1,10 +1,10 @@
-import ExceptionsTable from 'components/ExceptionsTable/ExceptionsTable';
+import ExceptionsTab from 'components/ExceptionsTab/ExceptionsTab';
 import FailuresTable from 'components/FailuresTable/FailuresTable';
 import LogViewer from 'components/LogViewer/LogViewer';
 import Reports from 'components/Reports/Reports';
 import StatsTable from 'components/StatsTable/StatsTable';
 import SwarmCharts from 'components/SwarmCharts/SwarmCharts';
-import SwarmRatios from 'components/SwarmRatios/SwarmRatios';
+import SwarmRatiosTab from 'components/SwarmRatiosTab/SwarmRatiosTab';
 import WorkersTable from 'components/WorkersTable/WorkersTable';
 import { LOG_VIEWER_KEY } from 'constants/logs';
 import { IRootState } from 'redux/store';
@@ -27,12 +27,12 @@ export const tabConfig = {
     title: 'Failures',
   },
   exceptions: {
-    component: ExceptionsTable,
+    component: ExceptionsTab,
     key: 'exceptions',
     title: 'Exceptions',
   },
   ratios: {
-    component: SwarmRatios,
+    component: SwarmRatiosTab,
     key: 'ratios',
     title: 'Current Ratio',
   },

--- a/locust/webui/src/hooks/useFetchExceptions.ts
+++ b/locust/webui/src/hooks/useFetchExceptions.ts
@@ -22,5 +22,6 @@ export default function useFetchExceptions() {
 
   useInterval(refetchExceptions, 5000, {
     shouldRunInterval: shouldRunRefetchInterval,
+    immediate: true,
   });
 }

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -56,7 +56,7 @@ export default function useFetchStats() {
     const percentilesWithTime = Object.entries(currentResponseTimePercentiles).reduce(
       (percentiles, [key, value]) => ({
         ...percentiles,
-        [key]: [time, value],
+        [key]: [time, value || 0],
       }),
       {},
     );
@@ -90,6 +90,7 @@ export default function useFetchStats() {
 
   useInterval(updateStats, STATS_REFETCH_INTERVAL, {
     shouldRunInterval: !!statsData && shouldRunRefetchInterval,
+    // immediate: true,
   });
 
   useInterval(refetchStats, STATS_REFETCH_INTERVAL, {

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -90,7 +90,6 @@ export default function useFetchStats() {
 
   useInterval(updateStats, STATS_REFETCH_INTERVAL, {
     shouldRunInterval: !!statsData && shouldRunRefetchInterval,
-    // immediate: true,
   });
 
   useInterval(refetchStats, STATS_REFETCH_INTERVAL, {

--- a/locust/webui/src/hooks/useFetchTasks.ts
+++ b/locust/webui/src/hooks/useFetchTasks.ts
@@ -22,5 +22,6 @@ export default function useFetchTasks() {
 
   useInterval(refetchTasks, 5000, {
     shouldRunInterval: shouldRunRefetchInterval,
+    immediate: true,
   });
 }

--- a/locust/webui/src/pages/Dashboard.tsx
+++ b/locust/webui/src/pages/Dashboard.tsx
@@ -8,9 +8,7 @@ import SwarmForm from 'components/SwarmForm/SwarmForm';
 import Tabs from 'components/Tabs/Tabs';
 import { SWARM_STATE } from 'constants/swarm';
 import useCreateTheme from 'hooks/useCreateTheme';
-import useFetchExceptions from 'hooks/useFetchExceptions';
 import useFetchStats from 'hooks/useFetchStats';
-import useFetchTasks from 'hooks/useFetchTasks';
 import { IRootState } from 'redux/store';
 import { ITab } from 'types/tab.types';
 import { SwarmState } from 'types/ui.types';
@@ -24,8 +22,6 @@ interface IDashboard {
 
 function Dashboard({ swarmState, tabs, extendedTabs }: IDashboard) {
   useFetchStats();
-  useFetchExceptions();
-  useFetchTasks();
   useLogViewer();
 
   const theme = useCreateTheme();


### PR DESCRIPTION
### Proposal
1. The chart tab was not displaying properly if it was the first tab to be viewed after starting a test (e.g. ?tab=chart)
2. The chart tab would briefly show random timestamps. This can be fixed by setting a min value
3. Improve the view of the response percentiles graph by starting it at 0
4. Improve performance slightly by only fetching exceptions and ratios on the respective tabs
