### PR TITLE
Fixes #3134 - Improve the performance of the `/stats/requests` endpoint

### DIFF
--- a/locust/web.py
+++ b/locust/web.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import itertools
 import json
 import logging
 import mimetypes
@@ -8,7 +9,6 @@ import os.path
 from functools import wraps
 from html import escape
 from io import StringIO
-from itertools import chain
 from json import dumps
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -456,18 +456,17 @@ class WebUI:
 
                 return jsonify(report)
 
-            for s in chain(stats.sort_stats(environment.runner.stats.entries), [environment.runner.stats.total]):
-                _stats.append(s.to_dict())
-
-            errors = [e.serialize() for e in environment.runner.errors.values()]
-
             # Truncate the total number of stats and errors displayed since a large number of rows will cause the app
             # to render extremely slowly. Aggregate stats should be preserved.
-            truncated_stats = _stats[:500]
-            if len(_stats) > 500:
-                truncated_stats += [_stats[-1]]
+            _stats.extend(
+                stat.to_dict() for stat in itertools.islice(stats.sort_stats(environment.runner.stats.entries), 500)
+            )
+            _stats.append(environment.runner.stats.total.to_dict())
 
-            report = {"stats": truncated_stats, "errors": errors[:500]}
+            errors = [e.serialize() for e in itertools.islice(environment.runner.errors.values(), 500)]
+
+            report = {"stats": _stats, "errors": errors}
+
             total_stats = _stats[-1]
 
             if _stats:


### PR DESCRIPTION
With the following pathological locustfile, the following change hugely reduces the time it takes to call the `/stats/requests` endpoint.

```python
import uuid
from locust import FastHttpUser, between, task 

class User(FastHttpUser):
    wait_time = between(1, 5)

    @task
    def call(self):
        self.client.get(
            f"/some-endpoint?a={uuid.uuid4()}",
            json=None,
        )
``` 

With the existing code, the endpoint almost immediately takes >100ms to execute:

![Screenshot 2025-05-09 at 14 04 18](https://github.com/user-attachments/assets/ebdc2f60-fbab-4dfb-b30d-3f27cff7057a)

Whereas with this branch, it stays around 50ms consistently:

![Screenshot 2025-05-09 at 14 07 06](https://github.com/user-attachments/assets/4aab2d4e-5b86-4ade-8c06-f73cd0579662)


Fixes #3134

