### PR TITLE
docs: add distributed mode limitations documentation

### DIFF
--- a/docs/distributed-limitations.rst
+++ b/docs/distributed-limitations.rst
@@ -1,0 +1,63 @@
+.. _distributed-limitations:
+
+===============================
+Distributed Mode Limitations
+===============================
+
+When using distributed mode with ``-f -`` (getting locustfile from master), there are important limitations to be aware of:
+
+Single File Only
+================
+
+The ``-f -`` feature only works with single locustfiles. If your test setup uses multiple files or modules, this approach will not work.
+
+**This will NOT work:**
+
+.. code-block:: bash
+
+    # Multiple files - will fail
+    locust -f locustfile.py -f common.py --worker --master-host <host>
+    
+    # Imports from other modules - will fail  
+    locust -f - --worker --master-host <host>
+    # When locustfile.py contains: from common import helper_functions
+
+**Error you'll see:**
+::
+
+    ModuleNotFoundError: No module named 'common'
+
+Workarounds
+===========
+
+If you need to use multiple files in distributed mode, consider these alternatives:
+
+1. **Combine into single file**: Merge all your code into one locustfile
+2. **Use traditional approach**: Copy all files to each worker machine and use ``-f locustfile.py``
+3. **Use locust-swarm**: Though deprecated, it handles multi-file distribution
+4. **Container approach**: Package your test files in a Docker image
+
+Example Single File Structure
+=============================
+
+Instead of splitting across files, structure everything in one file:
+
+.. code-block:: python
+
+    # locustfile.py - everything in one file
+    from locust import HttpUser, task, between
+    
+    # Helper functions (previously in common.py)
+    def helper_function():
+        return "helper data"
+    
+    # User classes
+    class WebsiteUser(HttpUser):
+        wait_time = between(1, 3)
+        
+        @task
+        def index_page(self):
+            data = helper_function()  # Use helper directly
+            self.client.get("/")
+
+This limitation exists because the ``-f -`` feature was designed for simple, single-file test scenarios to reduce complexity in distributed setups.


### PR DESCRIPTION
## Description
This PR addresses issue #3203 by adding comprehensive documentation about the limitations of using `-f -` (distributed locustfile) with multiple files.

## Changes
- Added new documentation file `docs/distributed-limitations.rst`
- Clearly explains why `-f -` doesn't work with multiple files
- Provides practical workarounds for multi-file test structures
- Includes examples of both problematic and working approaches

## Why this change?
Issue #3203 highlighted that the current documentation mentions `-f -` works for "single locustfiles" but doesn't clearly explain the implications for users with multi-file test structures. This leads to confusion and `ModuleNotFoundError` when users try to import from other modules.

## Benefits
- **Prevents user frustration** - Clear upfront explanation of limitations
- **Provides solutions** - Multiple workaround strategies
- **Improves developer experience** - Users can make informed architectural decisions
- **Reduces support burden** - Fewer duplicate issues about import errors

## Documentation Structure
The new file covers:
1. Clear explanation of the single-file limitation
2. Examples of what doesn't work and why
3. Multiple workaround strategies
4. Example of proper single-file structure

This addresses the maintainer's comment that "serving multiple files is a bit thorny" by documenting the current limitations while providing practical alternatives.