### PR TITLE
pin poetry-core version to <2.0.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+requires = ["poetry-core>=1.0.0,<2.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]


### PR DESCRIPTION
got back from christmas vacation and rebuilt our framework that uses locust as a library for the first time, and running it failed:
```
master-1  |     from locust.event import EventHook
master-1  |   File "/venv/lib/python3.12/site-packages/locust/__init__.py", line 24, in <module>
master-1  |     from ._version import version as __version__
master-1  | ModuleNotFoundError: No module named 'locust._version'
```

scratching my head abit, but realised it thought it was probably related to `poetry-dynamic-versioning`, so saw that there had been a new release 2025-01-04, but in `pyproject.toml` this has been pinned with `<2.0.0`, but `poetry-core` had a broader constraint and a 2.x version had been released 2025-01-04 as well.

looking through the commit history I found:
https://github.com/locustio/locust/commit/81116b20cdc097f8da8f0686c62c22946381254a - Pin Poetry verison in one more place.
https://github.com/locustio/locust/commit/fcb61043953ef55ae4c11eaeb49b22bb7585386d - Pin Poetry to 1.x

adding a `<2.0.0` constraint in `pyproject.toml` for `poetry-core` solved the issue when using `locust` as a library.