### PR TITLE
FastHttpUser: Dont send zstd in Accept-Encoding header 

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -231,7 +231,7 @@ class FastHttpSession:
         elif self.auth_header:
             headers["Authorization"] = self.auth_header
         if "Accept-Encoding" not in headers and "accept-encoding" not in headers:
-            headers["Accept-Encoding"] = "gzip, deflate, br, zstd"
+            headers["Accept-Encoding"] = "gzip, deflate, br"
 
         if not data and json is not None:
             data = unshadowed_json.dumps(json)


### PR DESCRIPTION
Because it isn't actually supported by geventhttpclient.

Solves ValueError: Unknown content encoding: zstd