### PR TITLE
Add option to force the use of IPv4

### DIFF
--- a/docs/running-distributed.rst
+++ b/docs/running-distributed.rst
@@ -76,6 +76,17 @@ to localhost)
 
 Optionally used together with ``--worker`` to set the port number of the master node (defaults to 5557).
 
+``--master-ipv4-only``
+----------------------
+
+Optionally used together with ``--worker`` or ``--master`` to force the use of IPv4 (defaults to preferring Ipv6)
+
+.. note::
+    If a hostname is provided in ``--msater-host`` and this can be resolved via getaddrinfo to an IPv6 address
+    this will be preferred by default. Some environments might have an IPv6 hosts file entry in place which
+    doesn't work but is difficult to remove so this allows you to pick.
+
+
 ``--master-bind-host <ip>``
 ---------------------------
 

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -250,9 +250,9 @@ See documentation for more details, including how to set options using a file or
     return parser
 
 
-def download_locustfile_from_master(master_host: str, master_port: int) -> str:
+def download_locustfile_from_master(master_host: str, master_port: int, ipv4_only: bool) -> str:
     client_id = socket.gethostname() + "_download_locustfile_" + uuid4().hex
-    tempclient = zmqrpc.Client(master_host, master_port, client_id)
+    tempclient = zmqrpc.Client(master_host, master_port, client_id, ipv4_only)
     got_reply = False
 
     def ask_for_locustfile():
@@ -338,6 +338,13 @@ def parse_locustfile_option(args=None) -> tuple[argparse.Namespace, list[str]]:
         default=5557,
         env_var="LOCUST_MASTER_NODE_PORT",
     )
+    parser.add_argument(
+        "--master-ipv4-only",
+        action="store_true",
+        default=False,
+        help="Only use IPv4 when connecting to the master node",
+        env_var="LOCUST_MASTER_NODE_IPV4_ONLY",
+    )
 
     options, unknown = parser.parse_known_args(args=args)
 
@@ -382,7 +389,9 @@ def retrieve_locustfiles_from_master(options) -> list[str]:
         )
         sys.exit(1)
     # having this in argument_parser module is a bit weird, but it needs to be done early
-    locustfile_sources = download_locustfile_from_master(options.master_host, options.master_port)
+    locustfile_sources = download_locustfile_from_master(
+        options.master_host, options.master_port, options.master_ipv4_only
+    )
     return parse_locustfiles_from_master(locustfile_sources)
 
 
@@ -701,6 +710,13 @@ Typically ONLY these options (and --locustfile) need to be specified on workers,
         default=5557,
         help="Port to connect to on master node. Defaults to 5557.",
         env_var="LOCUST_MASTER_NODE_PORT",
+    )
+    worker_group.add_argument(
+        "--master-ipv4-only",
+        action="store_true",
+        default=False,
+        help="Only use IPv4 when connecting to the master node",
+        env_var="LOCUST_MASTER_NODE_IPV4_ONLY",
     )
 
     web_ui_group.add_argument(

--- a/locust/env.py
+++ b/locust/env.py
@@ -135,7 +135,9 @@ class Environment:
         """
         return self._create_runner(LocalRunner)
 
-    def create_master_runner(self, master_bind_host="*", master_bind_port=5557) -> MasterRunner:
+    def create_master_runner(
+        self, master_bind_host: str = "*", master_bind_port: int = 5557, master_ipv4_only: bool = False
+    ) -> MasterRunner:
         """
         Create a :class:`MasterRunner <locust.runners.MasterRunner>` instance for this Environment
 
@@ -147,14 +149,16 @@ class Environment:
             MasterRunner,
             master_bind_host=master_bind_host,
             master_bind_port=master_bind_port,
+            master_ipv4_only=master_ipv4_only,
         )
 
-    def create_worker_runner(self, master_host: str, master_port: int) -> WorkerRunner:
+    def create_worker_runner(self, master_host: str, master_port: int, master_ipv4_only: bool = False) -> WorkerRunner:
         """
         Create a :class:`WorkerRunner <locust.runners.WorkerRunner>` instance for this Environment
 
         :param master_host: Host/IP of a running master node
         :param master_port: Port on master node to connect to
+        :param master_ipv4_only: Only use ipv4 when connecting to master
         """
         # Create a new RequestStats with use_response_times_cache set to False to save some memory
         # and CPU cycles, since the response_times_cache is not needed for Worker nodes
@@ -163,6 +167,7 @@ class Environment:
             WorkerRunner,
             master_host=master_host,
             master_port=master_port,
