### PR TITLE
Add LICENSE file for Locust Cloud and reference it from the main license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
-The MIT License
-
 Copyright (c) 2009-2025, Carl Byström, Jonatan Heyman, Lars Holmberg
+
+* Content that resides under the "proprietary/" directory of this repository, is licensed under the license defined in "proprietary/LICENSE".
+* Content outside of the above mentioned directory is licensed as defined below.
+
+The MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/proprietary/LICENSE
+++ b/proprietary/LICENSE
@@ -1,0 +1,38 @@
+Copyright (c) 2024-present Locust Technologies Inc.
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Locust Cloud Terms of Service, available
+at https://locust.cloud/terms, or other agreement governing the use of the Software,
+as agreed by you and Locust Technologies, and otherwise have a valid Locust Cloud
+subscription. Subject to the foregoing sentence, you are free to
+modify this Software and publish patches to the Software. You agree that Locust
+Technologies and/or its licensors (as applicable) retain all right, title and
+interest in and to all such modifications and/or patches, and all such modifications
+and/or patches may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Locust Cloud subscription. Subject to the foregoing,
+it is forbidden to copy, merge, publish, distribute, sublicense,
+and/or sell the Software.
+
+This License applies only to the part of this Software that is not
+distributed as part of Locust Core, and that is not an image,
+font, cascading stylesheet (CSS), or a file which is served as client-side
+JavaScript, either directly or after having been compiled, arranged, augmented,
+or combined into client-side JavaScript. Any part of this Software distributed
+as part of Locust Core or that is an image, font, cascading stylesheet (CSS), a
+file which produces or is compiled, arranged, augmented, or combined into
+client-side JavaScript, in whole or in part, is copyrighted under the MIT
+license. The full text of this License shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into Locust Cloud, those
+components are licensed under the original license provided by the owner of the
+applicable component.


### PR DESCRIPTION
In the future, Locust Cloud files will be added under /proprietary instead of having them in a separate repo.