### PR TITLE
fix: MQTT client_id and protocol not passed down to Client

### DIFF
--- a/locust/contrib/mqtt.py
+++ b/locust/contrib/mqtt.py
@@ -101,7 +101,7 @@ class MqttClient(mqtt.Client):
         if not client_id:
             client_id = f"locust-{_generate_random_id(16)}"
 
-        super().__init__(*args, client_id=self.client_id, protocol=protocol, **kwargs)
+        super().__init__(*args, client_id=client_id, protocol=protocol, **kwargs)
         self.environment = environment
         # we need to set client_id in case the broker assigns one to us
         self.client_id = client_id


### PR DESCRIPTION
When migrating the MqttClient from Locust Plugins I accidentally modified the call to the parent constructor.

https://github.com/SvenskaSpel/locust-plugins/pull/224/commits/f1845b924bc435751c6c0d18c244f8b78d4e86f9#diff-94fac3dc568e54a6e6f7dc07955bfe16912cea237d2dfcc98f54d97d9d556071L115
