### PR TITLE
Fix false "--run-time limit reached" log message when shape test completes

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -493,9 +493,9 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
         web_ui.start()
         main_greenlet = web_ui.greenlet
 
-    def stop_and_optionally_quit():
+    def stop_and_optionally_quit(reason="--run-time limit reached"):
         if options.autostart and not options.headless:
-            logger.info("--run-time limit reached, stopping test")
+            logger.info(f"{reason}, stopping test")
             runner.stop()
             if options.autoquit != -1:
                 logger.debug(f"Autoquit time limit set to {options.autoquit} seconds")
@@ -507,7 +507,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
             else:
                 logger.info("--autoquit not specified, leaving web ui running indefinitely")
         else:  # --headless run
-            logger.info("--run-time limit reached, shutting down")
+            logger.info(f"{reason}, shutting down")
             runner.quit()
 
     def spawn_run_time_quit_greenlet():
@@ -562,7 +562,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
                 except KeyboardInterrupt:
                     logging.info("Exiting due to CTRL+C interruption")
                 finally:
-                    stop_and_optionally_quit()
+                    stop_and_optionally_quit(reason="Shape test completed")
             else:
                 headless_master_greenlet = gevent.spawn(runner.start, options.num_users, options.spawn_rate)
                 headless_master_greenlet.link_exception(greenlet_exception_handler)

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -550,7 +550,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                 self.assertEqual(200, response.status_code)
 
                 tp.expect("Shape test starting")
-                tp.expect("--run-time limit reached")
+                tp.expect("Shape test completed")
 
     @unittest.skipIf(sys.platform == "darwin", reason="Disable on macOS for now because it has issues on GH")
     def test_autostart_multiple_locustfiles_with_shape(self):
@@ -604,7 +604,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
                     tp.expect("Shape test starting")
                     tp.expect("Shape test stopping")
 
-                    tp.expect("--run-time limit reached")
+                    tp.expect("Shape test completed")
                     tp.expect("--autoquit time reached")
                     tp.expect("Shutting down")
 


### PR DESCRIPTION
## Summary

- Fixes the misleading `--run-time limit reached` log message that appears when a `LoadTestShape` test completes naturally or is interrupted, even though the stop was not caused by the `--run-time` limit.
- Adds a `reason` parameter to `stop_and_optionally_quit()` (defaults to `"--run-time limit reached"` for backward compatibility) and passes `"Shape test completed"` from the shape class `finally` block.
- Updates corresponding tests to expect the corrected log message.

Fixes #3178

## Context

As noted in #3178, calling `stop()` / `quit()` or letting a `LoadTestShape` finish naturally would print `--run-time limit reached, shutting down` (or `stopping test`), which is incorrect and confusing since the stop was not triggered by `--run-time`. A maintainer acknowledged this as a valid bug but it was closed as stale with no fix applied.

## Changes

- **`locust/main.py`**: `stop_and_optionally_quit()` now takes an optional `reason` parameter. The timer-based call (`spawn_run_time_quit_greenlet`) still passes the default `"--run-time limit reached"`. The shape class `finally` block now passes `"Shape test completed"`.
- **`locust/test/test_main.py`**: Updated two shape-class integration tests (`test_autostart_w_load_shape` and `test_autostart_multiple_locustfiles_with_shape`) to expect `"Shape test completed"` instead of `"--run-time limit reached"`.

## Test plan

- [ ] Existing tests in `test_main.py` and `test_log.py` that verify `--run-time limit reached` for actual timer-triggered stops remain unchanged and should pass
- [ ] The two updated shape-class tests should now correctly expect `"Shape test completed"`
- [ ] Manual test: run a `LoadTestShape` with `--autostart` and verify the log says `"Shape test completed, stopping test"` instead of `"--run-time limit reached, stopping test"`