### PR TITLE
Fix FastHttpUser crash on Python 3.13+ due to GC collecting __dict__ reference cycle

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -707,10 +707,10 @@ class ResponseContextManager(FastResponse):
     _entered = False
 
     def __init__(self, response, request_event, request_meta, catch_response: bool):
-        # copy data from response to this object
-        # I wanted to change this to the approach from the HttpUser's ResponseContentManager.from_request,
-        # but it was such a mess
-        self.__dict__ = response.__dict__
+        # copy data from response to this object (use update to avoid sharing
+        # the dict reference, which creates a GC-reference cycle that Python 3.13+
+        # can collect mid-request — see #3388)
+        self.__dict__.update(response.__dict__)
         try:
             self._cached_content = response._cached_content
         except AttributeError:


### PR DESCRIPTION
## Summary

ResponseContextManager.__init__ in fasthttp.py shares a dict between two objects via self.__dict__ = response.__dict__. Combined with request_meta["response"] = response, this creates a reference cycle. On Python 3.13+, the GC can collect this cycle mid-request (especially during gevent I/O with large responses), clearing request_meta to {}. When the with-block exits, events.request.fire(**{}) is called with no arguments, triggering:

TypeError: on_request() missing 4 required positional arguments

## Fix

Change self.__dict__ = response.__dict__ to self.__dict__.update(response.__dict__) so response data is copied instead of sharing the underlying dict. This breaks the GC reference cycle while preserving all existing behavior.

Fixes #3388 (also related to #3050, #3207)

## Details

- Only one line of logic changed: = -> .update()
- No new dependencies or API changes