### PR TITLE
Fix Toml Parser Being Called on Conf Files

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -98,7 +98,7 @@ When using a TOML file, configuration options should be defined within the ``[to
 
     .. code-block:: console
 
-       ~/.locust.conf -> ./locust.conf -> ./pyproject.toml -> (file specified using --conf) -> env vars -> cmd args
+       ./pyproject.toml -> ./locust.conf -> (file specified using --config) -> env vars -> cmd args
 
 
 All available configuration options

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -151,6 +151,14 @@ class LocustTomlConfigParser(configargparse.TomlConfigParser):
         return result
 
 
+class LocustConfigParser(configargparse.ConfigFileParser):
+    def parse(self, stream):
+        if stream.name.endswith(".toml"):
+            return LocustTomlConfigParser(["tool.locust"]).parse(stream)
+
+        return configargparse.DefaultConfigFileParser().parse(stream)
+
+
 def parse_locustfile_paths(paths: list[str]) -> list[str]:
     """
     Returns a list of relative file paths.
@@ -218,12 +226,7 @@ def download_locustfile_from_url(url: str) -> str:
 def get_empty_argument_parser(add_help=True, default_config_files=DEFAULT_CONFIG_FILES) -> LocustArgumentParser:
     parser = LocustArgumentParser(
         default_config_files=default_config_files,
-        config_file_parser_class=configargparse.CompositeConfigParser(
-            [
-                LocustTomlConfigParser(["tool.locust"]),
-                configargparse.DefaultConfigFileParser,
-            ]
-        ),
+        config_file_parser_class=LocustConfigParser,
         add_env_var_help=False,
         add_config_file_help=False,
         add_help=add_help,


### PR DESCRIPTION
### Proposal
- Adds a class to detect if the TOML or default config file parser should be used and parse the file accordingly
- Update docs