### PR TITLE
FastHttpUser: Fix ssl loading performance issue by avoiding to load certs when they wont be used anyway

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -96,10 +96,7 @@ def _construct_basic_auth_str(username, password):
 
 
 def insecure_ssl_context_factory():
-    context = gevent.ssl.create_default_context()
-    context.check_hostname = False
-    context.verify_mode = gevent.ssl.CERT_NONE
-    return context
+    return gevent.ssl._create_unverified_context()
 
 
 class FastHttpSession:


### PR DESCRIPTION
Relates to https://github.com/python/cpython/issues/95031