### PR TITLE
Webui Add Auth Info to Auth Page

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -154,7 +154,9 @@ to the ``login_manager``. The ``user_loader`` should return ``None`` to deny aut
 authentication to the app should be granted.
 
 To display errors on the login page, such as an incorrect username / password combination, you may store the ``auth_error``
-on the session object: ``session["auth_error"] = "Incorrect username or password"``.
+on the session object: ``session["auth_error"] = "Incorrect username or password"``. If you have non-erroneous information
+you would like to display to the user, you can opt instead to set ``auth_info`` on the session object:
+``session["auth_info"] = "Successfully created new user!"``
 
 A full example can be seen `in the auth example <https://github.com/locustio/locust/tree/master/examples/web_ui_auth/basic.py>`_.
 

--- a/locust/webui/src/pages/Auth.tsx
+++ b/locust/webui/src/pages/Auth.tsx
@@ -13,6 +13,7 @@ export default function Auth({
   authProviders,
   customForm,
   error,
+  info,
   usernamePasswordCallback,
 }: IAuthArgs) {
   const theme = useCreateTheme();
@@ -36,6 +37,7 @@ export default function Auth({
           rowGap: 4,
           boxShadow: 24,
           borderRadius: 4,
+          width: 400,
           border: '3px solid black',
           p: 4,
         }}
@@ -48,6 +50,7 @@ export default function Auth({
             <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 2 }}>
               <TextField label='Username' name='username' />
               <PasswordField />
+              {info && <Alert severity='info'>{info}</Alert>}
               {error && <Alert severity='error'>{error}</Alert>}
               <Button size='large' type='submit' variant='contained'>
                 Login
@@ -61,6 +64,7 @@ export default function Auth({
               {customForm.inputs.map((inputProps, index) => (
                 <CustomInput key={`custom-form-input-${index}`} {...inputProps} />
               ))}
+              {info && <Alert severity='info'>{info}</Alert>}
               {error && <Alert severity='error'>{error}</Alert>}
               <Button size='large' type='submit' variant='contained'>
                 {customForm.submitButtonText || 'Login'}

--- a/locust/webui/src/types/auth.types.ts
+++ b/locust/webui/src/types/auth.types.ts
@@ -9,6 +9,7 @@ export interface IAuthProviders {
 export interface IAuthArgs {
   usernamePasswordCallback?: string;
   error?: string;
+  info?: string;
   authProviders?: IAuthProviders[];
   customForm?: {
     inputs: ICustomInput[];


### PR DESCRIPTION
### Proposal
1. Add type hints for auth args
2. Add "info" to auth args, allowing to display an info message
3. Update docs

### Screenshots
![image](https://github.com/user-attachments/assets/dd0e7584-13c0-437f-88e7-d48138f54881)
