### PR TITLE
Web Ui: Ensure form element has name

### DIFF
--- a/locust/webui/src/components/Form/Form.tsx
+++ b/locust/webui/src/components/Form/Form.tsx
@@ -43,10 +43,13 @@ export default function Form<IInputData extends BaseInputData>({
       const inputData: IInputData = [
         ...form.querySelectorAll<HTMLInputElement | HTMLSelectElement>(FORM_INPUT_ELEMENTS),
       ].reduce(
-        (inputData, inputElement) => ({
-          ...inputData,
-          [inputElement.name]: getInputValue(inputElement),
-        }),
+        (inputData, inputElement) =>
+          inputElement.name
+            ? {
+                ...inputData,
+                [inputElement.name]: getInputValue(inputElement),
+              }
+            : inputData,
         {} as IInputData,
       );
 


### PR DESCRIPTION
Small fix / enhancement where form inputs without a name will not be included in the form data