### PR TITLE
fix: break reference cycle in ResponseContextManager (fixes #3388)

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -710,7 +710,7 @@ class ResponseContextManager(FastResponse):
         # copy data from response to this object
         # I wanted to change this to the approach from the HttpUser's ResponseContentManager.from_request,
         # but it was such a mess
-        self.__dict__ = response.__dict__
+        self.__dict__.update(response.__dict__)
         try:
             self._cached_content = response._cached_content
         except AttributeError:

--- a/locust/test/test_fasthttp.py
+++ b/locust/test/test_fasthttp.py
@@ -806,6 +806,20 @@ class TestFastHttpCatchResponse(WebserverTestCase):
         self.assertEqual(0, self.num_success)
 
 
+    def test_response_context_manager_does_not_share_dict(self):
+        """Test that ResponseContextManager copies response.__dict__ instead of sharing it.
+        Sharing the dict creates a reference cycle that Python 3.13+ GC can collect
+        mid-request, clearing request_meta and causing TypeError (fixes #3388).
+        """
+        response = self.user.client.get("/ultra_fast")
+        from locust.contrib.fasthttp import ResponseContextManager
+        request_meta = {"request_type": "GET", "name": "/test", "context": {}, "response": response,
+                        "exception": None, "start_time": 0, "url": "/test", "response_time": 0, "response_length": 0}
+        rcm = ResponseContextManager(response, self.environment.events.request, request_meta, True)
+        # After construction, rcm.__dict__ must NOT be the same object as response.__dict__
+        self.assertIsNot(rcm.__dict__, response.__dict__,
+                         "ResponseContextManager should copy, not share, response.__dict__")
+
 class TestFastHttpSsl(LocustTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

- **Root cause:** `ResponseContextManager.__init__` used `self.__dict__ = response.__dict__`, which shares (not copies) the underlying dict object. Combined with `request_meta["response"] = response`, this creates a reference cycle. Python 3.13+ incremental GC collects this cycle mid-request, clearing `request_meta` to `{}`, causing `TypeError` in `events.request.fire(**{})`.
- **Fix:** Changed `self.__dict__ = response.__dict__` to `self.__dict__.update(response.__dict__)`, which copies the attributes into a new dict, breaking the reference cycle.
- **Impact:** This crash only manifests on Python 3.13+ due to changes in the garbage collector (PEP 703 / incremental GC). On older Python versions the cycle existed but was rarely collected at a problematic time.

## Related issues

- Fixes #3388
- Also addresses the root cause behind #3050 and #3207, which reported similar `TypeError` / `request_meta` clearing symptoms

## Test plan

- [x] Added unit test `test_response_context_manager_does_not_share_dict` verifying that `ResponseContextManager.__dict__` is not the same object as `response.__dict__` after construction
- [ ] Verify existing `TestFastHttpCatchResponse` tests still pass
- [ ] Test with Python 3.13+ under load to confirm the `TypeError` crash no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)