### PR TITLE
Refactoring: Extract locustfile content merger from main function

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -99,8 +99,7 @@ def main():
     locustfiles = parse_locustfile_option()
 
     # Importing Locustfile(s) - setting available UserClasses and ShapeClasses to choose from in UI
-    user_classes: dict[str, locust.User] = {}
-    available_user_classes = {}
+    available_user_classes: dict[str, locust.User] = {}
     available_shape_classes = {}
     available_user_tasks = {}
     shape_class = None
@@ -121,7 +120,7 @@ def main():
         # Setting Available User Classes
         for key, value in file_user_classes.items():
             if key in available_user_classes.keys():
-                previous_path = inspect.getfile(user_classes[key])
+                previous_path = inspect.getfile(available_user_classes[key])
                 new_path = inspect.getfile(value)
                 if previous_path == new_path:
                     # The same User class was defined in two locustfiles but one probably imported the other, so we just ignore it
@@ -132,7 +131,6 @@ def main():
                     )
                     sys.exit(1)
 
-            user_classes[key] = value
             available_user_classes[key] = value
             available_user_tasks[key] = value.tasks or {}
 
@@ -285,25 +283,25 @@ def main():
 
     if options.list_commands:
         print("Available Users:")
-        for name in user_classes:
+        for name in available_user_classes:
             print("    " + name)
         sys.exit(0)
 
-    if not user_classes:
+    if not available_user_classes:
         logger.error("No User class found!")
         sys.exit(1)
 
     # make sure specified User exists
     if options.user_classes:
-        if missing := set(options.user_classes) - set(user_classes.keys()):
+        if missing := set(options.user_classes) - set(available_user_classes.keys()):
             logger.error(f"Unknown User(s): {', '.join(missing)}\n")
             sys.exit(1)
         else:
-            names = set(options.user_classes) & set(user_classes.keys())
-            user_classes = [user_classes[n] for n in names]
+            names = set(options.user_classes) & set(available_user_classes.keys())
+            user_classes = [available_user_classes[n] for n in names]
     else:
         # list() call is needed to consume the dict_view object in Python 3
-        user_classes = list(user_classes.values())
+        user_classes = list(available_user_classes.values())
 
     if not shape_class and options.num_users:
         fixed_count_total = sum([user_class.fixed_count for user_class in user_classes])

