### PR TITLE
Bumped the gRPC example server’s worker pool to 100

### DIFF
--- a/examples/grpc/hello_server.py
+++ b/examples/grpc/hello_server.py
@@ -17,7 +17,7 @@ class HelloServiceServicer(hello_pb2_grpc.HelloServiceServicer):
 
 
 def start_server():
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=100))
     hello_pb2_grpc.add_HelloServiceServicer_to_server(HelloServiceServicer(), server)
     server.add_insecure_port("localhost:50051")
     server.start()


### PR DESCRIPTION
related issue - https://github.com/locustio/locust/issues/3221

## PR Title Suggestion
Increase gRPC example server worker pool

## Proposed PR Description

bump the example gRPC server’s [ThreadPoolExecutor](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to 100 workers so the demo scales with concurrent users
keeps the rest of the example untouched, per maintainer’s request
Testing

python3 -m py_compile examples/grpc/hello_server.py