### PR TITLE
Update Dockerfile to use Python 3.12 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn webui:install --production --network-timeout 60000
 RUN yarn webui:build
 
 # Stage 2: Build Locust package
-FROM python:3.11-slim AS base
+FROM python:3.13-slim AS base
 
 FROM base AS builder
 RUN apt-get update && apt-get install -y git 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn webui:install --production --network-timeout 60000
 RUN yarn webui:build
 
 # Stage 2: Build Locust package
-FROM python:3.13-slim AS base
+FROM python:3.12-slim AS base
 
 FROM base AS builder
 RUN apt-get update && apt-get install -y git 


### PR DESCRIPTION
Python 3.13 is supported since version 2.32, but the base image was still based on 3.11.