### PR TITLE
Web UI: Use mutations for state buttons

### DIFF
--- a/locust/webui/src/components/StateButtons/ResetButton.tsx
+++ b/locust/webui/src/components/StateButtons/ResetButton.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@mui/material';
 
+import { useResetStatsMutation } from 'redux/api/swarm';
+
 export default function ResetButton() {
+  const [resetStats] = useResetStatsMutation()
+
   const onResetStatsClick = () => {
-    fetch(
-      (window.baseUrl ? `${window.baseUrl}/` : '') + 'stats/reset',
-      window.baseUrl ? { credentials: 'include' } : undefined,
-    );
+    resetStats()
   };
 
   return (

--- a/locust/webui/src/components/StateButtons/StopButton.tsx
+++ b/locust/webui/src/components/StateButtons/StopButton.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@mui/material';
 
+import { useStopSwarmMutation } from 'redux/api/swarm';
+
 export default function StopButton() {
   const [isLoading, setIsLoading] = useState(false);
+  const [stopSwarm] = useStopSwarmMutation()
+  
 
   useEffect(() => {
     setIsLoading(false);
   }, []);
 
   const onStopButtonClick = () => {
-    fetch(
-      (window.baseUrl ? `${window.baseUrl}/` : '') + 'stop',
-      window.baseUrl ? { credentials: 'include' } : undefined,
-    );
+    stopSwarm()
     setIsLoading(true);
   };
 

--- a/locust/webui/src/components/StateButtons/tests/StopButton.test.tsx
+++ b/locust/webui/src/components/StateButtons/tests/StopButton.test.tsx
@@ -1,32 +1,38 @@
-import { act, fireEvent } from '@testing-library/react';
-import { beforeAll, afterAll, describe, test, expect, vi } from 'vitest';
+import { act, fireEvent, waitFor } from '@testing-library/react';
+import { http } from 'msw';
+import { setupServer } from 'msw/node';
+import { beforeAll, afterAll, describe, test, expect, vi, afterEach } from 'vitest';
 
 import StopButton from 'components/StateButtons/StopButton';
+import { TEST_BASE_API } from 'test/constants';
 import { renderWithProvider } from 'test/testUtils';
 
-const resetStats = vi.fn();
-const baseFetch = fetch;
+const stopSwarm = vi.fn();
+
+const server = setupServer(
+  http.get(`${TEST_BASE_API}/stop`, stopSwarm)
+);
 
 describe('StopButton', () => {
-  beforeAll(() => {
-    global.fetch = resetStats;
+  beforeAll(() => server.listen());
+  afterEach(() => {
+    server.resetHandlers();
+    stopSwarm.mockClear();
   });
-  afterAll(() => {
-    global.fetch = baseFetch;
-  });
+  afterAll(() => server.close());
 
   test('should stop run on StopButton click', async () => {
-    const { getByText, queryByText, rerender } = renderWithProvider(<StopButton />);
+    const { getByText, queryByText } = renderWithProvider(<StopButton />);
+
+    expect(queryByText('Loading')).toBeFalsy();
 
     act(() => {
       fireEvent.click(getByText('Stop'));
     });
 
     expect(getByText('Loading')).toBeTruthy();
-
-    expect(resetStats).toHaveBeenCalled();
-    expect(resetStats).toBeCalledWith('stop', undefined);
-    rerender(<StopButton />);
-    expect(queryByText('Loading')).toBeFalsy();
+    await waitFor(async () => {
+      expect(stopSwarm).toHaveBeenCalled();
+    })
   });
 });

--- a/locust/webui/src/redux/api/swarm.ts
+++ b/locust/webui/src/redux/api/swarm.ts
@@ -55,6 +55,19 @@ export const api = createApi({
         body: snakeCaseKeys(body),
       }),
     }),
+
+    resetStats: builder.mutation<void, void>({
+      query: () => ({
+        url: 'stats/reset',
+        method: 'GET',
+      }),
+    }),
+    stopSwarm: builder.mutation<void, void>({
+      query: () => ({
+        url: 'stop',
+        method: 'GET',
+      }),
+    }),
   }),
 });
 
@@ -65,4 +78,6 @@ export const {
   useGetLogsQuery,
   useStartSwarmMutation,
   useUpdateUserSettingsMutation,
+  useStopSwarmMutation,
+  useResetStatsMutation
 } = api;


### PR DESCRIPTION
Allows us to have the baseUrl logic in one place, and ensures credentials are passed correctly should they be included