### PR TITLE
Webui Add Custom Form to Auth Page

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -137,13 +137,14 @@ source code.
 Adding Authentication to the Web UI
 ===================================
 
-Locust uses `Flask-Login <https://pypi.org/project/Flask-Login/>`_ to handle authentication. The ``login_manager`` is
-exposed on ``environment.web_ui.app``, allowing the flexibility for you to implement any kind of auth that you would like!
+Locust uses `Flask-Login <https://pypi.org/project/Flask-Login/>`_ to handle authentication when the ``--web-login`` flag is present.
+The ``login_manager`` is exposed on ``environment.web_ui.app``, allowing the flexibility for you to implement any kind of auth that
+you would like!
 
 To use username / password authentication, simply provide a ``username_password_callback`` to the ``environment.web_ui.auth_args``.
 You are responsible for defining the route for the callback and implementing the authentication.
 
-Authentication providers can additionally be configured to allow authentication from 3rd parties such as GitHub or an SSO.
+Authentication providers can additionally be configured to allow authentication from 3rd parties such as GitHub or an SSO provider.
 Simply provide a list of desired ``auth_providers``. You may specify the ``label`` and ``icon`` for display on the button.
 The ``callback_url`` will be the url that the button directs to. You will be responsible for defining the callback route as
 well as the authentication with the 3rd party.
@@ -155,7 +156,14 @@ authentication to the app should be granted.
 To display errors on the login page, such as an incorrect username / password combination, you may store the ``auth_error``
 on the session object: ``session["auth_error"] = "Incorrect username or password"``.
 
-A full example can be seen `in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth.py>`_.
+A full example can be seen `in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth/basic.py>`_.
+
+In certain situations you may wish to further extend the fields present in the auth form. To achieve this, pass a ``custom_form`` dict
+to the ``environment.web_ui.auth_args``. In this case, the fields will be represented by a list of ``inputs``, the callback url is
+configured by the ``custom_form.callback_url``, and the submit button may optionally be configured using the ``custom_form.submit_button_text``.
+The fields in the auth form may be a text, select, checkbox, or secret password field.
+
+For a full example see `configuring the custom_form in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth/custom_form.py>`_.
 
 
 Run a background greenlet

--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -152,6 +152,9 @@ Whether you are using username / password authentication, an auth provider, or b
 to the ``login_manager``. The ``user_loader`` should return ``None`` to deny authentication or return a User object when
 authentication to the app should be granted.
 
+To display errors on the login page, such as an incorrect username / password combination, you may store the ``auth_error``
+on the session object: ``session["auth_error"] = "Incorrect username or password"``.
+
 A full example can be seen `in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth.py>`_.
 
 

--- a/examples/web_ui_auth.py
+++ b/examples/web_ui_auth.py
@@ -76,7 +76,7 @@ def locust_init(environment, **kwargs):
 
                 return redirect(url_for("index"))
 
-            environment.web_ui.auth_args = {**environment.web_ui.auth_args, "error": "Invalid username or password"}
+            session["auth_error"] = "Invalid username or password"
 
             return redirect(url_for("login"))
 

--- a/examples/web_ui_auth/basic.py
+++ b/examples/web_ui_auth/basic.py
@@ -9,10 +9,9 @@ For more information, see https://docs.locust.io/en/stable/extending-locust.html
 
 from locust import HttpUser, events, task
 
-import json
 import os
 
-from flask import Blueprint, make_response, redirect, request, session, url_for
+from flask import Blueprint, redirect, request, session, url_for
 from flask_login import UserMixin, login_user
 
 
@@ -33,12 +32,12 @@ class AuthUser(UserMixin):
 auth_blueprint = Blueprint("auth", "web_ui_auth")
 
 
-def load_user(user_id):
-    return AuthUser(session.get("username"))
+def load_user(username):
+    return AuthUser(username)
 
 
 @events.init.add_listener
-def locust_init(environment, **kwargs):
+def locust_init(environment, **_kwargs):
     if environment.web_ui:
         environment.web_ui.login_manager.user_loader(load_user)
 