+            master_ipv4_only=master_ipv4_only,
         )
 
     def create_web_ui(

--- a/locust/main.py
+++ b/locust/main.py
@@ -419,10 +419,13 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         runner = environment.create_master_runner(
             master_bind_host=options.master_bind_host,
             master_bind_port=options.master_bind_port,
+            master_ipv4_only=options.master_ipv4_only,
         )
     elif options.worker:
         try:
-            runner = environment.create_worker_runner(options.master_host, options.master_port)
+            runner = environment.create_worker_runner(
+                options.master_host, options.master_port, options.master_ipv4_only
+            )
             logger.debug(
                 "Connected to locust master: %s:%s%s", options.master_host, options.master_port, options.web_base_path
             )

--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -62,7 +62,9 @@ class BaseSocket:
     def close(self, linger=None):
         self.socket.close(linger=linger)
 
-    def ipv4_only(self, host, port) -> bool:
+    def ipv4_only(self, host, port, force=False) -> bool:
+        if force:
+            return True
         try:
             if host == "*":
                 return False
@@ -75,8 +77,8 @@ class BaseSocket:
 
 
 class Server(BaseSocket):
-    def __init__(self, host, port):
-        BaseSocket.__init__(self, zmq.ROUTER, self.ipv4_only(host, port))
+    def __init__(self, host, port, ipv4_only):
+        BaseSocket.__init__(self, zmq.ROUTER, self.ipv4_only(host, port, ipv4_only))
         if port == 0:
             self.port = self.socket.bind_to_random_port(f"tcp://{host}")
         else:
@@ -88,7 +90,7 @@ class Server(BaseSocket):
 
 
 class Client(BaseSocket):
-    def __init__(self, host, port, identity):
-        BaseSocket.__init__(self, zmq.DEALER, self.ipv4_only(host, port))
+    def __init__(self, host, port, identity, ipv4_only):
+        BaseSocket.__init__(self, zmq.DEALER, self.ipv4_only(host, port, ipv4_only))
         self.socket.setsockopt(zmq.IDENTITY, identity.encode())
         self.socket.connect("tcp://%s:%i" % (host, port))

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -3436,7 +3436,7 @@ class TestWorkerRunner(LocustTestCase):
             environment = self.environment
         user_classes = user_classes or []
         environment.user_classes = user_classes
-        return WorkerRunner(environment, master_host="localhost", master_port=5557)
+        return WorkerRunner(environment, master_host="localhost", master_port=5557, master_ipv4_only=False)
 
     def test_worker_stop_timeout(self):
         class MyTestUser(User):

--- a/locust/test/test_zmqrpc.py
+++ b/locust/test/test_zmqrpc.py
@@ -10,8 +10,8 @@ import zmq
 class ZMQRPC_tests(LocustTestCase):
     def setUp(self):
         super().setUp()
-        self.server = zmqrpc.Server("*", 0)
-        self.client = zmqrpc.Client("localhost", self.server.port, "identity")
+        self.server = zmqrpc.Server("*", 0, False)
+        self.client = zmqrpc.Client("localhost", self.server.port, "identity", False)
 
     def tearDown(self):
         self.server.close()
@@ -44,15 +44,15 @@ class ZMQRPC_tests(LocustTestCase):
         self.assertEqual(msg.node_id, "identity")
 
     def test_client_retry(self):
-        server = zmqrpc.Server("*", 0)
+        server = zmqrpc.Server("*", 0, False)
         server.socket.close()
         with self.assertRaises(RPCError):
             server.recv_from_client()
 
     def test_rpc_error(self):
-        server = zmqrpc.Server("*", 0)
+        server = zmqrpc.Server("*", 0, False)
         with self.assertRaises(RPCError):
-            server = zmqrpc.Server("*", server.port)
+            server = zmqrpc.Server("*", server.port, False)
         server.close()
         with self.assertRaises(RPCSendError):
             server.send_to_client(Message("test", "message", "identity"))


### PR DESCRIPTION
Locust works great in scalable container environments like ECS which has different ways to allow for the workers to talk to master nodes. One option is Service Connect/Envoy Proxy, this adds a host file entry for a service name for both IPv4 and IPv6 based comms. Except while the OS might have an Ipv6 address the added entry can't be resolved and so the connection fails. 

See https://github.com/aws/amazon-ecs-service-connect-agent/issues/120 for a more detailed rundown of the findings for this

This PR  allows you to force IPv4 as the preferred option instead of the current setup which prefers IPv6 if the provided hostname resolves to an IPv6 address.

This can be configured using the --master-ipv4-only argument and will apply to both master and workers 