### PR TITLE
FastHttpUser: Accept brotli and zstd compression encoding

### DIFF
--- a/docs/running-in-debugger.rst
+++ b/docs/running-in-debugger.rst
@@ -91,7 +91,7 @@ Example output (for FastHttpUser):
     REQUEST: http://example.com/
     GET / HTTP/1.1
     user-agent: python/gevent-http-client-1.5.3
-    accept-encoding: gzip, deflate
+    accept-encoding: gzip, deflate, br, zstd
     host: example.com
 
     RESPONSE: HTTP/1.1 200

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -229,7 +229,7 @@ class FastHttpSession:
         elif self.auth_header:
             headers["Authorization"] = self.auth_header
         if "Accept-Encoding" not in headers and "accept-encoding" not in headers:
-            headers["Accept-Encoding"] = "gzip, deflate"
+            headers["Accept-Encoding"] = "gzip, deflate, br, zstd"
 
         if not data and json is not None:
             data = unshadowed_json.dumps(json)


### PR DESCRIPTION
Hey, I was wondering if we can extend the locust defaults for Accept-Encoding header with `brotli` and `zstd` to get closer to what modern browsers do:
* Safari: gzip, deflate, br 
* Firefox: gzip, deflate, br, zstd
* Chrome: gzip, deflate, br, zstd

Underlying python requests libs handle them well, I tested this by overwriting the header. 

