### PR TITLE
Add missing event hook parameter documentation

### DIFF
--- a/locust/event.py
+++ b/locust/event.py
@@ -159,6 +159,8 @@ class Events:
     """
     Fired on master when a new worker connects. Note that is fired immediately after the connection is established, so init event may not yet have finished on worker.
 
+    Event arguments:
+
     :param client_id: Client id of the connected worker
     """
 
@@ -213,16 +215,28 @@ class Events:
     """
     Fired on each node when a new load test is started. It's not fired again if the number of
     users change during a test.
+
+    Event arguments:
+
+    :param environment: Environment instance
     """
 
     test_stopping: EventHook
     """
     Fired on each node when a load test is about to stop - before stopping users.
+
+    Event arguments:
+
+    :param environment: Environment instance
     """
 
     test_stop: EventHook
     """
     Fired on each node when a load test is stopped.
+
+    Event arguments:
+
+    :param environment: Environment instance
     """
 
     reset_stats: EventHook
@@ -233,6 +247,11 @@ class Events:
     cpu_warning: EventHook
     """
     Fired when the CPU usage exceeds runners.CPU_WARNING_THRESHOLD (90% by default)
+
+    Event arguments:
+
+    :param environment: Environment instance
+    :param cpu_usage: Current CPU usage in percent
     """
 
     heartbeat_sent: EventHook


### PR DESCRIPTION
## Summary

- Adds missing `environment` parameter documentation to `test_start`, `test_stopping`, `test_stop`, and `cpu_warning` event hooks
- Adds missing `cpu_usage` parameter documentation to the `cpu_warning` event hook
- Adds the missing "Event arguments:" header to `worker_connect` for consistency with other documented hooks

Fixes #3338

## Details

Several event hooks in `locust/event.py` were missing their keyword argument documentation, which caused confusion for users (e.g., the `test_stop` handler expecting `environment` but the docs not mentioning it). This PR documents the parameters by cross-referencing the actual `fire()` calls in `runners.py`, `web.py`, and `debug.py`.

Events updated:
| Event | Parameters Added |
|---|---|
| `test_start` | `environment` |
| `test_stopping` | `environment` |
| `test_stop` | `environment` |
| `cpu_warning` | `environment`, `cpu_usage` |
| `worker_connect` | (added "Event arguments:" header for consistency) |

## Test plan

- [x] Verified Python syntax with `ast.parse()`
- [ ] Confirmed rendered docs look correct in Sphinx (docstring-only change, follows existing patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)