### PR TITLE
adding mqtt user feature that works around the paho mqtt 340 connections limit issue

### DIFF
--- a/locust/contrib/mqtt.py
+++ b/locust/contrib/mqtt.py
@@ -332,8 +332,8 @@ class MqttClient(mqtt.Client):
     def _loop(self, timeout: float = 1.0) -> MQTTErrorCode:
         """Override the parent's _loop method to optionally use selectors.
 
-        When use_loop_selectors is True, this uses a selector-based implementation
-        for better performance. Otherwise, it falls back to the parent's implementation.
+        When use_loop_selectors is True, this uses a selector-based implementation that allows more than 340 connections.
+        Otherwise, it falls back to the parent's implementation.
         """
         if self._use_loop_selectors:
             return self._loop_selectors(timeout)
@@ -466,7 +466,7 @@ class MqttClient(mqtt.Client):
         qos: int = 0,
         options: SubscribeOptions | None = None,
         properties: Properties | None = None,
-    ) -> tuple[mqtt.MQTTErrorCode, int | None]:  # type: ignore
+    ) -> tuple[mqtt.MQTTErrorCode, int | None]:
         """Subscribe to a given topic.
 
         This method wraps the underlying paho-mqtt client's method in order to


### PR DESCRIPTION
Hello,

There's a limitation caused by the use of `select` in the [paho.mqtt.python](https://github.com/eclipse-paho/paho.mqtt.python) library.

https://github.com/eclipse-paho/paho.mqtt.python/issues/697

The purpose of this PR is to provide an implementation of `MqttClient` that has an overriden `_loop` method that uses `selectors` instead of `select`.

The implementation was initially posted on the solution above, by @j04n-f

Please advise on:
🤔 I'm not sure about the `Experimental` name.
📌 Code placement in a separate file.
🧀 If any specific tests are desired and or necessary.
🩻 What better example I could provide.

After the implementation is confirmed I will add documentation and README file updates.

Thanks!