@@ -71,7 +70,6 @@ def locust_init(environment, **kwargs):
 
             # Implement real password verification here
             if password:
-                session["username"] = username
                 login_user(AuthUser(username))
 
                 return redirect(url_for("index"))

--- a/examples/web_ui_auth/custom_form.py
+++ b/examples/web_ui_auth/custom_form.py
@@ -1,0 +1,107 @@
+"""
+Example of implementing authentication with a custom form for Locust when the --web-login
+flag is given
+
+This is only to serve as a starting point, proper authentication should be implemented
+according to your projects specifications.
+
+For more information, see https://docs.locust.io/en/stable/extending-locust.html#authentication
+"""
+
+from __future__ import annotations
+
+from locust import HttpUser, events, task
+
+import os
+
+from flask import Blueprint, redirect, request, session, url_for
+from flask_login import UserMixin, login_user
+
+
+class LocustHttpUser(HttpUser):
+    @task
+    def example(self):
+        self.client.get("/")
+
+
+class AuthUser(UserMixin):
+    def __init__(self, username):
+        self.username = username
+        self.is_admin = False
+        self.user_group: str | None = None
+
+    def get_id(self):
+        return self.username
+
+
+auth_blueprint = Blueprint("auth", "web_ui_auth")
+
+
+def load_user(user_id):
+    return AuthUser(user_id)
+
+
+@events.init.add_listener
+def locust_init(environment, **_kwargs):
+    if environment.web_ui:
+        environment.web_ui.login_manager.user_loader(load_user)
+
+        environment.web_ui.app.config["SECRET_KEY"] = os.getenv("FLASK_SECRET_KEY")
+
+        environment.web_ui.auth_args = {
+            "custom_form": {
+                "inputs": [
+                    {
+                        "label": "Username",
+                        "name": "username",
+                    },
+                    # boolean checkmark field
+                    {"label": "Admin", "name": "is_admin", "default_value": False},
+                    # select field
+                    {"label": "User Group", "name": "user_group", "choices": ["developer", "manager"]},
+                    {
+                        "label": "Password",
+                        "name": "password",
+                        "is_secret": True,
+                    },
+                    {
+                        "label": "Confirm Password",
+                        "name": "confirm_password",
+                        "is_secret": True,
+                    },
+                ],
+                "callback_url": "/login_submit",
+                "submit_button_text": "Submit",
+            },
+        }
+
+        @auth_blueprint.route("/login_submit", methods=["POST"])
+        def login_submit():
+            username = request.form.get("username")
+            password = request.form.get("password")
+            confirm_password = request.form.get("confirm_password")
+            is_admin = request.form.get("is_admin") == "on"
+            user_group = request.form.get("user_group")
+
+            if password != confirm_password:
+                session["auth_error"] = "Passwords do not match!"
+
+                return redirect(url_for("login"))
+
+            # Implement real password verification here
+            if password:
+                current_user = AuthUser(username)
+
+                # do something with your custom variables
+                current_user.is_admin = is_admin
+                current_user.user_group = user_group
+
+                login_user(AuthUser(username))
+
+                return redirect(url_for("index"))
+
+            session["auth_error"] = "Invalid username or password"
+
+            return redirect(url_for("login"))
+
+        environment.web_ui.app.register_blueprint(auth_blueprint)

--- a/locust/web.py
+++ b/locust/web.py
@@ -24,6 +24,7 @@ from flask import (
     request,
     send_file,
     send_from_directory,
+    session,
     url_for,
 )
 from flask_cors import CORS
@@ -504,6 +505,8 @@ class WebUI:
             if not self.web_login:
                 return redirect(url_for("index"))
 
