### PR TITLE
docs: update python-requests documentation links

### DIFF
--- a/docs/increase-performance.rst
+++ b/docs/increase-performance.rst
@@ -4,7 +4,7 @@
 Increase performance with a faster HTTP client
 ==============================================================
 
-Locust's default HTTP client uses `python-requests <http://www.python-requests.org/>`_. 
+Locust's default HTTP client uses `python-requests <https://requests.readthedocs.io/>`_.
 It provides a nice API that many python developers are familiar with, and is very well-maintained. But if you're planning to run tests with very high throughput and have limited hardware for running Locust, it is sometimes not efficient enough.
 
 Because of this, Locust also comes with :py:class:`FastHttpUser <locust.contrib.fasthttp.FastHttpUser>` which

--- a/docs/running-in-debugger.rst
+++ b/docs/running-in-debugger.rst
@@ -57,7 +57,7 @@ Print HTTP communication
 
 Sometimes it can be hard to understand why an HTTP request fails in Locust when it works from a regular browser/other application. Here's how to examine the communication in detail:
 
-For ``HttpUser`` (`python-requests <https://python-requests.org>`_):
+For ``HttpUser`` (`python-requests <https://requests.readthedocs.io/>`_):
 
 .. code-block:: python
 

--- a/locust/clients.py
+++ b/locust/clients.py
@@ -68,7 +68,7 @@ class HttpSession(requests.Session):
     to be able to log in and out of websites). Each request is logged so that locust can display
     statistics.
 
-    This is a slightly extended version of `python-request <http://python-requests.org>`_'s
+    This is a slightly extended version of `python-request <https://requests.readthedocs.io/>`_'s
     :py:class:`requests.Session` class and mostly this class works exactly the same. However
     the methods for making requests (get, post, delete, put, head, options, patch, request)
     can now take a *url* argument that's only the path part of the URL, in which case the host


### PR DESCRIPTION
Replace outdated python-requests URLs (python-requests.org) with current documentation URL (requests.readthedocs.io) in various documentation files and source code.

source: https://github.com/psf/requests/pull/5236