### PR TITLE
Allow showing auth info on blank page

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -550,8 +550,7 @@ class WebUI:
             self.auth_args["info"] = session.get("auth_info", None)
 
             return render_template_from(
-                "auth.html",
-                auth_args=self.auth_args,
+                "auth.html", auth_args=self.auth_args, auth_title=self.auth_args.get("title", "Locust")
             )
 
         @app_blueprint.route("/user", methods=["POST"])

--- a/locust/webui/auth.html
+++ b/locust/webui/auth.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 
-    <title>Locust</title>
+    <title>{{ auth_title | default("Locust") }}</title>
   </head>
   <body>
     <div id="root"></div>

--- a/locust/webui/src/pages/Auth.tsx
+++ b/locust/webui/src/pages/Auth.tsx
@@ -73,6 +73,9 @@ export default function Auth({
             </Box>
           </form>
         )}
+        {info && !customForm && !usernamePasswordCallback && (
+          <Alert severity='info'>{<Markdown content={info} />}</Alert>
+        )}
         {authProviders && (
           <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 1 }}>
             {authProviders.map(({ label, callbackUrl, iconUrl }, index) => (


### PR DESCRIPTION
(also adds an update to allow for overriding the title of the auth page)
![image](https://github.com/user-attachments/assets/32ee0daf-adc6-4b1f-9d0d-f083312208ae)
