### PR TITLE
Remove duplicated line in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ maintainers = [
     { name = "Andrew Baldwin" },
 ]
 classifiers = [
-    "Topic :: Software Development :: Testing :: Traffic Generation",
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Simple correction to `pyproject.toml`. It had a duplicated item in the `project.classifiers` list.

The two lines (from the current latest commit in master) are the following.

https://github.com/locustio/locust/blob/7985068237fe0b8ad46455c84100ecf21196e2c6/pyproject.toml#L19

https://github.com/locustio/locust/blob/7985068237fe0b8ad46455c84100ecf21196e2c6/pyproject.toml#L32