### PR TITLE
Enable HTML Report Filename Parsing

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -208,6 +208,9 @@ Usage: locust [options] [UserClass ...]
 
     locust --headless -u 100 -t 20m --processes 4 MyHttpUser AnotherUser
 
+    locust --headless -u 100 -r 10 -t 50 --print-stats --html "test_report_{u}_{r}_{t}.html" -H https://www.example.com
+    (The above run would generate an html file with the name "test_report_100_10_50.html")
+
 See documentation for more details, including how to set options using a file or environment variables: https://docs.locust.io/en/stable/configuration.html""",
     )
     parser.add_argument(
@@ -754,7 +757,7 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
         "--html",
         metavar="<filename>",
         dest="html_file",
-        help="Store HTML report to file path specified",
+        help="Store HTML report to file path specified. Able to parse certain tags - {u}, {r}, {t} and convert them to number of users, spawn rate and run time respectively.",
         env_var="LOCUST_HTML",
     )
     stats_group.add_argument(

--- a/locust/html.py
+++ b/locust/html.py
@@ -15,6 +15,25 @@ PERCENTILES_FOR_HTML_REPORT = [0.50, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0]
 DEFAULT_BUILD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "webui", "dist")
 
 
+def process_html_filename(options) -> None:
+    num_users = options.num_users
+    spawn_rate = options.spawn_rate
+    run_time = options.run_time
+
+    option_mapping = {
+        "{u}": num_users,
+        "{r}": spawn_rate,
+        "{t}": run_time,
+    }
+
+    html_filename = options.html_file
+
+    for option_term, option_value in option_mapping.items():
+        html_filename = html_filename.replace(option_term, str(int(option_value)))
+
+    options.html_file = html_filename
+
+
 def render_template_from(file, build_path=DEFAULT_BUILD_PATH, **kwargs):
     env = JinjaEnvironment(loader=FileSystemLoader(build_path))
     template = env.get_template(file)

--- a/locust/main.py
+++ b/locust/main.py
@@ -20,7 +20,7 @@ import gevent
 from . import log, stats
 from .argument_parser import parse_locustfile_option, parse_options
 from .env import Environment
-from .html import get_html_report
+from .html import get_html_report, process_html_filename
 from .input_events import input_listener
 from .log import greenlet_exception_logger, setup_logging
 from .stats import (
@@ -651,6 +651,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
     def save_html_report():
         html_report = get_html_report(environment, show_download_link=False)
+        process_html_filename(options)
         logger.info("writing html report to file: %s", options.html_file)
         with open(options.html_file, "w", encoding="utf-8") as file:
             file.write(html_report)

--- a/locust/test/test_html_filename.py
+++ b/locust/test/test_html_filename.py
@@ -1,0 +1,42 @@
+from locust.html import process_html_filename
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestProcessHtmlFilename(unittest.TestCase):
+    def test_process_html_filename(self):
+        mock_options = MagicMock()
+        mock_options.num_users = 100
+        mock_options.spawn_rate = 10
+        mock_options.run_time = 60
+        mock_options.html_file = "report_u{u}_r{r}_t{t}.html"
+
+        process_html_filename(mock_options)
+
+        expected_filename = "report_u100_r10_t60.html"
+        self.assertEqual(mock_options.html_file, expected_filename)
+
+    def test_process_html_filename_partial_replacement(self):
+        mock_options = MagicMock()
+        mock_options.num_users = 50
+        mock_options.spawn_rate = 5
+        mock_options.run_time = 30
+        mock_options.html_file = "loadtest_{u}_{r}.html"
+
+        process_html_filename(mock_options)
+
+        expected_filename = "loadtest_50_5.html"
+        self.assertEqual(mock_options.html_file, expected_filename)
+
+    def test_process_html_filename_no_replacement(self):
+        mock_options = MagicMock()
+        mock_options.num_users = 50
+        mock_options.spawn_rate = 5
+        mock_options.run_time = 30
+        mock_options.html_file = "static_report.html"
+
+        process_html_filename(mock_options)
+
+        expected_filename = "static_report.html"
+        self.assertEqual(mock_options.html_file, expected_filename)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -7,6 +7,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import textwrap
 import unittest
 from subprocess import PIPE, STDOUT
@@ -110,7 +111,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             gevent.sleep(1)
 
         requests.post(
-            "http://127.0.0.1:%i/swarm" % port,
+            f"http://127.0.0.1:{port}/swarm",
             data={"user_count": 1, "spawn_rate": 1, "host": "https://localhost", "custom_string_arg": "web_form_value"},
         )
         gevent.sleep(1)
@@ -859,7 +860,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 stderr=PIPE,
             )
             gevent.sleep(1)