--- a/locust/main.py
+++ b/locust/main.py
@@ -100,7 +100,7 @@ def create_environment(
 def merge_locustfiles_content(
     locustfiles: list[str],
 ) -> tuple[
-    dict[str, locust.User],
+    dict[str, type[locust.User]],
     dict[str, locust.LoadTestShape],
     dict[str, list[locust.TaskSet | Callable]],
     locust.LoadTestShape | None,
@@ -110,7 +110,7 @@ def merge_locustfiles_content(
 
     Can stop locust execution on errors.
     """
-    available_user_classes: dict[str, locust.User] = {}
+    available_user_classes: dict[str, type[locust.User]] = {}
     available_shape_classes: dict[str, locust.LoadTestShape] = {}
     # TODO: list[locust.TaskSet | Callable] should be replaced with correct type,
     #  supported by User class task attribute. This require additional rewrite,

--- a/locust/main.py
+++ b/locust/main.py
@@ -97,11 +97,6 @@ def main():
     # find specified locustfile(s) and make sure it exists, using a very simplified
     # command line parser that is only used to parse the -f option.
     locustfiles = parse_locustfile_option()
-    locustfiles_length = len(locustfiles)
-
-    # Grabbing the Locustfile if only one was provided. Otherwise, allowing users to select the locustfile in the UI
-    # If --headless or --autostart and multiple locustfiles, all provided UserClasses will be ran
-    locustfile = locustfiles[0] if locustfiles_length == 1 else None
 
     # Importing Locustfile(s) - setting available UserClasses and ShapeClasses to choose from in UI
     user_classes: dict[str, locust.User] = {}
@@ -335,9 +330,10 @@ It's not high enough for load testing, and the OS didn't allow locust to increas
 See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit for more info."""
             )
 
-    # create locust Environment
-    locustfile_path = None if not locustfile else os.path.basename(locustfile)
+    # At least one locust file exists, or system will exit earlier
+    locustfile_path = os.path.basename(locustfiles[0])
 
+    # create locust Environment
     environment = create_environment(
         user_classes,
         options,

--- a/locust/main.py
+++ b/locust/main.py
@@ -104,7 +104,7 @@ def merge_locustfiles_content(locustfiles: list[str]) -> tuple[dict, dict, dict,
     available_user_tasks = {}
     shape_class = None
     for _locustfile in locustfiles:
-        file_user_classes, shape_classes = load_locustfile(_locustfile)
+        user_classes, shape_classes = load_locustfile(_locustfile)
 
         # Setting Available Shape Classes
         if shape_classes:
@@ -118,21 +118,21 @@ def merge_locustfiles_content(locustfiles: list[str]) -> tuple[dict, dict, dict,
                 available_shape_classes[shape_class_name] = shape_class
 
         # Setting Available User Classes
-        for key, value in file_user_classes.items():
-            if key in available_user_classes.keys():
-                previous_path = inspect.getfile(available_user_classes[key])
-                new_path = inspect.getfile(value)
+        for class_name, class_definition in user_classes.items():
+            if class_name in available_user_classes.keys():
+                previous_path = inspect.getfile(available_user_classes[class_name])
+                new_path = inspect.getfile(class_definition)
                 if previous_path == new_path:
                     # The same User class was defined in two locustfiles but one probably imported the other, so we just ignore it
                     continue
                 else:
                     sys.stderr.write(
-                        f"Duplicate user class names: {key} is defined in both {previous_path} and {new_path}\n"
+                        f"Duplicate user class names: {class_name} is defined in both {previous_path} and {new_path}\n"
                     )
                     sys.exit(1)
 
-            available_user_classes[key] = value
-            available_user_tasks[key] = value.tasks or {}
+            available_user_classes[class_name] = class_definition
+            available_user_tasks[class_name] = class_definition.tasks or {}
 
     return available_user_classes, available_shape_classes, available_user_tasks, shape_class
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -102,20 +102,18 @@ def merge_locustfiles_content(locustfiles: list[str]) -> tuple[dict, dict, dict,
     available_user_classes: dict[str, locust.User] = {}
     available_shape_classes = {}
     available_user_tasks = {}
-    shape_class = None
+
     for _locustfile in locustfiles:
         user_classes, shape_classes = load_locustfile(_locustfile)
 
         # Setting Available Shape Classes
-        if shape_classes:
-            shape_class = shape_classes[0]
-            for shape_class in shape_classes:
-                shape_class_name = type(shape_class).__name__
-                if shape_class_name in available_shape_classes.keys():
-                    sys.stderr.write(f"Duplicate shape classes: {shape_class_name}\n")
-                    sys.exit(1)
+        for _shape_class in shape_classes:
+            shape_class_name = type(_shape_class).__name__
+            if shape_class_name in available_shape_classes.keys():
+                sys.stderr.write(f"Duplicate shape classes: {shape_class_name}\n")
+                sys.exit(1)
 
-                available_shape_classes[shape_class_name] = shape_class
+            available_shape_classes[shape_class_name] = _shape_class
 
         # Setting Available User Classes
         for class_name, class_definition in user_classes.items():
@@ -133,6 +131,8 @@ def merge_locustfiles_content(locustfiles: list[str]) -> tuple[dict, dict, dict,
 
             available_user_classes[class_name] = class_definition
             available_user_tasks[class_name] = class_definition.tasks or {}
+
+    shape_class = list(available_shape_classes.values())[0] if available_shape_classes else None
 
     return available_user_classes, available_shape_classes, available_user_tasks, shape_class
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -93,12 +93,12 @@ def create_environment(
     )
 
 
-def main():
-    # find specified locustfile(s) and make sure it exists, using a very simplified
-    # command line parser that is only used to parse the -f option.
-    locustfiles = parse_locustfile_option()
+def merge_locustfiles_content(locustfiles: list[str]) -> tuple[dict, dict, dict, locust.LoadTestShape | None]:
+    """
+    Validate content of each locustfile in locustfiles and merge data to single objects output.
 
-    # Importing Locustfile(s) - setting available UserClasses and ShapeClasses to choose from in UI
+    Can stop locust execution on errors.
+    """
     available_user_classes: dict[str, locust.User] = {}
     available_shape_classes = {}
     available_user_tasks = {}
@@ -133,6 +133,22 @@ def main():
 
             available_user_classes[key] = value
             available_user_tasks[key] = value.tasks or {}
+
+    return available_user_classes, available_shape_classes, available_user_tasks, shape_class
+
+
+def main():
+    # find specified locustfile(s) and make sure it exists, using a very simplified
+    # command line parser that is only used to parse the -f option.
+    locustfiles = parse_locustfile_option()
+
+    # Importing Locustfile(s) - setting available UserClasses and ShapeClasses to choose from in UI
+    (
+        available_user_classes,
+        available_shape_classes,
+        available_user_tasks,
+        shape_class,
+    ) = merge_locustfiles_content(locustfiles)
 
     if len(stats.PERCENTILES_TO_CHART) > 6:
         logging.error("stats.PERCENTILES_TO_CHART parameter should be a maximum of 6 parameters \n")

--- a/locust/main.py
+++ b/locust/main.py
@@ -105,7 +105,7 @@ def main():
     available_user_tasks = {}
     shape_class = None
     for _locustfile in locustfiles:
-        docstring, _user_classes, shape_classes = load_locustfile(_locustfile)
+        file_user_classes, shape_classes = load_locustfile(_locustfile)
 
         # Setting Available Shape Classes
         if shape_classes:
@@ -119,7 +119,7 @@ def main():
                 available_shape_classes[shape_class_name] = shape_class
 
         # Setting Available User Classes
-        for key, value in _user_classes.items():
+        for key, value in file_user_classes.items():
             if key in available_user_classes.keys():
                 previous_path = inspect.getfile(user_classes[key])
                 new_path = inspect.getfile(value)

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -39,7 +39,7 @@ class TestLoadLocustfile(LocustTestCase):
 
     def test_load_locust_file_from_absolute_path(self):
         with mock_locustfile() as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertIn("UserSubclass", user_classes)
             self.assertNotIn("NotUserSubclass", user_classes)
             self.assertNotIn("LoadTestShape", user_classes)
@@ -47,7 +47,7 @@ class TestLoadLocustfile(LocustTestCase):
 
     def test_load_locust_file_from_relative_path(self):
         with mock_locustfile() as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(
+            user_classes, shape_classes = main.load_locustfile(
                 os.path.join(os.path.relpath(mocked.directory, os.getcwd()), mocked.filename)
             )
 
@@ -56,19 +56,18 @@ class TestLoadLocustfile(LocustTestCase):
             new_filename = mocked.file_path.replace(mocked.filename, "locust.py")
             os.rename(mocked.file_path, new_filename)
             try:
-                docstring, user_classes, shape_classes = main.load_locustfile(new_filename)
+                user_classes, shape_classes = main.load_locustfile(new_filename)
             finally:
                 # move it back, so it can be deleted
                 os.rename(new_filename, mocked.file_path)
 
     def test_load_locust_file_with_a_dot_in_filename(self):
         with mock_locustfile(filename_prefix="mocked.locust.file") as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
 
     def test_return_docstring_and_user_classes(self):
         with mock_locustfile() as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
-            self.assertEqual("This is a mock locust file for unit testing", docstring)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertIn("UserSubclass", user_classes)
             self.assertNotIn("NotUserSubclass", user_classes)
             self.assertNotIn("LoadTestShape", user_classes)
@@ -82,8 +81,7 @@ class TestLoadLocustfile(LocustTestCase):
         """
         )
         with mock_locustfile(content=content) as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
-            self.assertEqual("This is a mock locust file for unit testing", docstring)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertIn("UserSubclass", user_classes)
             self.assertNotIn("NotUserSubclass", user_classes)
             self.assertEqual(shape_classes[0].__class__.__name__, "LoadTestShape")
@@ -101,8 +99,7 @@ class TestLoadLocustfile(LocustTestCase):
         """
         )
         with mock_locustfile(content=content) as mocked:
-            docstring, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
-            self.assertEqual("This is a mock locust file for unit testing", docstring)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertIn("UserSubclass", user_classes)
             self.assertNotIn("NotUserSubclass", user_classes)
             self.assertEqual(shape_classes[0].__class__.__name__, "LoadTestShape1")
@@ -124,7 +121,7 @@ class TestLoadLocustfile(LocustTestCase):
         )
 
         with mock_locustfile(content=content) as mocked:
-            _, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertNotIn("UserBaseLoadTestShape", user_classes)
             self.assertNotIn("UserLoadTestShape", user_classes)
             self.assertEqual(shape_classes[0].__class__.__name__, "UserLoadTestShape")
@@ -139,7 +136,7 @@ class TestLoadLocustfile(LocustTestCase):
         )
 
         with mock_locustfile(content=content) as mocked:
-            _, user_classes, shape_classes = main.load_locustfile(mocked.file_path)
+            user_classes, shape_classes = main.load_locustfile(mocked.file_path)
             self.assertNotIn("UserLoadTestShape", user_classes)
             self.assertEqual(shape_classes[0].__class__.__name__, "UserLoadTestShape")
 

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -24,7 +24,7 @@ def is_shape_class(item):
     return bool(inspect.isclass(item) and issubclass(item, LoadTestShape) and not getattr(item, "abstract", True))
 
 
-def load_locustfile(path) -> tuple[str | None, dict[str, User], list[LoadTestShape]]:
+def load_locustfile(path) -> tuple[dict[str, User], list[LoadTestShape]]:
     """
     Import given locustfile path and return (docstring, callables).
 
@@ -82,4 +82,4 @@ def load_locustfile(path) -> tuple[str | None, dict[str, User], list[LoadTestSha
     # Find shape class, if any, return it
     shape_classes = [value() for value in vars(imported).values() if is_shape_class(value)]
 
-    return imported.__doc__, user_classes, shape_classes
+    return user_classes, shape_classes

--- a/locust/util/load_locustfile.py
+++ b/locust/util/load_locustfile.py
@@ -10,21 +10,21 @@ from ..shape import LoadTestShape
 from ..user import User
 
 
-def is_user_class(item):
+def is_user_class(item) -> bool:
     """
     Check if a variable is a runnable (non-abstract) User class
     """
     return bool(inspect.isclass(item) and issubclass(item, User) and item.abstract is False)
 
 
-def is_shape_class(item):
+def is_shape_class(item) -> bool:
     """
     Check if a class is a LoadTestShape
     """
     return bool(inspect.isclass(item) and issubclass(item, LoadTestShape) and not getattr(item, "abstract", True))
 
 
-def load_locustfile(path) -> tuple[dict[str, User], list[LoadTestShape]]:
+def load_locustfile(path) -> tuple[dict[str, type[User]], list[LoadTestShape]]:
     """
     Import given locustfile path and return (docstring, callables).
 


### PR DESCRIPTION
Continue to work on #3099 

This PR includes the following changes:

1. Change of `load_locustfile` function output objects. This is internal API change, but still should be released as next version, for example 2.36.0
2. Move merge locustfiles objects to separate function in main.py
3. Fix old incorrect typing in `load_locustfile` function in load_locustfile.py. It is interesting why mypy do not complain earlier.

Note: I leaved TODO message. Incorrect typing of User.tasks attribute is one of the reason I looked at main, the second one is incorrect help work (for command line objects). But correct .tasks attribute type rewrite will trigger many errors in different places, and will require additional tests. So not included at this point. It is in long 'todo' list, that out of my several available days.

Note2: It is interesting that load_locustfile return class for user, and **instance** for `LoadTestShape`. It may be incorrect historical behaviour, but will be cleaner when more code will be refactored. At least at this point it is hard to catch this from first look (now typing will help).

Check commit messages for details