### PR TITLE
Webui: Warn on Missing Host

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -306,3 +306,5 @@ This table lists the constants that are set within locust and may be overridden.
 | locust.runners.WORKER_LOG_REPORT_INTERVAL | Interval for how frequently worker logs are reported to master. Can be disabled      |
 |                                           | by setting to a negative number                                                      |
 +-------------------------------------------+--------------------------------------------------------------------------------------+
+| locust.web.HOST_IS_REQUIRED               | Makes the host field for the webui required                                          |
++-------------------------------------------+--------------------------------------------------------------------------------------+

--- a/locust/web.py
+++ b/locust/web.py
@@ -33,10 +33,12 @@ from gevent import pywsgi
 
 from . import __version__ as version
 from . import argument_parser, stats
+from .contrib import fasthttp
 from .html import DEFAULT_BUILD_PATH, get_html_report, render_template_from
 from .log import get_logs, greenlet_exception_logger
 from .runners import STATE_MISSING, STATE_RUNNING, MasterRunner
 from .user.inspectuser import get_ratio
+from .user.users import HttpUser
 from .util.cache import memoize
 from .util.date import format_safe_timestamp
 from .util.timespan import parse_timespan
@@ -49,6 +51,7 @@ logger = logging.getLogger(__name__)
 greenlet_exception_handler = greenlet_exception_logger(logger)
 
 DEFAULT_CACHE_TIME = 2.0
+HOST_IS_REQUIRED = False
 
 
 class InputField(TypedDict, total=False):
@@ -652,6 +655,7 @@ class WebUI:
 
     def update_template_args(self):
         override_host_warning = False
+        missing_host_warning = False
         if self.environment.host:
             host = self.environment.host
         elif self.environment.runner.user_classes:
@@ -663,8 +667,15 @@ class WebUI:
                 # inform that specifying host will override the host for all User classes
                 override_host_warning = True
                 host = None
+                all_http_user_hosts = [
+                    user_class.host
+                    for user_class in self.environment.runner.user_classes
+                    if issubclass(user_class, HttpUser) or issubclass(user_class, fasthttp.FastHttpUser)
+                ]
+                missing_host_warning = not all(all_http_user_hosts)
         else:
             host = None
+            missing_host_warning = True
 
         options = self.environment.parsed_options
 
@@ -707,6 +718,7 @@ class WebUI:
             "host": host if host else "",
             "history": request_stats.history if request_stats.num_requests > 0 else [],
             "override_host_warning": override_host_warning,
+            "missing_host_warning": missing_host_warning,
             "num_users": options and options.num_users,
             "spawn_rate": options and options.spawn_rate,
             "worker_count": worker_count,
@@ -727,6 +739,7 @@ class WebUI:
             "users": users,
             "percentiles_to_chart": stats.PERCENTILES_TO_CHART,
             "percentiles_to_statistics": stats.PERCENTILES_TO_STATISTICS,
+            "is_host_required": HOST_IS_REQUIRED,
             "profile": self.environment.profile,
         }
 

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -63,6 +63,8 @@ interface ISwarmForm
       | 'shapeUseCommonOptions'
       | 'host'
       | 'overrideHostWarning'
+      | 'missingHostWarning'
+      | 'isHostRequired'
       | 'profile'
       | 'runTime'
       | 'showUserclassPicker'
@@ -107,6 +109,7 @@ function SwarmForm({
   numUsers,
   userCount,
   overrideHostWarning,
+  missingHostWarning,
   profile,
   runTime,
   setSwarm,
@@ -115,6 +118,7 @@ function SwarmForm({
   alert,
   isDisabled = false,
   isEditSwarm = false,
+  isHostRequired,
   onFormChange,
   onFormSubmit,
   advancedOptions,
@@ -230,6 +234,7 @@ function SwarmForm({
                     : ''
                 }`}
                 name='host'
+                required={isHostRequired}
               />
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -283,6 +288,12 @@ function SwarmForm({
           {(errorMessage || formDisabledReason) && (
             <Alert severity={'error'}>{errorMessage || formDisabledReason}</Alert>
           )}
+          {!isHostRequired && missingHostWarning && (
+            <Alert severity='warning'>
+              No host could not be detected on one or more user classes. Please ensure one is
+              provided before running your test.
+            </Alert>
+          )}
           <Button disabled={isFormDisabled} size='large' type='submit' variant='contained'>
             {isEditSwarm ? 'Update' : 'Start'}
           </Button>
@@ -305,6 +316,8 @@ const storeConnector = (
       numUsers,
       userCount,
       overrideHostWarning,
+      missingHostWarning,
+      isHostRequired,
       profile,
       runTime,
       spawnRate,
@@ -321,6 +334,8 @@ const storeConnector = (
   shapeUseCommonOptions,
   host,
   overrideHostWarning,
+  missingHostWarning,
+  isHostRequired,
   profile,
   showUserclassPicker,
   numUsers,

--- a/locust/webui/src/test/mocks/swarmState.mock.ts
+++ b/locust/webui/src/test/mocks/swarmState.mock.ts
@@ -16,6 +16,8 @@ export const swarmStateMock = {
   locustfile: 'main.py',
   numUsers: null,
   overrideHostWarning: false,
+  missingHostWarning: false,
+  isHostRequired: false,
   percentile1: 0.95,
   percentile2: 0.99,
   percentilesToStatistics: percentilesToStatistics,

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -52,6 +52,8 @@ export interface ISwarmState {
   locustfile: string;
   numUsers: number | null;
   overrideHostWarning: boolean;
+  missingHostWarning: boolean;
+  isHostRequired: boolean;
   percentilesToChart: number[];
   percentilesToStatistics: number[];
   runTime?: string | number;


### PR DESCRIPTION
### Proposal
1. Show a warning if no host can be detected (e.g. no host flag is set and at least one http user is missing a host)
2. Add a configuration variable that allows for making the host required from the webui

### Screenshots
![image](https://github.com/user-attachments/assets/5af3d0df-b6e2-4698-a033-21eed8a6760a)
