### PR TITLE
fix(fasthttp): catch FAILURE_EXCEPTIONS during response body read

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -282,7 +282,7 @@ class FastHttpSession:
         else:
             try:
                 request_meta["response_length"] = len(response.content) if response.content else 0
-            except HTTPParseError as e:
+            except (HTTPParseError, *FAILURE_EXCEPTIONS) as e:
                 request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
                 request_meta["exception"] = e
                 if catch_response:


### PR DESCRIPTION
## Summary

- `FastHttpSession.request()` accesses `response.content` to measure response length after `_send_request_safe_mode` has already returned successfully (headers received).
- The existing `except` only caught `HTTPParseError`, leaving network exceptions raised *during body read* (e.g. `SSLErrorReadTimeout`, which gevent raises as `socket.timeout`) to escape `request()` and reach user code as unhandled exceptions, bypassing Locust's request event and metrics.
- Fix: broaden the `except` clause to also include `FAILURE_EXCEPTIONS`, consistent with how `_send_request_safe_mode` handles the same error set during the connection phase.

## Related issues

- Related to #1457, #2640, #2894 (pattern: exceptions during body read not caught consistently)