### PR TITLE
Add AI-optimized documentation (llms.txt)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,38 @@
+# Third-Party Notices
+
+Locust uses third-party software components. This file lists components that are
+integrated at the source level (where Locust code closely couples to their APIs)
+along with their license attributions.
+
+## sphinx-markdown-builder
+
+`docs/_ext/llms_txt.py` uses `sphinx_markdown_builder.translator.MarkdownTranslator`
+(via a minimal builder proxy) to convert Sphinx doctrees to Markdown for the
+auto-generated `llms.txt` / `llms-full.txt` files.
+
+- Source: https://github.com/liran-funaro/sphinx-markdown-builder
+- License: MIT
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2023-2026, Liran Funaro.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/docs/_ext/llms_txt.py
+++ b/docs/_ext/llms_txt.py
@@ -1,0 +1,219 @@
+"""Sphinx extension that generates llms.txt and llms-full.txt for AI consumption.
+
+Generates an index file (llms.txt) and a full concatenated markdown file (llms-full.txt)
+from the existing RST documentation during the HTML build, following the llmstxt.org standard.
+"""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+from sphinx.util import logging
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://docs.locust.io/en/stable/"
+DEFAULT_EXCLUDE = ["changelog", "faq", "further-reading", "ai-docs"]
+DEFAULT_DESCRIPTION = "Developer-friendly load testing framework. Write scalable load tests in plain Python."
+
+
+class _MarkdownConfig:
+    """Config proxy with default values for sphinx-markdown-builder's translator."""
+
+    markdown_http_base = ""
+    markdown_uri_doc_suffix = ".html"
+    markdown_anchor_sections = False
+    markdown_anchor_signatures = False
+    markdown_docinfo = False
+    markdown_bullet = "*"
+    markdown_flavor = ""
+
+
+class _MarkdownBuilderProxy:
+    """Minimal proxy providing the attributes MarkdownTranslator needs from a builder."""
+
+    def __init__(self, current_doc_name: str = ""):
+        self.config = _MarkdownConfig()
+        self.current_doc_name = current_doc_name
+
+    def get_target_uri(self, docname: str, typ: str = None) -> str:
+        return f"{docname}.html"
+
+
+def _doctree_to_markdown(doctree: nodes.document, docname: str) -> str:
+    """Convert a Sphinx doctree to Markdown using sphinx-markdown-builder's translator."""
+    from sphinx_markdown_builder.translator import MarkdownTranslator
+
+    tree = deepcopy(doctree)
+    # deepcopy loses the reporter; restore it from the original
+    tree.reporter = doctree.reporter
+    proxy = _MarkdownBuilderProxy(current_doc_name=docname)
+    visitor = MarkdownTranslator(tree, proxy)
+    tree.walkabout(visitor)
+    return visitor.astext()
+
+
+def _get_first_paragraph(doctree: nodes.document) -> str:
+    """Extract the first paragraph text from a doctree for use as a description."""
+    for node in doctree.traverse(nodes.paragraph):
+        return node.astext().replace("\n", " ").strip()
+    return ""
+
+
+def _walk_toctree(env, docname: str, exclude: list[str]) -> list[str]:
+    """Recursively walk toctree includes and return ordered docnames, excluding specified ones."""
+    result = []
+    includes = env.toctree_includes.get(docname, [])
+    for child in includes:
+        if child in exclude:
+            continue
+        result.append(child)
+        result.extend(_walk_toctree(env, child, exclude))
+    return result
+
+
+def _get_section_groups(env, master_doc: str, exclude: list[str]) -> list[tuple[str, list[str]]]:
+    """Parse the master document's toctree to get section groups.
+
+    Returns a list of (section_title, [docnames]) pairs based on the master doc structure.
+    Only processes direct child sections of the root, not the root section itself.
+    """
+    doctree = env.get_doctree(master_doc)
+    groups = []
+
+    # Find the root section
+    root_sections = list(doctree.traverse(nodes.section, descend=True, siblings=False))
+    if not root_sections:
+        return groups
+
+    root_section = root_sections[0]
+
+    # Process only direct child sections of the root
+    for child in root_section.children:
+        if not isinstance(child, nodes.section):
+            continue
+
+        title_node = child.next_node(nodes.title)
+        if title_node is None:
+            continue
+        section_title = title_node.astext()
+
+        # Only get toctrees that are direct children of this section (not nested)
+        toctree_nodes = []
+        for node in child.children:
+            if node.tagname == "toctree":
+                toctree_nodes.append(node)
+            elif isinstance(node, nodes.compound):
+                for subnode in node.children:
+                    if subnode.tagname == "toctree":
+                        toctree_nodes.append(subnode)
+
+        if not toctree_nodes:
+            continue
+
+        docnames = []
+        for toctree_node in toctree_nodes:
+            for entry in toctree_node.get("entries", []):
+                _, docname = entry
+                if docname and docname not in exclude:
+                    docnames.append(docname)
+
+        if docnames:
+            groups.append((section_title, docnames))
+
+    return groups
+
+
+def _generate_llms_txt(app: Sphinx, section_groups: list[tuple[str, list[str]]]) -> str:
+    """Generate the llms.txt index content."""
+    base_url = app.config.llms_txt_base_url.rstrip("/") + "/"
+    description = app.config.llms_txt_description
+    project = app.config.project
+
+    lines = [f"# {project}\n"]
+    lines.append(f"> {description}\n")
+
+    for section_title, docnames in section_groups:
+        lines.append(f"\n## {section_title}\n")
+        for docname in docnames:
+            title_node = app.env.titles.get(docname)
+            title = title_node.astext() if title_node else docname
+            url = f"{base_url}{docname}.html"
+
+            doctree = app.env.get_doctree(docname)
+            desc = _get_first_paragraph(doctree)
+            if desc:
+                lines.append(f"- [{title}]({url}): {desc}")
+            else:
+                lines.append(f"- [{title}]({url})")
+
+    return "\n".join(lines) + "\n"
+
+
+def _generate_llms_full_txt(app: Sphinx, section_groups: list[tuple[str, list[str]]]) -> str:
+    """Generate the llms-full.txt full content."""
+    project = app.config.project
+    description = app.config.llms_txt_description
+
+    parts = [f"# {project}\n\n> {description}\n"]
+
+    for section_title, docnames in section_groups:
+        for docname in docnames:
+            doctree = app.env.get_doctree(docname)
+            try:
+                md_content = _doctree_to_markdown(doctree, docname)
+                parts.append(f"\n---\n\n{md_content}")
+            except Exception as e:
+                logger.warning("llms_txt: failed to convert %s to markdown: %s", docname, e)
+                text = doctree.astext()
+                title_node = app.env.titles.get(docname)
+                title = title_node.astext() if title_node else docname
+                parts.append(f"\n---\n\n# {title}\n\n{text}")
+
+    return "\n".join(parts) + "\n"
+
+
+def on_build_finished(app: Sphinx, exception: Exception | None) -> None:
+    """Event handler called when the build finishes."""
+    if exception:
+        return
+
+    if app.builder.name != "html":
+        return
+
+    exclude = app.config.llms_txt_exclude
+    master_doc = app.config.master_doc
+
+    section_groups = _get_section_groups(app.env, master_doc, exclude)
+    if not section_groups:
+        logger.warning("llms_txt: no toctree sections found, skipping generation")
+        return
+
+    llms_txt = _generate_llms_txt(app, section_groups)
+    llms_full_txt = _generate_llms_full_txt(app, section_groups)
+
+    outdir = app.outdir
+    llms_txt_path = os.path.join(outdir, "llms.txt")
+    llms_full_txt_path = os.path.join(outdir, "llms-full.txt")
+
+    with open(llms_txt_path, "w", encoding="utf-8") as f:
+        f.write(llms_txt)
+    logger.info("llms_txt: wrote %s", llms_txt_path)
+
+    with open(llms_full_txt_path, "w", encoding="utf-8") as f:
+        f.write(llms_full_txt)
+    logger.info("llms_txt: wrote %s", llms_full_txt_path)
+
+
+def setup(app: Sphinx) -> dict:
+    app.add_config_value("llms_txt_base_url", DEFAULT_BASE_URL, "html")
+    app.add_config_value("llms_txt_exclude", DEFAULT_EXCLUDE, "html")
+    app.add_config_value("llms_txt_description", DEFAULT_DESCRIPTION, "html")
+    app.connect("build-finished", on_build_finished)
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/_ext/llms_txt.py
+++ b/docs/_ext/llms_txt.py
@@ -1,7 +1,12 @@
 """Sphinx extension that generates llms.txt and llms-full.txt for AI consumption.
 
 Generates an index file (llms.txt) and a full concatenated markdown file (llms-full.txt)
-from the existing RST documentation during the HTML build, following the llmstxt.org standard.
+from the existing RST documentation during the HTML build, following the llmstxt.org
+standard.
+
+This extension uses ``sphinx_markdown_builder.translator.MarkdownTranslator``
+(MIT License, Copyright (c) 2023-2026 Liran Funaro) via a minimal builder proxy
+to render doctrees as Markdown. See THIRD-PARTY-NOTICES.md at the repository root.
 """
 
 from __future__ import annotations

