### PR TITLE
Add VS Code Extension and k8s operator to documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,7 @@ Other functionalities
     logging
     use-as-lib
     extensions
+    vscode-extension
 
 
 Further reading / knowledgebase

--- a/docs/vscode-extension.rst
+++ b/docs/vscode-extension.rst
@@ -1,0 +1,8 @@
+.. _vscode-extension:
+
+VS Code Extension
+=================
+
+Locust has an official extension for Visual Studio Code that helps you set up your Python environment, create and run tests and use Copilot to generate/adjust Locust test code.
+
+See `https://github.com/locustcloud/extension <https://github.com/locustcloud/extension>`__


### PR DESCRIPTION
This PR doesnt actually add k8s operator docs, those are in the locust-cloud repo, but I put it in the title to mention it in the release notes later :)