### PR TITLE
fix: use total_rps instead of current_rps in HTML report and navbar stats

### DIFF
--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -130,6 +130,20 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
         self.assertEqual("Aggregated", data["stats"][1]["name"])
         self.assertEqual(1, data["stats"][1]["num_requests"])
 
+    def test_html_report_uses_total_rps_not_current_rps(self):
+        self.stats.log_request("GET", "/test", 100, 1000)
+        self.stats.log_request("GET", "/test", 120, 1200)
+        response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
+        self.assertEqual(200, response.status_code)
+
+        data = json.loads(response.text)
+        self.assertIn("total_rps", data)
+        self.assertIn("total_fail_per_sec", data)
+
+        total_entry = data["stats"][-1]
+        self.assertEqual(total_entry["total_rps"], data["total_rps"])
+        self.assertEqual(total_entry["total_fail_per_sec"], data["total_fail_per_sec"])
+
     def test_stats_cache(self):
         self.stats.log_request("GET", "/test", 120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)

--- a/locust/web.py
+++ b/locust/web.py
@@ -483,8 +483,13 @@ class WebUI:
             total_stats = _stats[-1]
 
             if _stats:
-                report["total_rps"] = total_stats["current_rps"]
-                report["total_fail_per_sec"] = total_stats["current_fail_per_sec"]
+                # Use total_rps (total requests / elapsed time) instead of
+                # current_rps (a ~10-second sliding-window average) so that the
+                # HTML report and the navbar RPS figure reflect the entire test
+                # run, not just the last few seconds.  Consistent with the
+                # behaviour of the final console summary since #1152.
+                report["total_rps"] = total_stats["total_rps"]
+                report["total_fail_per_sec"] = total_stats["total_fail_per_sec"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio
                 report["current_response_time_percentiles"] = {
                     f"response_time_percentile_{percentile}": environment.runner.stats.total.get_current_response_time_percentile(

--- a/locust/web.py
+++ b/locust/web.py
@@ -483,11 +483,6 @@ class WebUI:
             total_stats = _stats[-1]
 
             if _stats:
-                # Use total_rps (total requests / elapsed time) instead of
-                # current_rps (a ~10-second sliding-window average) so that the
-                # HTML report and the navbar RPS figure reflect the entire test
-                # run, not just the last few seconds.  Consistent with the
-                # behaviour of the final console summary since #1152.
                 report["total_rps"] = total_stats["total_rps"]
                 report["total_fail_per_sec"] = total_stats["total_fail_per_sec"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio


### PR DESCRIPTION
## Summary

Fixes #3355.

The stats API endpoint used `current_rps` (a ~10-second sliding-window average) to populate `total_rps` and `total_fail_per_sec` in the report payload. This made the HTML report inconsistent with the final console summary, which correctly uses `total_rps` (total requests ÷ elapsed time) since #1152.

## Root Cause

```python
# locust/web.py line 486
report["total_rps"] = total_stats["current_rps"]         # ← wrong
report["total_fail_per_sec"] = total_stats["current_fail_per_sec"]  # ← wrong
```

## Fix

```python
report["total_rps"] = total_stats["total_rps"]           # ✓ aggregate rate
report["total_fail_per_sec"] = total_stats["total_fail_per_sec"]    # ✓
```

Since the HTML report is a post-test artifact representing the entire run, it should always show the aggregate rate — not whatever the last ~10 seconds happened to look like.