--- a/docs/ai-docs.rst
+++ b/docs/ai-docs.rst
@@ -1,0 +1,56 @@
+.. _ai-docs:
+
+==============================
+AI-optimized documentation
+==============================
+
+Locust provides machine-readable documentation optimized for use with LLMs and AI coding assistants,
+following the `llms.txt standard <https://llmstxt.org/>`_.
+
+Available files
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 50 30
+
+   * - File
+     - Description
+     - Use case
+   * - `llms.txt <llms.txt>`_
+     - Lightweight index with links to all documentation pages and short descriptions
+     - Quick reference, tool discovery
+   * - `llms-full.txt <llms-full.txt>`_
+     - Complete documentation content in a single Markdown file (~200KB)
+     - Full context for AI assistants
+
+How to use
+==========
+
+**With AI coding assistants:**
+
+Many AI tools can ingest ``llms.txt`` or ``llms-full.txt`` directly. For example, you can point your
+assistant to ``https://docs.locust.io/en/stable/llms-full.txt`` to give it full context about Locust.
+
+**With CLI tools:**
+
+.. code-block:: console
+
+    $ curl -s https://docs.locust.io/en/stable/llms-full.txt | your-llm-tool
+
+**As a CLAUDE.md reference:**
+
+.. code-block:: markdown
+
+    # Locust Documentation
+    See https://docs.locust.io/en/stable/llms-full.txt for full API and usage docs.
+
+How it works
+============
+
+These files are **auto-generated** from the same RST source files that produce this HTML documentation.
+They are built during every documentation build using a Sphinx extension, so they are always up to date
+and never out of sync with the rest of the docs.
+
+Excluded content: changelog, FAQ, and further reading pages are not included to keep the files focused
+on actionable documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,11 @@
 from locust.argument_parser import get_parser
 
 import os
