### PR TITLE
Fix missing optional argument definitions in PostKwargs

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
         auth: tuple[str | bytes, str | bytes] | None
         allow_redirects: bool
         context: dict
+        params: dict | None
+        files: dict | None
 
     class PutKwargs(PostKwargs, total=False):
         json: Any


### PR DESCRIPTION
This commit introduces `params` and `files` attributes to the PostKwargs class in fasthttp.py, enhancing static type analysis capabilities without affecting existing functionality.
These additions ensure more precise argument definitions for methods in FastHttpSession.