### PR TITLE
Move pytest plugin to its own directory, to prevent accidental import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,12 +120,12 @@ source = "vcs"
 version-file = "locust/_version.py"
 
 [tool.hatch.build.targets.sdist]
-include = ["locust"]
+include = ["locust", "pytest_locust"]
 exclude = ["locust/webui/*", "locust/test", "locust/build"]
 artifacts = ["locust/webui/dist"]
 
 [tool.hatch.build.targets.wheel]
-include = ["locust"]
+include = ["locust", "pytest_locust"]
 artifacts = ["locust/webui/dist"]
 
 [tool.hatch.version.raw-options]
@@ -265,4 +265,4 @@ python = ["3.12"]
 build = ["sphinx-build -b html docs/ docs/_build/"]
 
 [project.entry-points.pytest11]
-locust = "locust.pytestplugin"
+locust = "pytest_locust.plugin"

--- a/pytest_locust/plugin.py
+++ b/pytest_locust/plugin.py
@@ -1,4 +1,4 @@
-# This is used in pytest-based, see examples/test_pytest.py
+# This is used in pytest style locustfiles, see examples/test_pytest.py
 from typing import TYPE_CHECKING
 
 import pytest


### PR DESCRIPTION
… of `locust/__init__.py`