### PR TITLE
Fix typos in docs, docstrings, and UI string

### DIFF
--- a/docs/custom-load-shape.rst
+++ b/docs/custom-load-shape.rst
@@ -93,7 +93,7 @@ Adding the element ``user_classes`` to the return value gives you more detailed 
 
             return None
 
-This shape would create create in the first 10 seconds 10 User of ``UserA``. In the next twenty seconds 40 of type ``UserA / UserB`` and this continues until the stages end.
+This shape would create in the first 10 seconds 10 User of ``UserA``. In the next twenty seconds 40 of type ``UserA / UserB`` and this continues until the stages end.
 
 
 .. _use-common-options:
@@ -101,7 +101,7 @@ This shape would create create in the first 10 seconds 10 User of ``UserA``. In 
 Reusing common options in custom shapes
 ---------------------------------------
 
-When using shapes, the the *Users*, *Spawn Rate* and *Run Time* options will be hidden from the UI, and if you specify them on command line Locust will log a warning. This is because those options dont directly apply to shapes, and specifying them might be a mistake.
+When using shapes, the *Users*, *Spawn Rate* and *Run Time* options will be hidden from the UI, and if you specify them on command line Locust will log a warning. This is because those options don't directly apply to shapes, and specifying them might be a mistake.
 
 If you really want to combine a shape with these options, set the ``use_common_options`` attribute and access them from ``self.runner.environment.parsed_options``:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -31,9 +31,9 @@ Control headers or other things about my HTTP requests
 
 Basic auth (Authorization header) does not work after redirection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   `requests <https://requests.readthedocs.io/en/master/>`__ has a security mecanism that
-   drops the authorization header on domain change. It could occure when testing a SSO,
-   which is typically on a different domain and use mulitple redirections (30x).
+   `requests <https://requests.readthedocs.io/en/master/>`__ has a security mechanism that
+   drops the authorization header on domain change. It could occur when testing a SSO,
+   which is typically on a different domain and use multiple redirections (30x).
 
    Since ``allow_redirects=True`` is the default ``request`` behavior you'll have to turn it off,
    handle manually the redirections and inject again the authorization header, ex:
@@ -78,7 +78,7 @@ How to run a Docker container of Locust in Windows Subsystem for Linux (Windows 
 How to run locust on custom endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Prefix the the endpoint to all ``@app.route`` definitions in
+   Prefix the endpoint to all ``@app.route`` definitions in
    ``locust/web.py`` file & also change as follows (where ``/locust`` is
    new endpoint)
 

--- a/locust/event.py
+++ b/locust/event.py
@@ -261,7 +261,7 @@ class Events:
     Event arguments:
 
     :param client_id: worker client id
-    :param timestamp: time in seconds since the epoch (float) when the event occured
+    :param timestamp: time in seconds since the epoch (float) when the event occurred
     """
 
     heartbeat_received: EventHook
@@ -271,7 +271,7 @@ class Events:
     Event arguments:
 
     :param client_id: worker client id
-    :param timestamp: time in seconds since the epoch (float) when the event occured
+    :param timestamp: time in seconds since the epoch (float) when the event occurred
     """
 
     usage_monitor: EventHook

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -154,7 +154,7 @@ function SwarmForm({
         profile: inputData.profile,
       });
     } else {
-      setErrorMessage(data ? data.message : 'An unknown error occured.');
+      setErrorMessage(data ? data.message : 'An unknown error occurred.');
     }
 
     if (onFormSubmit) {


### PR DESCRIPTION
This PR fixes several typos across the codebase:

**docs/faq.rst:**
- `mecanism` → `mechanism`
- `occure` → `occur`
- `mulitple` → `multiple`
- `the the` → `the`

**docs/custom-load-shape.rst:**
- `the the` → `the`
- `dont` → `don't`
- `create create` → `create`

**locust/event.py:**
- `occured` → `occurred` (2 occurrences in docstrings)

**locust/webui/src/components/SwarmForm/SwarmForm.tsx:**
- `occured` → `occurred` in error message string
