### PR TITLE
fix readme image ref links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Locust has a user friendly web interface that shows the progress of your test in
 <picture>
 <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/locustio/locust/refs/heads/master/docs/images/bottlenecked-server-light.png" alt="Locust UI charts" height="100" width="200"/>
 <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/locustio/locust/refs/heads/master/docs/images/bottlenecked-server-dark.png" alt="Locust UI charts" height="100" width="200"/>
-<img src="https://raw.githubusercontent.com/locustio/locust/refs/heads/master/docs/images/bottlenecked-server-light.png" alt="Locust UI charts" height="100" width="200"/> 
+<img src="https://raw.githubusercontent.com/locustio/locust/refs/heads/master/docs/images/bottlenecked-server-light.png" alt="Locust UI charts" height="100" width="200"/>
 </picture>
 <picture>
 <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/locustio/locust/refs/heads/master/docs/images/webui-running-statistics-light.png" alt="Locust UI stats" height="100" width="200"/>

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,17 +32,17 @@ Locust's web interface
 
 Open http://localhost:8089
 
-.. image:: images/webui-splash-screenshot.png
+.. image:: images/webui-splash-light.png
 
 | Provide the host name of your server and try it out!
 
 The following screenshots show what it might look like when running this test using 50 concurrent users, with a ramp up rate of 1 user/s
 
-.. image:: images/webui-running-statistics.png
+.. image:: images/webui-running-statistics-light.png
 
 | Under the *Charts* tab you'll find things like requests per second (RPS), response times and number of running users:
 
-.. image:: images/bottlenecked_server.png
+.. image:: images/bottlenecked-server-light.png
 
 .. note::
 


### PR DESCRIPTION
Since v2.32.2, the new images have been added to the project, but the `quickstart.rst` still uses the old ones, Which causes the images not to be shown.

![image](https://github.com/user-attachments/assets/393256c2-65e7-4d79-acb6-0bc738e2f0e5)