-            self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % port, timeout=3).status_code)
+            self.assertEqual(200, requests.get(f"http://127.0.0.1:{port}/", timeout=3).status_code)
             proc.terminate()
 
     @unittest.skipIf(os.name == "nt", reason="termios doesnt exist on windows, and thus we cannot import pty")
@@ -1150,44 +1151,59 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
             self.assertEqual(0, proc.returncode)
 
     def test_html_report_option(self):
+        html_template = "some_name_{u}_{r}_{t}.html"
+        expected_filename = "some_name_11_5_2.html"
+
         with mock_locustfile() as mocked:
-            with temporary_file("", suffix=".html") as html_report_file_path:
-                try:
-                    subprocess.check_output(
-                        [
-                            "locust",
-                            "-f",
-                            mocked.file_path,
-                            "--host",
-                            "https://test.com/",
-                            "--run-time",
-                            "2s",
-                            "--headless",
-                            "--exit-code-on-error",
-                            "0",
-                            "--html",
-                            html_report_file_path,
-                        ],
-                        stderr=subprocess.STDOUT,
-                        timeout=10,
-                        text=True,
-                    ).strip()
-                except subprocess.CalledProcessError as e:
-                    raise AssertionError(f"Running locust command failed. Output was:\n\n{e.stdout}") from e
+            # Get system temp directory
+            temp_dir = tempfile.gettempdir()
 
-                with open(html_report_file_path, encoding="utf-8") as f:
-                    html_report_content = f.read()
+            # Define the input filename as well as the resulting filename within the temp directory
+            html_report_file_path = os.path.join(temp_dir, html_template)
+            output_html_report_file_path = os.path.join(temp_dir, expected_filename)
 
-        # make sure title appears in the report
-        _, locustfile = os.path.split(mocked.file_path)
-        self.assertIn(locustfile, html_report_content)
+            try:
+                output = subprocess.check_output(
+                    [
+                        "locust",
+                        "-f",
+                        mocked.file_path,
+                        "--host",
+                        "https://test.com/",
+                        "--run-time",
+                        "2s",
+                        "--headless",
+                        "--exit-code-on-error",
+                        "0",
+                        "-u",
+                        "11",
+                        "-r",
+                        "5",
+                        "--html",
+                        html_report_file_path,
+                    ],
+                    stderr=subprocess.STDOUT,
+                    timeout=10,
+                    text=True,
+                ).strip()
 
-        # make sure host appears in the report
-        self.assertIn("https://test.com/", html_report_content)
-        self.assertIn('"show_download_link": false', html_report_content)
-        self.assertRegex(html_report_content, r'"start_time": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"')
-        self.assertRegex(html_report_content, r'"end_time": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"')
-        self.assertRegex(html_report_content, r'"duration": "\d* seconds?"')
+            except subprocess.CalledProcessError as e:
+                raise AssertionError(f"Running locust command failed. Output was:\n\n{e.stdout}") from e
+            with open(output_html_report_file_path, encoding="utf-8") as f:
+                html_report_content = f.read()
+
+            # make sure correct name is generated based on filename arguments
+            self.assertIn(expected_filename, output)
+
+            _, locustfile = os.path.split(mocked.file_path)
+            self.assertIn(locustfile, html_report_content)
+
+            # make sure host appears in the report
+            self.assertIn("https://test.com/", html_report_content)
+            self.assertIn('"show_download_link": false', html_report_content)
+            self.assertRegex(html_report_content, r'"start_time": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"')
+            self.assertRegex(html_report_content, r'"end_time": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"')
+            self.assertRegex(html_report_content, r'"duration": "\d* seconds?"')
 
     def test_run_with_userclass_picker(self):
         with temporary_file(content=MOCK_LOCUSTFILE_CONTENT_A) as file1:


### PR DESCRIPTION
## Added a feature for adding optional parameters to the HTML report file name.

Here is an example:
locust --headless -u 12 -r 10 -t 10s --host http://127.0.0.1:8000 --html "{u}\_{r}\_{t}\_locust.html"

This would generate a filename:
12_10_10_locust.html

I use locust a lot at work, and in order to keep track of various test conditions among all the report files, I would manually update the filename. With this change, the file names can be more indicative of what the test was for. I would also consider adding P50, avg, etc...


Add HTML filename parsing
Add usage details to help command (The generated output is used in the docs)
Add tests


Put up a [PR previously](https://github.com/locustio/locust/pull/3005), but it was closed as stale. I've added tests and updated the help menu to contain usage information as well as an additional example.