### PR TITLE
Add Google Analytics to docs.locust.io

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_search.extension",
     "sphinx_rtd_theme",
+    "sphinxcontrib.googleanalytics",
 ]
 
 # autoclass options
@@ -161,6 +162,9 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_css_files = ["_static/theme-overrides.css", "_static/css/rtd_sphinx_search.min.css"]
 
+# Google Analytics ID
+googleanalytics_id = "G-MCG99XYF9M"
+googleanalytics_enabled = True
 
 # HTML theme
 # html_theme = "haiku"

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -36,7 +36,7 @@ Basic auth (Authorization header) does not work after redirection
    which is typically on a different domain and use mulitple redirections (30x).
 
    Since ``allow_redirects=True`` is the default ``request`` behavior you'll have to turn it off,
-   handle manually the redirections and inject again the authorization header, ex::
+   handle manually the redirections and inject again the authorization header, ex:
 
 
 .. code-block:: python

--- a/poetry.lock
+++ b/poetry.lock
@@ -2157,6 +2157,20 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "sphinxcontrib-googleanalytics"
+version = "0.4"
+description = "Sphinx extension googleanalytics"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sphinxcontrib-googleanalytics-0.4.tar.gz", hash = "sha256:4b19c1f0fce5df6c7da5633201b64a9e5b0cb3210a14fdb4134942ceee8c5d12"},
+    {file = "sphinxcontrib_googleanalytics-0.4-py3-none-any.whl", hash = "sha256:a6574983f9a58e5864ec10d34dc99914c4d647108b22c9249c8f0038b0cb18b3"},
+]
+
+[package.dependencies]
+Sphinx = ">=0.6"
+
+[[package]]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
@@ -2460,4 +2474,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "fe62e2430b2750fb006f7fe225752ad640c1f7f218340ad7f61536efcc2c8151"
+content-hash = "9e58a176725655fe7b74069776ba86492cdc74c7f34b9c2a1788da9fba924e8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ sphinxcontrib-htmlhelp = "2.0.1"
 sphinxcontrib-jsmath = "1.0.1"
 sphinxcontrib-qthelp = "1.0.3"
 sphinxcontrib-serializinghtml = "1.1.10"
+sphinxcontrib-googleanalytics = ">=0.4"
 
 [tool.poetry.scripts]
 locust = "locust.main:main"


### PR DESCRIPTION
Previously ReadTheDocs had built-in support for Google Analytics. This has been removed, and this PR fixes the GA tracking using a Sphinx extension.