### PR TITLE
Remove uv lock file from build artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,12 +110,12 @@ source = "vcs"
 version-file = "locust/_version.py"
 
 [tool.hatch.build.targets.sdist]
-include = ["locust", "uv.lock"]
+include = ["locust"]
 exclude = ["locust/webui/*", "locust/test", "locust/build"]
 artifacts = ["locust/webui/dist"]
 
 [tool.hatch.build.targets.wheel]
-include = ["locust", "uv.lock"]
+include = ["locust"]
 artifacts = ["locust/webui/dist"]
 
 [tool.hatch.version.raw-options]


### PR DESCRIPTION
Removes `uv.lock` from build artifacts

Addresses behaviour described in https://github.com/locustio/locust/issues/3053