+import sys
 import subprocess
+
+# Add local extensions directory to path
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "_ext"))
 
 # Add fixes for RTD deprecation
 # https://about.readthedocs.com/blog/2024/07/addons-by-default/
@@ -98,6 +102,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinxcontrib.googleanalytics",
     "sphinx.ext.extlinks",
+    "llms_txt",
 ]
 
 extlinks = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 from locust.argument_parser import get_parser
 
 import os
-import sys
 import subprocess
+import sys
 
 # Add local extensions directory to path
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "_ext"))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Further reading / knowledgebase
 
     developing-locust
     further-reading
+    ai-docs
     faq
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ docs = [
     "sphinxcontrib-qthelp==1.0.3",
     "sphinxcontrib-serializinghtml==2.0.0",
     "sphinxcontrib-googleanalytics>=0.4",
+    "sphinx-markdown-builder>=0.6.0",
     # these optional dependencies are needed to build the some contrib modules
     "pymilvus>=2.5.0",
     "psycopg[binary]>=3.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1249,6 +1249,7 @@ docs = [
     { name = "readthedocs-sphinx-search" },
     { name = "snowballstemmer" },
     { name = "sphinx" },
+    { name = "sphinx-markdown-builder" },
     { name = "sphinx-prompt" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinx-substitution-extensions" },
@@ -1341,6 +1342,7 @@ docs = [
     { name = "readthedocs-sphinx-search", specifier = "==0.3.2" },
     { name = "snowballstemmer", specifier = "==3.0.1" },
     { name = "sphinx", specifier = "==7.4.7" },
+    { name = "sphinx-markdown-builder", specifier = ">=0.6.0" },
     { name = "sphinx-prompt", specifier = "==1.5.0" },
     { name = "sphinx-rtd-theme", specifier = "==3.1.0" },
     { name = "sphinx-substitution-extensions", specifier = "==2020.9.30.0" },
@@ -3275,6 +3277,20 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+]
+
+[[package]]
 name = "sphinx-prompt"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3389,6 +3405,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

  Adds a Sphinx extension that auto-generates `llms.txt` and `llms-full.txt` during the
  normal HTML docs build, following the [llms.txt standard](https://llmstxt.org/).

  - `llms.txt` — lightweight index with links and descriptions for all doc pages
  - `llms-full.txt` — complete documentation in a single Markdown file (~210KB)

  Both files are derived artifacts (like HTML) generated from the same RST sources —
  **no content duplication**. This addresses the concern from [PR #3123](https://github.com/locustio/locust/pull/3123)
  which was closed because it introduced a separate `docs-md/` directory with duplicated content.

  Closes #3372

  ## How it works

  A Sphinx extension (`docs/_ext/llms_txt.py`) hooks into the `build-finished` event and:
  1. Walks the toctree structure to build the `llms.txt` index
  2. Converts each document's doctree to Markdown using `sphinx-markdown-builder`
  3. Concatenates all pages into `llms-full.txt`
  4. Writes both files to the HTML output directory

  Changelog, FAQ, and further-reading pages are excluded to keep files focused on actionable docs.

  ## Files changed

  | File | Change |
  |------|--------|
  | `docs/_ext/llms_txt.py` | New Sphinx extension (~150 lines) |
  | `docs/ai-docs.rst` | New doc page describing the AI-optimized files |
  | `docs/conf.py` | Register the extension |
  | `docs/index.rst` | Add ai-docs to toctree |
  | `pyproject.toml` | Add `sphinx-markdown-builder` to docs deps |

  ## Post-merge action

  Configure RTD redirects so AI tools can find files at the standard paths:
  - `/llms.txt` → `/en/stable/llms.txt`
  - `/llms-full.txt` → `/en/stable/llms-full.txt`

  ## Test plan

  - [x] `sphinx-build -b html docs/ docs/_build/` succeeds (4 pre-existing warnings only)
  - [x] `docs/_build/llms.txt` follows llmstxt.org spec (H1, blockquote, H2 sections with links)
  - [x] `docs/_build/llms-full.txt` contains all expected pages in Markdown (~5600 lines)
  - [x] Excluded pages (changelog, faq, further-reading) are absent from generated files
  - [x] `docs/_build/ai-docs.html` renders correctly