### PR TITLE
Add optional parameter parsing for HTML file name

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -705,8 +705,27 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         logger.info("Got SIGTERM signal")
         shutdown()
 
+    def process_html_filename(options) -> None:
+        num_users = options.num_users
+        spawn_rate = options.spawn_rate
+        run_time = options.run_time
+
+        option_mapping = {
+            "{u}": num_users,
+            "{r}": spawn_rate,
+            "{t}": run_time,
+        }
+
+        html_filename = options.html_file
+
+        for option_term, option_value in option_mapping.items():
+            html_filename = html_filename.replace(option_term, str(int(option_value)))
+
+        options.html_file = html_filename
+
     def save_html_report():
         html_report = get_html_report(environment, show_download_link=False)
+        process_html_filename(options)
         logger.info("writing html report to file: %s", options.html_file)
         with open(options.html_file, "w", encoding="utf-8") as file:
             file.write(html_report)


### PR DESCRIPTION
Added a feature for adding optional parameters to the HTML report file name.

Here is an example:
`locust --headless -u 12 -r 10 -t 10s --host http://127.0.0.1:8000 --html "{u}_{r}_{t}_locust.html"`

This would generate a filename:
`12_10_10_locust.html`

I use locust a lot at work, and in order to keep track of various test conditions among all the report files, I would manually update the filename. With this change, the file names can be more indicative of what the test was for. I would also consider adding P50, avg, etc...