### PR TITLE
loosen dependency on gevent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pywin32; sys_platform == 'win32'",
     "setuptools>=70.0.0",
     "locust-cloud>=1.27.2",
-    "gevent>=24.10.1,<25.8.1",
+    "gevent>=24.10.1,<25.9.1",
     "python-socketio[client]>=5.13.0",
     "python-engineio>=4.12.2",
     "pytest>=8.3.3,<9.0.0",


### PR DESCRIPTION
Congratulations on 2.41.6!

This PR loosens the top pin for `gevent` to allow for using versions with a number of [bug fixes](https://github.com/gevent/gevent/compare/25.8.1...25.9.1).