### PR TITLE
Fix Incorrectly Updating Stat History

### DIFF
--- a/locust/html.py
+++ b/locust/html.py
@@ -53,7 +53,8 @@ def get_html_report(
         {**exc, "nodes": ", ".join(exc["nodes"])} for exc in environment.runner.exceptions.values()
     ]
 
-    update_stats_history(environment.runner)
+    if stats.history and stats.history[-1]["time"] < end_time:
+        update_stats_history(environment.runner, end_time)
     history = stats.history
 
     is_distributed = isinstance(environment.runner, MasterRunner)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -902,9 +902,9 @@ def sort_stats(stats: dict[Any, S]) -> list[S]:
     return [stats[key] for key in sorted(stats.keys())]
 
 
-def update_stats_history(runner: Runner) -> None:
+def update_stats_history(runner: Runner, timestamp: str | None = None) -> None:
     stats = runner.stats
-    timestamp = format_utc_timestamp(time.time())
+    timestamp = timestamp or format_utc_timestamp(time.time())
     current_response_time_percentiles = {
         f"response_time_percentile_{percentile}": [
             timestamp,
@@ -929,7 +929,8 @@ def stats_history(runner: Runner) -> None:
     while True:
         if not runner.stats.total.use_response_times_cache:
             break
-        if runner.state != "stopped":
+
+        if runner.state != "ready" and runner.state != "stopped":
             update_stats_history(runner)
 
         gevent.sleep(HISTORY_STATS_INTERVAL_SEC)

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -585,11 +585,12 @@ class TestCsvStats(LocustTestCase):
     def test_stats_history(self):
         env1 = Environment(events=locust.events, catch_exceptions=False)
         runner1 = env1.create_master_runner("127.0.0.1", 5558)
+        runner1.state = "running"
         env2 = Environment(events=locust.events, catch_exceptions=False)
         runner2 = env2.create_worker_runner("127.0.0.1", 5558)
         greenlet1 = gevent.spawn(stats_history, runner1)
         greenlet2 = gevent.spawn(stats_history, runner2)
-        gevent.sleep(1)
+        gevent.sleep(0.1)
         hs1 = runner1.stats.history
         hs2 = runner2.stats.history
         gevent.kill(greenlet1)


### PR DESCRIPTION
### Proposal
1. Only update stats when a test is running (not before the test starts, not after test stop)
2. The HTML report should update history only up to the test end time

Fixes #2910 