### PR TITLE
Update Dockerfile base to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn webui:install --production --network-timeout 60000
 RUN yarn webui:build
 
 # Stage 2: Build Locust package (make sure any changes here are also reflected in Dockerfile.ci)
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 
 FROM base AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This is the image pushed to Dockerhub, containing the built and tested Locust package
 
 # Stage 1: Install Locust package
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 
 FROM base AS builder
 RUN apt-get update && apt-get install -y git 


### PR DESCRIPTION
Hi,
it was a long time ago since Python 3.13 was released (back in October 2024). So maybe it's time to release locust Docker image with Python 3.13 maybe.

Feel free to comment if I should change some Python version in CI or elsewhere.

Thanks for review.