### PR TITLE
Update tests to check for hostname instead of fqdn

### DIFF
--- a/locust/test/test_log.py
+++ b/locust/test/test_log.py
@@ -1,6 +1,7 @@
 from locust import log
 from locust.log import greenlet_exception_logger
 
+import re
 import socket
 import subprocess
 import textwrap
@@ -12,6 +13,8 @@ import gevent
 from . import changed_rlimit
 from .testcases import LocustTestCase
 from .util import temporary_file
+
+HOSTNAME = re.sub(r"\..*", "", socket.gethostname())
 
 
 class TestGreenletExceptionLogger(LocustTestCase):
@@ -74,15 +77,15 @@ class TestLoggingOptions(LocustTestCase):
             )
 
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: Run time limit set to 1 seconds",
+            f"{HOSTNAME}/INFO/locust.main: Run time limit set to 1 seconds",
             output,
         )
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: --run-time limit reached, shutting down",
+            f"{HOSTNAME}/INFO/locust.main: --run-time limit reached, shutting down",
             output,
         )
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: Shutting down (exit code 0)",
+            f"{HOSTNAME}/INFO/locust.main: Shutting down (exit code 0)",
             output,
         )
         self.assertIn(
@@ -91,12 +94,12 @@ class TestLoggingOptions(LocustTestCase):
         )
         # check that custom message of root logger is also printed
         self.assertIn(
-            f"{socket.gethostname()}/INFO/root: custom log message",
+            f"{HOSTNAME}/INFO/root: custom log message",
             output,
         )
         # check that custom message of custom_logger is also printed
         self.assertIn(
-            f"{socket.gethostname()}/INFO/custom_logger: test",
+            f"{HOSTNAME}/INFO/custom_logger: test",
             output,
         )
 
@@ -189,20 +192,20 @@ class TestLoggingOptions(LocustTestCase):
 
         # check that log messages goes into file
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: Run time limit set to 1 seconds",
+            f"{HOSTNAME}/INFO/locust.main: Run time limit set to 1 seconds",
             log_content,
         )
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: --run-time limit reached, shutting down",
+            f"{HOSTNAME}/INFO/locust.main: --run-time limit reached, shutting down",
             log_content,
         )
         self.assertIn(
-            f"{socket.gethostname()}/INFO/locust.main: Shutting down (exit code 0)",
+            f"{HOSTNAME}/INFO/locust.main: Shutting down (exit code 0)",
             log_content,
         )
         # check that message of custom logger also went into log file
         self.assertIn(
-            f"{socket.gethostname()}/INFO/root: custom log message",
+            f"{HOSTNAME}/INFO/root: custom log message",
             log_content,
         )
 


### PR DESCRIPTION
locust.test.test_log was broken locally for me as test_log was looking at the fqdn instead of hostname. To match this change: https://github.com/locustio/locust/pull/2705
```
test_logs: commands[0]> python -m unittest -f locust.test.test_log
.F
======================================================================
FAIL: test_log_to_file (locust.test.test_log.TestLoggingOptions.test_log_to_file)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ajtuquero/Code/locust/locust/test/test_log.py", line 191, in test_log_to_file
    self.assertIn(
    ~~~~~~~~~~~~~^
        f"{socket.gethostname()}/INFO/locust.main: Run time limit set to 1 seconds",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        log_content,
        ^^^^^^^^^^^^
    )
    ^
AssertionError: 'AJs-MacBook-Air.local/INFO/locust.main: Run time limit set to 1 seconds' not found in '[2025-01-12 08:38:42,235] AJs-MacBook-Air/INFO/locust.main: Starting Locust 0.10.1.dev4312\n[2025-01-12 08:38:42,236] AJs-MacBook-Air/INFO/locust.main: Run time limit set to 1 seconds\n[2025-01-12 08:38:42,236] AJs-MacBook-Air/INFO/locust.runners: Ramping to 1 users at a rate of 1.00 per second\n[2025-01-12 08:38:42,236] AJs-MacBook-Air/INFO/locust.runners: All users spawned: {"MyUser": 1} (1 total users)\n[2025-01-12 08:38:42,236] AJs-MacBook-Air/INFO/root: custom log message\n[2025-01-12 08:38:43,126] AJs-MacBook-Air/INFO/locust.main: --run-time limit reached, shutting down\n[2025-01-12 08:38:43,161] AJs-MacBook-Air/INFO/locust.main: Shutting down (exit code 0)\n'

----------------------------------------------------------------------
Ran 2 tests in 1.224s

FAILED (failures=1)
test_logs: exit 1 (1.50 seconds) /Users/ajtuquero/Code/locust> python -m unittest -f locust.test.test_log pid=19383
  test_logs: FAIL code 1 (1.98=setup[0.03]+cmd[0.45,1.50] seconds)
  evaluation failed :( (2.03 seconds)
  ```