### PR TITLE
Code quality: Fix unused imports and switch on related ruff check

### DIFF
--- a/examples/custom_shape/wait_user_count.py
+++ b/examples/custom_shape/wait_user_count.py
@@ -1,6 +1,5 @@
 from locust import HttpUser, LoadTestShape, TaskSet, constant, task
 
-import math
 import random
 import time
 from collections import namedtuple

--- a/examples/dispatch_test_scripts/locustfile.py
+++ b/examples/dispatch_test_scripts/locustfile.py
@@ -1,7 +1,5 @@
 from locust import HttpUser, LoadTestShape, constant, task
 
-import math
-
 
 class UserA(HttpUser):
     wait_time = constant(600)

--- a/examples/events.py
+++ b/examples/events.py
@@ -3,7 +3,7 @@ This is an example of a locustfile that uses Locust's built in event hooks to
 track the sum of the content-length header in all successful HTTP responses
 """
 
-from locust import HttpUser, TaskSet, between, events, task, web
+from locust import HttpUser, TaskSet, between, events, task
 
 
 class MyTaskSet(TaskSet):

--- a/examples/extend_web_ui.py
+++ b/examples/extend_web_ui.py
@@ -4,14 +4,14 @@ UI extension hooks to track the sum of the content-length header in all
 successful HTTP responses and display them in the web UI.
 """
 
-from locust import HttpUser, TaskSet, between, events, task, web
+from locust import HttpUser, TaskSet, between, events, task
 
 import json
 import os
 from html import escape
 from time import time
 
-from flask import Blueprint, jsonify, make_response, render_template, request
+from flask import Blueprint, make_response, render_template, request
 
 
 class MyTaskSet(TaskSet):

--- a/examples/manual_stats_reporting.py
+++ b/examples/manual_stats_reporting.py
@@ -20,7 +20,7 @@ Usage as a decorator:
 from locust import User, constant, events, task
 
 import random
-from contextlib import ContextDecorator, contextmanager
+from contextlib import contextmanager
 from time import sleep, time
 
 

--- a/examples/mongodb/locustfile.py
+++ b/examples/mongodb/locustfile.py
@@ -1,4 +1,4 @@
-from locust import between, task
+from locust import task
 from locust.contrib.mongodb import MongoDBUser
 
 import os

--- a/examples/postgres/locustfile.py
+++ b/examples/postgres/locustfile.py
@@ -1,4 +1,4 @@
-from locust import TaskSet, between, task
+from locust import task
 from locust.contrib.postgres import PostgresUser
 
 import os

--- a/examples/terraform/aws/plan/basic.py
+++ b/examples/terraform/aws/plan/basic.py
@@ -1,7 +1,5 @@
 from locust import HttpUser, between, task
 
-import time
-
 
 class Quickstart(HttpUser):
     wait_time = between(1, 5)