+            self.auth_args["error"] = session.get("auth_error", None)
+
             return render_template_from(
                 "auth.html",
                 auth_args=self.auth_args,
@@ -573,6 +576,7 @@ class WebUI:
         def wrapper(*args, **kwargs):
             if self.web_login:
                 try:
+                    session["auth_error"] = None
                     return login_required(view_func)(*args, **kwargs)
                 except Exception as e:
                     return f"Locust auth exception: {e} See https://docs.locust.io/en/stable/extending-locust.html#adding-authentication-to-the-web-ui for configuring authentication."

--- a/locust/webui/src/components/Form/CustomInput.tsx
+++ b/locust/webui/src/components/Form/CustomInput.tsx
@@ -34,7 +34,7 @@ export default function CustomInput({
   }
 
   if (isSecret) {
-    return <PasswordField label={label} name={name} />;
+    return <PasswordField defaultValue={defaultValue} label={label} name={name} />;
   }
 
   return (

--- a/locust/webui/src/components/Form/CustomInput.tsx
+++ b/locust/webui/src/components/Form/CustomInput.tsx
@@ -1,0 +1,49 @@
+import { Checkbox, FormControlLabel, TextField } from '@mui/material';
+
+import PasswordField from 'components/Form/PasswordField';
+import Select from 'components/Form/Select';
+import { ICustomInput } from 'types/form.types';
+
+export default function CustomInput({
+  name,
+  label,
+  defaultValue,
+  choices,
+  isSecret,
+}: ICustomInput) {
+  if (choices) {
+    return (
+      <Select
+        defaultValue={defaultValue as string}
+        label={label}
+        name={name}
+        options={choices}
+        sx={{ width: '100%' }}
+      />
+    );
+  }
+
+  if (typeof defaultValue === 'boolean') {
+    return (
+      <FormControlLabel
+        control={<Checkbox defaultChecked={defaultValue} />}
+        label={label}
+        name={name}
+      />
+    );
+  }
+
+  if (isSecret) {
+    return <PasswordField label={label} name={name} />;
+  }
+
+  return (
+    <TextField
+      defaultValue={defaultValue}
+      label={label}
+      name={name}
+      sx={{ width: '100%' }}
+      type='text'
+    />
+  );
+}

--- a/locust/webui/src/components/Form/NumericField.tsx
+++ b/locust/webui/src/components/Form/NumericField.tsx
@@ -20,7 +20,9 @@ export default function NumericField({ defaultValue, ...textFieldProps }: TextFi
   };
 
   useEffect(() => {
-    setValue(defaultValue as string);
+    if (defaultValue) {
+      setValue(defaultValue as string);
+    }
   }, [defaultValue]);
 
   return <TextField {...textFieldProps} onChange={filterNonNumeric} value={value} />;

--- a/locust/webui/src/components/Form/PasswordField.tsx
+++ b/locust/webui/src/components/Form/PasswordField.tsx
@@ -8,7 +8,7 @@ export default function PasswordField({
   name = 'password',
   label = 'Password',
   defaultValue,
-}: Pick<ICustomInput, 'name' | 'label' | 'defaultValue'>) {
+}: Partial<Pick<ICustomInput, 'name' | 'label' | 'defaultValue'>>) {
   const [showPassword, setShowPassword] = useState(false);
 
   const handleClickShowPassword = () => setShowPassword(!showPassword);

--- a/locust/webui/src/components/Form/PasswordField.tsx
+++ b/locust/webui/src/components/Form/PasswordField.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { FormControl, IconButton, InputAdornment, InputLabel, OutlinedInput } from '@mui/material';
+
+export default function PasswordField({ name = 'password', label = 'Password' }) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClickShowPassword = () => setShowPassword(!showPassword);
+
+  return (
+    <FormControl variant='outlined'>
+      <InputLabel htmlFor='password-field'>{label}</InputLabel>
+      <OutlinedInput
+        endAdornment={
+          <InputAdornment position='end'>
+            <IconButton edge='end' onClick={handleClickShowPassword}>
+              {showPassword ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
+          </InputAdornment>
+        }
+        id={`${label}-${name}-field`}
+        label={label}
+        name={name}
+        type={showPassword ? 'text' : 'password'}
+      />
+    </FormControl>
+  );
+}

--- a/locust/webui/src/components/Form/PasswordField.tsx
+++ b/locust/webui/src/components/Form/PasswordField.tsx
@@ -2,15 +2,22 @@ import { useState } from 'react';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { FormControl, IconButton, InputAdornment, InputLabel, OutlinedInput } from '@mui/material';
 
-export default function PasswordField({ name = 'password', label = 'Password' }) {
+import { ICustomInput } from 'types/form.types';
+
+export default function PasswordField({
+  name = 'password',
+  label = 'Password',
+  defaultValue,
+}: Pick<ICustomInput, 'name' | 'label' | 'defaultValue'>) {
   const [showPassword, setShowPassword] = useState(false);
 
   const handleClickShowPassword = () => setShowPassword(!showPassword);
 
   return (
     <FormControl variant='outlined'>
-      <InputLabel htmlFor='password-field'>{label}</InputLabel>
+      <InputLabel htmlFor={`${label}-${name}-field`}>{label}</InputLabel>
       <OutlinedInput
+        defaultValue={defaultValue}
         endAdornment={
           <InputAdornment position='end'>
             <IconButton edge='end' onClick={handleClickShowPassword}>

--- a/locust/webui/src/components/Form/tests/CustomInput.test.tsx
+++ b/locust/webui/src/components/Form/tests/CustomInput.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import CustomInput from 'components/Form/CustomInput';
 import { renderWithProvider } from 'test/testUtils';
 
-describe('SwarmCustomParameters', () => {
+describe('CustomInput', () => {
   test('renders a text field', () => {
     const fieldName = 'textField';
     const fieldLabel = 'Text Field';

--- a/locust/webui/src/components/Form/tests/CustomInput.test.tsx
+++ b/locust/webui/src/components/Form/tests/CustomInput.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest';
+
+import CustomInput from 'components/Form/CustomInput';
+import { renderWithProvider } from 'test/testUtils';
+
+describe('SwarmCustomParameters', () => {
+  test('renders a text field', () => {
+    const fieldName = 'textField';
+    const fieldLabel = 'Text Field';
+    const fieldDefaultValue = 'value';
+
+    const { getByLabelText } = renderWithProvider(
+      <CustomInput defaultValue={fieldDefaultValue} label={fieldLabel} name={fieldName} />,
+    );
+
+    const textField = getByLabelText(fieldLabel);
+
+    expect(textField).toBeTruthy();
+    expect(textField.getAttribute('name')).toBe(fieldName);
+    expect(textField.getAttribute('type')).toBe('text');
+    expect(textField.getAttribute('value')).toBe(fieldDefaultValue);
+  });
+
+  test('renders a password field', () => {
+    const fieldName = 'passwordField';
+    const fieldLabel = 'Password Field';
+    const fieldDefaultValue = 'Secret value';
+
+    const { getByLabelText } = renderWithProvider(
+      <CustomInput defaultValue={fieldDefaultValue} isSecret label={fieldLabel} name={fieldName} />,
+    );
+
+    const textField = getByLabelText(fieldLabel);
+
+    expect(textField).toBeTruthy();
+    expect(textField.getAttribute('name')).toBe(fieldName);
+    expect(textField.getAttribute('type')).toBe('password');
+    expect(textField.getAttribute('value')).toBe(fieldDefaultValue);
+  });
+
+  test('renders a select component when choices are provided', () => {
+    const fieldName = 'options';
+    const fieldLabel = 'Options';
+
+    const firstCustomChoice = 'Option1';
+    const secondCustomChoice = 'Option2';
+
+    const { getByLabelText, getByText } = renderWithProvider(
+      <CustomInput
+        choices={[firstCustomChoice, secondCustomChoice]}
+        defaultValue={firstCustomChoice}
+        label={fieldLabel}
+        name={fieldName}
+      />,
+    );
+
+    const selectField = getByLabelText(fieldLabel);
+    const option1 = getByText(firstCustomChoice);
+    const option2 = getByText(secondCustomChoice);
+
+    expect(selectField).toBeTruthy();
+
+    expect(option1.parentElement instanceof HTMLSelectElement).toBeTruthy();
+    expect(option1.parentElement?.getAttribute('name')).toBe(fieldName);
+
+    expect(option1 instanceof HTMLOptionElement).toBeTruthy();
+    expect(option2 instanceof HTMLOptionElement).toBeTruthy();
+
+    // Sets default value
+    expect(option1.hasAttribute('selected')).toBeTruthy();
+    expect(option2.hasAttribute('selected')).toBeFalsy();
+  });
+
+  test('renders a checkbox when a boolean default value is provided', () => {
+    const fieldTruthyName = 'truthyBoolean';
+    const fieldTruthyLabel = 'Truthy Boolean';
+    const fieldFalseyName = 'falseyBoolean';
+    const fieldFalseyLabel = 'Falsey Boolean';
+
+    const { getByLabelText } = renderWithProvider(
+      <>
+        <CustomInput defaultValue={true} label={fieldTruthyLabel} name={fieldTruthyName} />
+        <CustomInput defaultValue={false} label={fieldFalseyLabel} name={fieldFalseyName} />
+      </>,
+    );
+
+    const booleanField = getByLabelText(fieldTruthyLabel) as HTMLInputElement;
+    const uncheckedBooleanField = getByLabelText(fieldFalseyLabel) as HTMLInputElement;
+
+    expect(booleanField).toBeTruthy();
+    expect(booleanField.getAttribute('name')).toBe(fieldTruthyName);
+    expect(booleanField.getAttribute('type')).toBe('checkbox');
+    expect(booleanField.checked).toBeTruthy();
+    expect(uncheckedBooleanField.getAttribute('name')).toBe(fieldFalseyName);
+    expect(uncheckedBooleanField.checked).toBeFalsy();
+  });
+
+  test('allows defaultValue to be null for text, password, and select fields', () => {
+    const customTextField = 'textField';
+    const customPasswordField = 'passwordField';
+    const customChoicesField = 'customChoices';
+    const firstCustomChoice = 'Option1';
+    const secondCustomChoice = 'Option2';
+
+    const { getByLabelText } = renderWithProvider(
+      <>
+        <CustomInput label={customTextField} name={customTextField} />
+        <CustomInput isSecret label={customPasswordField} name={customPasswordField} />
+        <CustomInput
+          choices={[firstCustomChoice, secondCustomChoice]}
+          label={customChoicesField}
+          name={customChoicesField}
+        />
+      </>,
+    );
+
+    const textField = getByLabelText(customTextField) as HTMLInputElement;
+    const passwordField = getByLabelText(customPasswordField) as HTMLInputElement;
+    const choicesField = getByLabelText(customChoicesField) as HTMLInputElement;
+
+    expect(textField).toBeTruthy();
+    expect(passwordField).toBeTruthy();
+    expect(choicesField).toBeTruthy();
+    expect(textField.value).toBe('');
+    expect(passwordField.value).toBe('');
+    expect(choicesField.value).toBe(firstCustomChoice);
+  });
+});

--- a/locust/webui/src/components/Form/tests/NumericField.test.tsx
+++ b/locust/webui/src/components/Form/tests/NumericField.test.tsx
@@ -1,0 +1,76 @@
+import { act } from 'react';
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import NumericField from 'components/Form/NumericField';
+import { renderWithProvider } from 'test/testUtils';
+
+describe('NumericField', () => {
+  test('renders a text field', () => {
+    const fieldName = 'numericField';
+    const fieldLabel = 'Numeric Field';
+
+    const { getByLabelText } = renderWithProvider(
+      <NumericField label={fieldLabel} name={fieldName} />,
+    );
+
+    const numericField = getByLabelText(fieldLabel);
+
+    expect(numericField).toBeTruthy();
+    expect(numericField.getAttribute('name')).toBe(fieldName);
+    expect(numericField.getAttribute('type')).toBe('text');
+  });
+
+  test('filters a non-numeric value input', () => {
+    const fieldName = 'numericField';
+    const fieldLabel = 'Numeric Field';
+
+    const { getByLabelText } = renderWithProvider(
+      <NumericField label={fieldLabel} name={fieldName} />,
+    );
+
+    const numericField = getByLabelText(fieldLabel);
+
+    act(() => {
+      fireEvent.change(numericField, { target: { value: '123hello' } });
+    });
+
+    expect(numericField.getAttribute('value')).toBe('123');
+  });
+
+  test('allows at most one decimal point', () => {
+    const fieldName = 'numericField';
+    const fieldLabel = 'Numeric Field';
+
+    const { getByLabelText } = renderWithProvider(
+      <NumericField label={fieldLabel} name={fieldName} />,
+    );
+
+    const numericField = getByLabelText(fieldLabel);
+
+    act(() => {
+      fireEvent.change(numericField, { target: { value: '1.23' } });
+      fireEvent.change(numericField, { target: { value: '1.23.' } });
+      fireEvent.change(numericField, { target: { value: '1.234' } });
+    });
+
+    expect(numericField.getAttribute('value')).toBe('1.234');
+  });
+
+  test('allows a decimal point as the first value', () => {
+    const fieldName = 'numericField';
+    const fieldLabel = 'Numeric Field';
+
+    const { getByLabelText } = renderWithProvider(
+      <NumericField label={fieldLabel} name={fieldName} />,
+    );
+
+    const numericField = getByLabelText(fieldLabel);
+
+    act(() => {
+      fireEvent.change(numericField, { target: { value: '.23' } });
+    });
+
+    expect(numericField.getAttribute('value')).toBe('.23');
+  });
+});

--- a/locust/webui/src/components/Form/tests/PasswordField.test.tsx
+++ b/locust/webui/src/components/Form/tests/PasswordField.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, test } from 'vitest';
 import PasswordField from 'components/Form/PasswordField';
 import { renderWithProvider } from 'test/testUtils';
 
-describe('SwarmCustomParameters', () => {
+describe('PasswordField', () => {
   test('renders a password field', () => {
     const fieldName = 'passwordField';
     const fieldLabel = 'Password Field';

--- a/locust/webui/src/components/Form/tests/PasswordField.test.tsx
+++ b/locust/webui/src/components/Form/tests/PasswordField.test.tsx
@@ -1,0 +1,41 @@
+import { act } from 'react';
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import PasswordField from 'components/Form/PasswordField';
+import { renderWithProvider } from 'test/testUtils';
+
+describe('SwarmCustomParameters', () => {
+  test('renders a password field', () => {
+    const fieldName = 'passwordField';
+    const fieldLabel = 'Password Field';
+
+    const { getByLabelText } = renderWithProvider(
+      <PasswordField label={fieldLabel} name={fieldName} />,
+    );
+
+    const passwordField = getByLabelText(fieldLabel);
+
+    expect(passwordField).toBeTruthy();
+    expect(passwordField.getAttribute('name')).toBe(fieldName);
+    expect(passwordField.getAttribute('type')).toBe('password');
+  });
+
+  test('displays the password on visibility toggle click', () => {
+    const fieldName = 'passwordField';
+    const fieldLabel = 'Password Field';
+
+    const { getByRole, getByLabelText } = renderWithProvider(
+      <PasswordField label={fieldLabel} name={fieldName} />,
+    );
+
+    const visibilityToggle = getByRole('button');
+    const passwordField = getByLabelText(fieldLabel);
+
+    act(() => {
+      fireEvent.click(visibilityToggle);
+    });
+
+    expect(passwordField.getAttribute('type')).toBe('text');
+  });
+});

--- a/locust/webui/src/components/SwarmForm/SwarmCustomParameters.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmCustomParameters.tsx
@@ -1,62 +1,12 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Checkbox,
-  FormControlLabel,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
 
-import Select from 'components/Form/Select';
-import { IExtraOptionParameter, IExtraOptions } from 'types/swarm.types';
+import CustomInput from 'components/Form/CustomInput';
+import { IExtraOptions } from 'types/swarm.types';
 import { toTitleCase } from 'utils/string';
 
 interface ICustomParameters {
   extraOptions: IExtraOptions;
-}
-
-interface ICustomInputProps extends IExtraOptionParameter {
-  label: string;
-}
-
-function CustomInput({ label, defaultValue, choices, helpText, isSecret }: ICustomInputProps) {
-  const labelTitle = toTitleCase(label);
-  const labelWithOptionalHelpText = helpText ? `${labelTitle} (${helpText})` : labelTitle;
-
-  if (choices) {
-    return (
-      <Select
-        defaultValue={defaultValue as string}
-        label={labelWithOptionalHelpText}
-        name={label}
-        options={choices}
-        sx={{ width: '100%' }}
-      />
-    );
-  }
-
-  if (typeof defaultValue === 'boolean') {
-    return (
-      <FormControlLabel
-        control={<Checkbox defaultChecked={defaultValue} />}
-        label={labelWithOptionalHelpText}
-        name={label}
-      />
-    );
-  }
-
-  return (
-    <TextField
-      defaultValue={defaultValue}
-      label={labelWithOptionalHelpText}
-      name={label}
-      sx={{ width: '100%' }}
-      type={isSecret ? 'password' : 'text'}
-    />
-  );
 }
 
 export default function CustomParameters({ extraOptions }: ICustomParameters) {
@@ -68,7 +18,16 @@ export default function CustomParameters({ extraOptions }: ICustomParameters) {
       <AccordionDetails>
         <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 4 }}>
           {Object.entries(extraOptions).map(([label, inputProps], index) => (
-            <CustomInput key={`valid-parameter-${index}`} label={label} {...inputProps} />
+            <CustomInput
+              {...inputProps}
+              key={`valid-parameter-${index}`}
+              label={
+                inputProps.helpText
+                  ? `${toTitleCase(label)} (${inputProps.helpText})`
+                  : toTitleCase(label)
+              }
+              name={label}
+            />
           ))}
         </Box>
       </AccordionDetails>

--- a/locust/webui/src/pages/Auth.tsx
+++ b/locust/webui/src/pages/Auth.tsx
@@ -1,30 +1,20 @@
-import { useState } from 'react';
-import { Visibility, VisibilityOff } from '@mui/icons-material';
-import {
-  Alert,
-  Box,
-  Button,
-  FormControl,
-  IconButton,
-  InputAdornment,
-  InputLabel,
-  OutlinedInput,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, Button, IconButton, TextField, Typography } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 
 import Logo from 'assets/Logo';
+import CustomInput from 'components/Form/CustomInput';
+import PasswordField from 'components/Form/PasswordField';
 import DarkLightToggle from 'components/Layout/Navbar/DarkLightToggle';
 import useCreateTheme from 'hooks/useCreateTheme';
 import { IAuthArgs } from 'types/auth.types';
 
-export default function Auth({ authProviders, error, usernamePasswordCallback }: IAuthArgs) {
-  const [showPassword, setShowPassword] = useState(false);
-
-  const handleClickShowPassword = () => setShowPassword(!showPassword);
-
+export default function Auth({
+  authProviders,
+  customForm,
+  error,
+  usernamePasswordCallback,
+}: IAuthArgs) {
   const theme = useCreateTheme();
 
   return (
@@ -53,29 +43,27 @@ export default function Auth({ authProviders, error, usernamePasswordCallback }:
         <Box sx={{ display: 'flex', justifyContent: 'center', columnGap: 2 }}>
           <Logo />
         </Box>
-        {usernamePasswordCallback && (
+        {usernamePasswordCallback && !customForm && (
           <form action={usernamePasswordCallback} method='POST'>
             <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 2 }}>
               <TextField label='Username' name='username' />
-              <FormControl variant='outlined'>
-                <InputLabel htmlFor='password-field'>Password</InputLabel>
-                <OutlinedInput
-                  endAdornment={
-                    <InputAdornment position='end'>
-                      <IconButton edge='end' onClick={handleClickShowPassword}>
-                        {showPassword ? <VisibilityOff /> : <Visibility />}
-                      </IconButton>
-                    </InputAdornment>
-                  }
-                  id='password-field'
-                  label='Password'
-                  name='password'
-                  type={showPassword ? 'text' : 'password'}
-                />
-              </FormControl>
+              <PasswordField />
               {error && <Alert severity='error'>{error}</Alert>}
               <Button size='large' type='submit' variant='contained'>
                 Login
+              </Button>
+            </Box>
+          </form>
+        )}
+        {customForm && (
+          <form action={customForm.callbackUrl} method='POST'>
+            <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 2 }}>
+              {customForm.inputs.map((inputProps, index) => (
+                <CustomInput key={`custom-form-input-${index}`} {...inputProps} />
+              ))}
+              {error && <Alert severity='error'>{error}</Alert>}
+              <Button size='large' type='submit' variant='contained'>
+                {customForm.submitButtonText || 'Login'}
               </Button>
             </Box>
           </form>

--- a/locust/webui/src/types/auth.types.ts
+++ b/locust/webui/src/types/auth.types.ts
@@ -1,3 +1,5 @@
+import { ICustomInput } from 'types/form.types';
+
 export interface IAuthProviders {
   label: string;
   iconUrl: string;
@@ -8,4 +10,9 @@ export interface IAuthArgs {
   usernamePasswordCallback?: string;
   error?: string;
   authProviders?: IAuthProviders[];
+  customForm?: {
+    inputs: ICustomInput[];
+    callbackUrl: string;
+    submitButtonText?: string;
+  };
 }

--- a/locust/webui/src/types/form.types.ts
+++ b/locust/webui/src/types/form.types.ts
@@ -1,0 +1,7 @@
+export interface ICustomInput {
+  label: string;
+  name: string;
+  choices: string[] | null;
+  defaultValue: string | number | boolean | null;
+  isSecret: boolean;
+}

--- a/locust/webui/src/types/form.types.ts
+++ b/locust/webui/src/types/form.types.ts
@@ -1,7 +1,7 @@
 export interface ICustomInput {
   label: string;
   name: string;
-  choices: string[] | null;
-  defaultValue: string | number | boolean | null;
-  isSecret: boolean;
+  choices?: string[] | null;
+  defaultValue?: string | number | boolean | null;
+  isSecret?: boolean;
 }

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -1,3 +1,4 @@
+import { ICustomInput } from 'types/form.types';
 import { ITab } from 'types/tab.types';
 import { ITableStructure } from 'types/table.types';
 import {
@@ -9,11 +10,8 @@ import {
   ISwarmException,
 } from 'types/ui.types';
 
-export interface IExtraOptionParameter {
-  choices: string[] | null;
-  defaultValue: string | number | boolean | null;
+export interface IExtraOptionParameter extends Omit<ICustomInput, 'name'> {
   helpText: string | null;
-  isSecret: boolean;
 }
 
 export interface IExtraOptions {

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -10,7 +10,7 @@ import {
   ISwarmException,
 } from 'types/ui.types';
 
-export interface IExtraOptionParameter extends Omit<ICustomInput, 'name'> {
+export interface IExtraOptionParameter extends Omit<ICustomInput, 'name' | 'label'> {
   helpText: string | null;
 }
 


### PR DESCRIPTION
### Proposal
1. Allow the auth form to be configured with any inputs. The configuration for the inputs use the same API and the same component as the locust custom arguments
2. Added an example of the auth custom form and updated the docs
3. Add tests for the custom inputs, the password input, and the numeric input
4. Custom arguments isSecret field will now have a visibility toggle in the webui

### Screenshots
![image](https://github.com/user-attachments/assets/11bfdab6-841c-4b38-8cc2-c5bfba29ace6)
![image](https://github.com/user-attachments/assets/54757c21-0bf6-4a33-8a50-fafdbd8be6d4)
