### PR TITLE
Number of requests lower than expected in web UI

### DIFF
--- a/locust/webui/eslint.config.mjs
+++ b/locust/webui/eslint.config.mjs
@@ -1,15 +1,16 @@
+import { fixupPluginRules } from '@eslint/compat';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import _import from 'eslint-plugin-import';
+import prettier from 'eslint-plugin-prettier';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import prettier from 'eslint-plugin-prettier';
 import unusedImports from 'eslint-plugin-unused-imports';
-import _import from 'eslint-plugin-import';
-import { fixupPluginRules } from '@eslint/compat';
-import tsParser from '@typescript-eslint/parser';
+
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/locust/webui/src/hooks/tests/useFetchStats.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchStats.test.tsx
@@ -41,9 +41,6 @@ describe('useFetchStats', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
 
     expect(store.getState().ui.stats).toEqual(statsResponseTransformed.stats);
   });
@@ -67,9 +64,6 @@ describe('useFetchStats', () => {
       store.dispatch(swarmActions.setSwarm({ state: SWARM_STATE.RUNNING }));
     });
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -24,12 +24,13 @@ export default function useFetchStats() {
   const shouldRunRefetchInterval =
     swarm.state === SWARM_STATE.SPAWNING || swarm.state == SWARM_STATE.RUNNING;
 
-  const updateStats = () => {
+  useEffect(() => {
     if (!statsData) {
       return;
     }
 
     const {
+      state,
       currentResponseTimePercentiles,
       extendedStats,
       stats,
@@ -80,17 +81,9 @@ export default function useFetchStats() {
       userCount,
     });
     updateCharts(newChartEntry);
-  };
 
-  useEffect(() => {
-    if (statsData) {
-      setSwarm({ state: statsData.state });
-    }
-  }, [statsData && statsData.state]);
-
-  useInterval(updateStats, STATS_REFETCH_INTERVAL, {
-    shouldRunInterval: !!statsData && shouldRunRefetchInterval,
-  });
+    setSwarm({ state });
+  }, [statsData]);
 
   useInterval(refetchStats, STATS_REFETCH_INTERVAL, {
     shouldRunInterval: shouldRunRefetchInterval,


### PR DESCRIPTION
Fixes #3000 

### Issue
The problem here was that was that updating the stats was happening at the same time as the fetch for stat data. So the UI was being updated with stale data, and when the new stat data would come in, the state would be updated immediately, but not the rest of the UI. The solution is to wait for the new stat data to be fetched, then update the entire UI

### Screenshots
![image](https://github.com/user-attachments/assets/bc9dcf94-5c56-4e30-a456-b69af3c36f5a)
![image](https://github.com/user-attachments/assets/9a5828d9-51b8-4ab1-ac1b-09d322040108)