--- a/examples/web_ui_cache_stats.py
+++ b/examples/web_ui_cache_stats.py
@@ -4,14 +4,14 @@ UI extension hooks to track the sum of Varnish cache hit/miss headers
 and display them in the web UI.
 """
 
-from locust import HttpUser, TaskSet, between, events, task, web
+from locust import HttpUser, TaskSet, between, events, task
 
 import json
 import os
 from html import escape
 from time import time
 
-from flask import Blueprint, jsonify, make_response, render_template, request
+from flask import Blueprint, make_response, render_template, request
 
 
 class MyTaskSet(TaskSet):

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -5,7 +5,7 @@ if os.getenv("LOCUST_PLAYWRIGHT", None):
     print("Uninstall trio package and remove the setting.")
     try:
         # preserve backwards compatibility for now
-        import trio
+        import trio  # noqa: F401
     except ModuleNotFoundError:
         # dont show a massive callstack if trio is not installed
         os._exit(1)
@@ -50,6 +50,9 @@ __all__ = (
     "events",
     "LoadTestShape",
     "run_single_user",
+    "HttpLocust",
+    "Locust",
+    "__version__",
 )
 
 # Used for raising a DeprecationWarning if old Locust/HttpLocust is used

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -10,7 +10,6 @@ import json
 import os
 import platform
 import socket
-import ssl
 import sys
 import tempfile
 import textwrap

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from locust.env import Environment
 from locust.exception import CatchResponseError, LocustError, ResponseError
 from locust.user import User
-from locust.util.deprecation import DeprecatedFastHttpLocustClass as FastHttpLocust
+from locust.util.deprecation import DeprecatedFastHttpLocustClass as FastHttpLocust  # noqa: F401
 
 import json
 import json as unshadowed_json  # some methods take a named parameter called json

--- a/locust/html.py
+++ b/locust/html.py
@@ -1,9 +1,6 @@
-import glob
 import os
-import pathlib
 from html import escape
 from itertools import chain
-from json import dumps
 
 from jinja2 import Environment as JinjaEnvironment
 from jinja2 import FileSystemLoader

--- a/locust/main.py
+++ b/locust/main.py
@@ -8,7 +8,6 @@ import gc
 import importlib.metadata
 import inspect
 import itertools
-import json
 import logging
 import os
 import signal
@@ -39,12 +38,12 @@ from .util.load_locustfile import load_locustfile
 
 # import external plugins if  installed to allow for registering custom arguments etc
 try:
-    import locust_plugins  # pyright: ignore[reportMissingImports]
+    import locust_plugins  # pyright: ignore[reportMissingImports] # noqa: F401
 except ModuleNotFoundError as e:
     if e.msg != "No module named 'locust_plugins'":
         raise
 try:
-    import locust_cloud  # pyright: ignore[reportMissingImports]
+    import locust_cloud  # pyright: ignore[reportMissingImports] # noqa: F401
 
     locust_cloud_version = f" (locust-cloud {importlib.metadata.version('locust-cloud')})"
 except ModuleNotFoundError as e:

--- a/locust/rpc/__init__.py
+++ b/locust/rpc/__init__.py
@@ -1,2 +1,7 @@
+__all__ = (
+    "Message",
+    "rpc",
+)
+
 from . import zmqrpc as rpc
 from .protocol import Message

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -1,5 +1,4 @@
 from locust import FastHttpUser
-from locust.argument_parser import parse_options
 from locust.contrib.fasthttp import FastHttpSession
 from locust.exception import CatchResponseError, InterruptTaskSet, LocustError, ResponseError
 from locust.user import TaskSet, task

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -6,7 +6,6 @@ from locust.util.load_locustfile import is_user_class
 
 import filecmp
 import os
-import pathlib
 import textwrap
 
 from .mock_locustfile import MOCK_LOCUSTFILE_CONTENT, mock_locustfile

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import textwrap
 import unittest
-from subprocess import DEVNULL, PIPE, STDOUT
+from subprocess import PIPE, STDOUT
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -10,7 +10,6 @@ from locust.argument_parser import (
 import os
 import unittest
 from io import StringIO
-from random import randint
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 

--- a/locust/test/test_sequential_taskset.py
+++ b/locust/test/test_sequential_taskset.py
@@ -1,4 +1,4 @@
-from locust import User, constant, task
+from locust import User, task
 from locust.exception import RescheduleTask
 from locust.user.sequential_taskset import SequentialTaskSet
 

--- a/locust/test/test_wait_time.py
+++ b/locust/test/test_wait_time.py
@@ -1,5 +1,4 @@
 from locust import TaskSet, User, between, constant, constant_throughput
-from locust.exception import MissingWaitTimeError
 
 import random
 import time

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -10,24 +10,19 @@ from locust.stats import StatsCSVFileWriter
 from locust.user import User, task
 from locust.web import WebUI
 
-import copy
 import csv
 import json
 import logging
 import os
-import re
-import textwrap
 import traceback
 from io import StringIO
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import NamedTemporaryFile
 
 import gevent
 import requests
 from flask_login import UserMixin
 from pyquery import PyQuery as pq
 
-from ..util.load_locustfile import load_locustfile
-from .mock_locustfile import mock_locustfile
 from .testcases import LocustTestCase
 from .util import create_tls_cert
 

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -1,4 +1,4 @@
-from locust.exception import RPCError, RPCReceiveError, RPCSendError
+from locust.exception import RPCError, RPCSendError
 from locust.rpc import Message, zmqrpc
 from locust.test.testcases import LocustTestCase
 

--- a/locust/user/__init__.py
+++ b/locust/user/__init__.py
@@ -1,2 +1,9 @@
+__all__ = (
+    "HttpUser",
+    "tag",
+    "task",
+    "TaskSet",
+    "User",
+)
 from .task import TaskSet, tag, task
 from .users import HttpUser, User

--- a/locust/web.py
+++ b/locust/web.py
@@ -10,7 +10,6 @@ from html import escape
 from io import StringIO
 from itertools import chain
 from json import dumps
-from time import time
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import gevent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ extend-exclude = [
     "examples/issue_*.py",
     "src/readthedocs-sphinx-search/",
 ]
-lint.ignore = ["E402", "E501", "E713", "E731", "E741", "F401"]
+lint.ignore = ["E402", "E501", "E713", "E731", "E741"]
 lint.select = ["E", "F", "W", "UP", "FA102", "I001"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
As any developer I am a little bit lazy from one side, and do not like pycharm warnings from another. 

Looking to locust internals I discovered, that there are a lot of places where unused imports exist and related check switched off in linting. This is not good practice, as it can lead to patch problems in some projects. So this PR fixes this problem and switch on related check.

Some required unused imports are excluded with noqa mark.