### PR TITLE
Embed client-side chart snapshot in downloaded reports

### DIFF
--- a/locust/webui/src/components/LineChart/LineChart.tsx
+++ b/locust/webui/src/components/LineChart/LineChart.tsx
@@ -34,6 +34,8 @@ interface ILineChartProps<ChartType extends IBaseChartType> extends ILineChart<C
   xAxis?: XAXisComponentOption;
   grid?: GridComponentOption;
   isDarkMode?: boolean;
+  onChartReady?: (chart: ECharts) => void;
+  chartGroup?: string;
 }
 
 echartsUse([
@@ -60,10 +62,17 @@ export default function LineChart<ChartType extends IBaseChartType>({
   scatterplot,
   shouldReplaceMergeLines = false,
   isDarkMode = false,
+  onChartReady,
+  chartGroup = 'swarmCharts',
 }: ILineChartProps<ChartType>) {
   const [chart, setChart] = useState<ECharts | null>(null);
 
   const chartContainer = useRef<HTMLDivElement | null>(null);
+  const onChartReadyRef = useRef(onChartReady);
+
+  useEffect(() => {
+    onChartReadyRef.current = onChartReady;
+  }, [onChartReady]);
 
   useEffect(() => {
     if (!chartContainer.current) {
@@ -94,10 +103,11 @@ export default function LineChart<ChartType extends IBaseChartType>({
     };
     window.addEventListener('resize', handleChartResize);
 
-    initChart.group = 'swarmCharts';
-    connect('swarmCharts');
+    initChart.group = chartGroup;
+    connect(chartGroup);
 
     setChart(initChart);
+    onChartReadyRef.current?.(initChart);
 
     return () => {
       dispose(initChart);

--- a/locust/webui/src/components/Reports/Reports.test.tsx
+++ b/locust/webui/src/components/Reports/Reports.test.tsx
@@ -89,7 +89,7 @@ describe('Reports', () => {
 
   test('injects a client-side charts PNG when downloading the report from chart data', async () => {
     const reportHtml =
-      '<html><body><script>window.templateArgs = {"is_report":true}</script><script type="module" src="/assets/report.js"></script></body></html>';
+      '<html><body><script>\n      window.templateArgs = {"is_report":true,"history":[{"time":"2026-04-27T12:00:00Z"}]}\n      window.theme = "light"\n    </script><script type="module" src="/assets/report.js"></script></body></html>';
     const fetchMock = vi.fn().mockResolvedValue({
       headers: {
         get: vi.fn().mockReturnValue('attachment; filename="Locust_report_with_charts.html"'),
@@ -167,6 +167,8 @@ describe('Reports', () => {
 
       expect(downloadedHtml).toContain('charts_png');
       expect(downloadedHtml).toContain('data:image/png');
+      expect(downloadedHtml).toContain('"history":[]');
+      expect(downloadedHtml).not.toContain('2026-04-27T12:00:00Z');
       expect(downloadedHtml.indexOf('charts_png')).toBeLessThan(
         downloadedHtml.indexOf('<script type="module"'),
       );
@@ -197,13 +199,15 @@ describe('Reports', () => {
     vi.unstubAllGlobals();
   });
 
-  test('injects the chart PNG before the report module script', () => {
+  test('adds the chart PNG to report template args and omits chart history', () => {
     const reportHtml =
-      '<html><body><script>window.templateArgs = {"is_report":true}</script><script type="module" src="/assets/report.js"></script></body></html>';
+      '<html><body><script>\n      window.templateArgs = {"is_report":true,"history":[{"time":"2026-04-27T12:00:00Z"}]}\n      window.theme = "light"\n    </script><script type="module" src="/assets/report.js"></script></body></html>';
 
     const injectedHtml = injectChartsPngIntoReportHtml(reportHtml, 'data:image/png;base64,test');
 
     expect(injectedHtml).toContain('"charts_png":"data:image/png;base64,test"');
+    expect(injectedHtml).toContain('"history":[]');
+    expect(injectedHtml).not.toContain('2026-04-27T12:00:00Z');
     expect(injectedHtml.indexOf('charts_png')).toBeLessThan(
       injectedHtml.indexOf('<script type="module"'),
     );

--- a/locust/webui/src/components/Reports/Reports.test.tsx
+++ b/locust/webui/src/components/Reports/Reports.test.tsx
@@ -1,6 +1,8 @@
-import { test, describe, expect } from 'vitest';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { test, describe, expect, vi } from 'vitest';
 
 import Reports from 'components/Reports/Reports';
+import { SWARM_CHART_COUNT } from 'components/SwarmCharts/SwarmCharts';
 import { statsResponseTransformed } from 'test/mocks/statsRequest.mock';
 import { renderWithProvider } from 'test/testUtils';
 
@@ -84,6 +86,42 @@ describe('Reports', () => {
 
     expect(link).toBeTruthy();
     expect(link.getAttribute('href')).toBeNull();
+  });
+
+  test('downloads a client-side charts PNG from rendered chart data', async () => {
+    const { container, getByText } = renderWithProvider(<Reports />, {
+      ui: { charts: statsResponseTransformed.charts },
+    });
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('canvas').length).toBe(SWARM_CHART_COUNT),
+    );
+
+    const downloadedAnchor = { current: null as HTMLAnchorElement | null };
+    const appendChild = document.body.appendChild.bind(document.body);
+    const appendChildSpy = vi
+      .spyOn(document.body, 'appendChild')
+      .mockImplementation(<T extends Node>(node: T) => {
+        if (node instanceof HTMLAnchorElement) {
+          downloadedAnchor.current = node;
+        }
+
+        return appendChild(node) as T;
+      });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    try {
+      await waitFor(() => {
+        fireEvent.click(getByText('Download charts PNG'));
+        expect(downloadedAnchor.current).toBeTruthy();
+      });
+
+      expect(downloadedAnchor.current?.download).toMatch(/^Locust_charts_.*\.png$/);
+      expect(downloadedAnchor.current?.href).toMatch(/^data:image\/png/);
+    } finally {
+      appendChildSpy.mockRestore();
+      clickSpy.mockRestore();
+    }
   });
 
   test('does not render a client-side charts PNG download when chart data is unavailable', () => {

--- a/locust/webui/src/components/Reports/Reports.test.tsx
+++ b/locust/webui/src/components/Reports/Reports.test.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, waitFor } from '@testing-library/react';
 import { test, describe, expect, vi } from 'vitest';
 
-import Reports from 'components/Reports/Reports';
-import { SWARM_CHART_COUNT } from 'components/SwarmCharts/SwarmCharts';
+import Reports, {
+  filenameFromContentDisposition,
+  injectChartsPngIntoReportHtml,
+} from 'components/Reports/Reports';
 import { statsResponseTransformed } from 'test/mocks/statsRequest.mock';
 import { renderWithProvider } from 'test/testUtils';
 
@@ -77,27 +79,28 @@ describe('Reports', () => {
     expect(link.getAttribute('href')).toBe('./stats/report?theme=light');
   });
 
-  test('renders a client-side charts PNG download when chart data is available', () => {
-    const { getByText } = renderWithProvider(<Reports />, {
+  test('does not render a duplicate client-side charts PNG download', () => {
+    const { queryByText } = renderWithProvider(<Reports />, {
       ui: { charts: statsResponseTransformed.charts },
     });
 
-    const link = getByText('Download charts PNG');
-
-    expect(link).toBeTruthy();
-    expect(link.getAttribute('href')).toBeNull();
+    expect(queryByText('Download charts PNG')).toBeNull();
   });
 
-  test('downloads a client-side charts PNG from rendered chart data', async () => {
-    const { container, getByText } = renderWithProvider(<Reports />, {
-      ui: { charts: statsResponseTransformed.charts },
+  test('injects a client-side charts PNG when downloading the report from chart data', async () => {
+    const reportHtml =
+      '<html><body><script>window.templateArgs = {"is_report":true}</script><script type="module" src="/assets/report.js"></script></body></html>';
+    const fetchMock = vi.fn().mockResolvedValue({
+      headers: {
+        get: vi.fn().mockReturnValue('attachment; filename="Locust_report_with_charts.html"'),
+      },
+      ok: true,
+      text: vi.fn().mockResolvedValue(reportHtml),
     });
-
-    await waitFor(() =>
-      expect(container.querySelectorAll('canvas').length).toBe(SWARM_CHART_COUNT),
-    );
+    type DownloadedBlob = { parts: BlobPart[]; type: string };
 
     const downloadedAnchor = { current: null as HTMLAnchorElement | null };
+    const downloadedBlob = { current: null as DownloadedBlob | null };
     const appendChild = document.body.appendChild.bind(document.body);
     const appendChildSpy = vi
       .spyOn(document.body, 'appendChild')
@@ -109,25 +112,112 @@ describe('Reports', () => {
         return appendChild(node) as T;
       });
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    const createObjectURL = vi.fn().mockImplementation((blob: DownloadedBlob) => {
+      downloadedBlob.current = blob;
+      return 'blob:locust-report';
+    });
+    const revokeObjectURL = vi.fn();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: BlobPart[];
+        type: string;
+
+        constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+          this.parts = parts;
+          this.type = options?.type || '';
+        }
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
 
     try {
-      await waitFor(() => {
-        fireEvent.click(getByText('Download charts PNG'));
-        expect(downloadedAnchor.current).toBeTruthy();
+      const { getByText } = renderWithProvider(<Reports />, {
+        ui: { charts: statsResponseTransformed.charts },
       });
 
-      expect(downloadedAnchor.current?.download).toMatch(/^Locust_charts_.*\.png$/);
-      expect(downloadedAnchor.current?.href).toMatch(/^data:image\/png/);
+      fireEvent.click(getByText('Download Report'));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith('./stats/report?download=1&theme=light'),
+      );
+      await waitFor(() => expect(downloadedBlob.current).toBeTruthy());
+
+      expect(downloadedAnchor.current?.download).toBe('Locust_report_with_charts.html');
+      expect(downloadedAnchor.current?.href).toBe('blob:locust-report');
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:locust-report');
+
+      const downloadedHtml = downloadedBlob.current?.parts.join('');
+
+      expect(downloadedHtml).toBeTruthy();
+      if (!downloadedHtml) {
+        return;
+      }
+
+      expect(downloadedHtml).toContain('charts_png');
+      expect(downloadedHtml).toContain('data:image/png');
+      expect(downloadedHtml.indexOf('charts_png')).toBeLessThan(
+        downloadedHtml.indexOf('<script type="module"'),
+      );
     } finally {
+      vi.unstubAllGlobals();
       appendChildSpy.mockRestore();
       clickSpy.mockRestore();
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreateObjectURL,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      });
     }
   });
 
-  test('does not render a client-side charts PNG download when chart data is unavailable', () => {
-    const { queryByText } = renderWithProvider(<Reports />);
+  test('keeps the normal report link when chart data is unavailable', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
 
-    expect(queryByText('Download charts PNG')).toBeNull();
+    const { getByText } = renderWithProvider(<Reports />);
+
+    fireEvent.click(getByText('Download Report'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  test('injects the chart PNG before the report module script', () => {
+    const reportHtml =
+      '<html><body><script>window.templateArgs = {"is_report":true}</script><script type="module" src="/assets/report.js"></script></body></html>';
+
+    const injectedHtml = injectChartsPngIntoReportHtml(reportHtml, 'data:image/png;base64,test');
+
+    expect(injectedHtml).toContain('"charts_png":"data:image/png;base64,test"');
+    expect(injectedHtml.indexOf('charts_png')).toBeLessThan(
+      injectedHtml.indexOf('<script type="module"'),
+    );
+  });
+
+  test('uses the report fallback filename when the report response has no filename header', () => {
+    expect(filenameFromContentDisposition(null)).toBe('Locust_report.html');
+    expect(filenameFromContentDisposition('attachment')).toBe('Locust_report.html');
+  });
+
+  test('uses the report filename from the content disposition header', () => {
+    expect(filenameFromContentDisposition('attachment; filename="Locust_2026.html"')).toBe(
+      'Locust_2026.html',
+    );
   });
 
   test('renders links to download extended CSV files', () => {

--- a/locust/webui/src/components/Reports/Reports.test.tsx
+++ b/locust/webui/src/components/Reports/Reports.test.tsx
@@ -1,6 +1,7 @@
 import { test, describe, expect } from 'vitest';
 
 import Reports from 'components/Reports/Reports';
+import { statsResponseTransformed } from 'test/mocks/statsRequest.mock';
 import { renderWithProvider } from 'test/testUtils';
 
 describe('Reports', () => {
@@ -72,6 +73,23 @@ describe('Reports', () => {
 
     expect(link).toBeTruthy();
     expect(link.getAttribute('href')).toBe('./stats/report?theme=light');
+  });
+
+  test('renders a client-side charts PNG download when chart data is available', () => {
+    const { getByText } = renderWithProvider(<Reports />, {
+      ui: { charts: statsResponseTransformed.charts },
+    });
+
+    const link = getByText('Download charts PNG');
+
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBeNull();
+  });
+
+  test('does not render a client-side charts PNG download when chart data is unavailable', () => {
+    const { queryByText } = renderWithProvider(<Reports />);
+
+    expect(queryByText('Download charts PNG')).toBeNull();
   });
 
   test('renders links to download extended CSV files', () => {

--- a/locust/webui/src/components/Reports/Reports.tsx
+++ b/locust/webui/src/components/Reports/Reports.tsx
@@ -1,15 +1,126 @@
-import { Link, List, ListItem } from '@mui/material';
+import { useRef, useState } from 'react';
+import { Box, Link, List, ListItem } from '@mui/material';
+import type { ECharts } from 'echarts';
 import { connect } from 'react-redux';
 
+import SwarmCharts, { SWARM_CHART_COUNT } from 'components/SwarmCharts/SwarmCharts';
 import { THEME_MODE } from 'constants/theme';
 import { useSelector } from 'redux/hooks';
 import { IRootState } from 'redux/store';
 import { ISwarmState } from 'types/swarm.types';
+import { ICharts } from 'types/ui.types';
+
+const CHART_EXPORT_WIDTH = 1200;
+const CHART_EXPORT_PIXEL_RATIO = 3;
+const CHART_EXPORT_GROUP = 'swarmReportCharts';
+
+type ExportableChart = ECharts & {
+  getConnectedDataURL?: (options: Record<string, unknown>) => string;
+  getDataURL: (options: Record<string, unknown>) => string;
+};
+
+const hasClientChartData = (charts: ICharts) =>
+  Boolean(
+    charts &&
+      [
+        charts.currentRps,
+        charts.currentFailPerSec,
+        charts.totalAvgResponseTime,
+        charts.userCount,
+      ].some(series => Array.isArray(series) && series.length > 0),
+  );
+
+const constructChartsPngFilename = () =>
+  `Locust_charts_${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
+
+const downloadDataUrl = (dataUrl: string, filename: string) => {
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};
+
+const chartBackgroundColor = (isDarkMode: boolean) => (isDarkMode ? '#121212' : '#ffffff');
+
+function ChartsPngDownload({ charts, isDarkMode }: { charts: ICharts; isDarkMode: boolean }) {
+  const chartRefs = useRef<(ECharts | null)[]>([]);
+  const [readyChartCount, setReadyChartCount] = useState(0);
+  const hasData = hasClientChartData(charts);
+
+  if (!hasData) {
+    return null;
+  }
+
+  const onChartReady = (chart: ECharts, index: number) => {
+    if (chartRefs.current[index] === chart) {
+      return;
+    }
+
+    chartRefs.current[index] = chart;
+    setReadyChartCount(chartRefs.current.filter(Boolean).length);
+  };
+
+  const onDownloadChartsPng = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+
+    if (readyChartCount < SWARM_CHART_COUNT) {
+      return;
+    }
+
+    const chart = chartRefs.current.find(Boolean) as ExportableChart | undefined;
+    if (!chart) {
+      return;
+    }
+
+    const exportOptions = {
+      type: 'png',
+      pixelRatio: CHART_EXPORT_PIXEL_RATIO,
+      backgroundColor: chartBackgroundColor(isDarkMode),
+      excludeComponents: ['toolbox'],
+    };
+    const dataUrl = chart.getConnectedDataURL
+      ? chart.getConnectedDataURL(exportOptions)
+      : chart.getDataURL(exportOptions);
+
+    downloadDataUrl(dataUrl, constructChartsPngFilename());
+  };
+
+  return (
+    <>
+      <Link component='button' onClick={onDownloadChartsPng} type='button'>
+        Download charts PNG
+      </Link>
+      <Box
+        aria-hidden
+        sx={{
+          height: SWARM_CHART_COUNT * 300,
+          left: -10000,
+          opacity: 0,
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          position: 'fixed',
+          top: 0,
+          width: CHART_EXPORT_WIDTH,
+        }}
+      >
+        <SwarmCharts
+          chartGroup={CHART_EXPORT_GROUP}
+          charts={charts}
+          isDarkMode={isDarkMode}
+          onChartReady={onChartReady}
+        />
+      </Box>
+    </>
+  );
+}
 
 function Reports({
+  charts,
   extendedCsvFiles,
   statsHistoryEnabled,
-}: Pick<ISwarmState, 'extendedCsvFiles' | 'statsHistoryEnabled'>) {
+}: Pick<ISwarmState, 'extendedCsvFiles' | 'statsHistoryEnabled'> & { charts: ICharts }) {
   const isDarkMode = useSelector(({ theme: { isDarkMode } }) => isDarkMode);
 
   return (
@@ -38,6 +149,11 @@ function Reports({
           Download Report
         </Link>
       </ListItem>
+      {hasClientChartData(charts) && (
+        <ListItem>
+          <ChartsPngDownload charts={charts} isDarkMode={isDarkMode} />
+        </ListItem>
+      )}
       {extendedCsvFiles &&
         extendedCsvFiles.map(({ href, title }, index) => (
           <ListItem key={`extended-csv-${index}`}>
@@ -48,7 +164,11 @@ function Reports({
   );
 }
 
-const storeConnector = ({ swarm: { extendedCsvFiles, statsHistoryEnabled } }: IRootState) => ({
+const storeConnector = ({
+  swarm: { extendedCsvFiles, statsHistoryEnabled },
+  ui: { charts },
+}: IRootState) => ({
+  charts,
   extendedCsvFiles,
   statsHistoryEnabled,
 });

--- a/locust/webui/src/components/Reports/Reports.tsx
+++ b/locust/webui/src/components/Reports/Reports.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { Box, Link, List, ListItem } from '@mui/material';
 import type { ECharts } from 'echarts';
 import { connect } from 'react-redux';
@@ -13,13 +14,15 @@ import { ICharts } from 'types/ui.types';
 const CHART_EXPORT_WIDTH = 1200;
 const CHART_EXPORT_PIXEL_RATIO = 3;
 const CHART_EXPORT_GROUP = 'swarmReportCharts';
+const REPORT_DOWNLOAD_FALLBACK_FILENAME = 'Locust_report.html';
+const REPORT_MODULE_SCRIPT_MARKER = '<script type="module" src=';
 
 type ExportableChart = ECharts & {
   getConnectedDataURL?: (options: Record<string, unknown>) => string;
   getDataURL: (options: Record<string, unknown>) => string;
 };
 
-const hasClientChartData = (charts: ICharts) =>
+export const hasClientChartData = (charts: ICharts) =>
   Boolean(
     charts &&
       [
@@ -30,47 +33,87 @@ const hasClientChartData = (charts: ICharts) =>
       ].some(series => Array.isArray(series) && series.length > 0),
   );
 
-const constructChartsPngFilename = () =>
-  `Locust_charts_${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
+const constructReportUrl = (isDarkMode: boolean, shouldDownload = false) =>
+  `./stats/report?${shouldDownload ? 'download=1&' : ''}theme=${
+    isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT
+  }`;
 
-const downloadDataUrl = (dataUrl: string, filename: string) => {
+export const filenameFromContentDisposition = (contentDisposition: string | null) => {
+  if (!contentDisposition) {
+    return REPORT_DOWNLOAD_FALLBACK_FILENAME;
+  }
+
+  const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+
+  return filenameMatch?.[1] || REPORT_DOWNLOAD_FALLBACK_FILENAME;
+};
+
+export const injectChartsPngIntoReportHtml = (reportHtml: string, chartsPng: string) => {
+  const script = `<script>window.templateArgs = Object.assign({}, window.templateArgs, ${JSON.stringify(
+    { charts_png: chartsPng },
+  )})</script>`;
+
+  if (reportHtml.includes(REPORT_MODULE_SCRIPT_MARKER)) {
+    return reportHtml.replace(
+      REPORT_MODULE_SCRIPT_MARKER,
+      `${script}\n    ${REPORT_MODULE_SCRIPT_MARKER}`,
+    );
+  }
+
+  if (reportHtml.includes('</body>')) {
+    return reportHtml.replace('</body>', `${script}\n  </body>`);
+  }
+
+  return `${reportHtml}\n${script}`;
+};
+
+const downloadHtml = (html: string, filename: string) => {
+  const url = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
   const link = document.createElement('a');
-  link.href = dataUrl;
+  link.href = url;
   link.download = filename;
   document.body.appendChild(link);
   link.click();
   link.remove();
+  URL.revokeObjectURL(url);
+};
+
+const downloadReportWithChartsPng = async (reportDownloadUrl: string, chartsPng: string) => {
+  const response = await fetch(reportDownloadUrl);
+
+  if (!response.ok) {
+    throw new Error('Unable to download report');
+  }
+
+  const reportHtml = await response.text();
+  const filename = filenameFromContentDisposition(response.headers.get('Content-Disposition'));
+
+  downloadHtml(injectChartsPngIntoReportHtml(reportHtml, chartsPng), filename);
 };
 
 const chartBackgroundColor = (isDarkMode: boolean) => (isDarkMode ? '#121212' : '#ffffff');
 
-function ChartsPngDownload({ charts, isDarkMode }: { charts: ICharts; isDarkMode: boolean }) {
+function ReportDownload({ charts, isDarkMode }: { charts: ICharts; isDarkMode: boolean }) {
   const chartRefs = useRef<(ECharts | null)[]>([]);
+  const isDownloadingReport = useRef(false);
+  const [isPreparingReport, setIsPreparingReport] = useState(false);
   const [readyChartCount, setReadyChartCount] = useState(0);
   const hasData = hasClientChartData(charts);
+  const reportHref = constructReportUrl(isDarkMode);
+  const reportDownloadHref = constructReportUrl(isDarkMode, true);
 
-  if (!hasData) {
-    return null;
-  }
-
-  const onChartReady = (chart: ECharts, index: number) => {
-    if (chartRefs.current[index] === chart) {
-      return;
-    }
-
-    chartRefs.current[index] = chart;
-    setReadyChartCount(chartRefs.current.filter(Boolean).length);
-  };
-
-  const onDownloadChartsPng = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-
-    if (readyChartCount < SWARM_CHART_COUNT) {
+  useEffect(() => {
+    if (
+      !isPreparingReport ||
+      isDownloadingReport.current ||
+      readyChartCount < SWARM_CHART_COUNT
+    ) {
       return;
     }
 
     const chart = chartRefs.current.find(Boolean) as ExportableChart | undefined;
     if (!chart) {
+      setIsPreparingReport(false);
       return;
     }
 
@@ -84,34 +127,70 @@ function ChartsPngDownload({ charts, isDarkMode }: { charts: ICharts; isDarkMode
       ? chart.getConnectedDataURL(exportOptions)
       : chart.getDataURL(exportOptions);
 
-    downloadDataUrl(dataUrl, constructChartsPngFilename());
+    isDownloadingReport.current = true;
+
+    void downloadReportWithChartsPng(reportDownloadHref, dataUrl)
+      .catch(() => {
+        window.open(reportHref, '_blank');
+      })
+      .finally(() => {
+        isDownloadingReport.current = false;
+        setIsPreparingReport(false);
+      });
+  }, [isDarkMode, isPreparingReport, readyChartCount, reportDownloadHref, reportHref]);
+
+  const onChartReady = (chart: ECharts, index: number) => {
+    if (chartRefs.current[index] === chart) {
+      return;
+    }
+
+    chartRefs.current[index] = chart;
+    setReadyChartCount(chartRefs.current.filter(Boolean).length);
+  };
+
+  const onDownloadReport = (event: MouseEvent<HTMLElement>) => {
+    if (!hasData) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (isPreparingReport) {
+      return;
+    }
+
+    chartRefs.current = [];
+    setReadyChartCount(0);
+    setIsPreparingReport(true);
   };
 
   return (
     <>
-      <Link component='button' onClick={onDownloadChartsPng} type='button'>
-        Download charts PNG
+      <Link href={reportHref} onClick={onDownloadReport} target='_blank'>
+        Download Report
       </Link>
-      <Box
-        aria-hidden
-        sx={{
-          height: SWARM_CHART_COUNT * 300,
-          left: -10000,
-          opacity: 0,
-          overflow: 'hidden',
-          pointerEvents: 'none',
-          position: 'fixed',
-          top: 0,
-          width: CHART_EXPORT_WIDTH,
-        }}
-      >
-        <SwarmCharts
-          chartGroup={CHART_EXPORT_GROUP}
-          charts={charts}
-          isDarkMode={isDarkMode}
-          onChartReady={onChartReady}
-        />
-      </Box>
+      {isPreparingReport && (
+        <Box
+          aria-hidden
+          sx={{
+            height: SWARM_CHART_COUNT * 300,
+            left: -10000,
+            opacity: 0,
+            overflow: 'hidden',
+            pointerEvents: 'none',
+            position: 'fixed',
+            top: 0,
+            width: CHART_EXPORT_WIDTH,
+          }}
+        >
+          <SwarmCharts
+            chartGroup={CHART_EXPORT_GROUP}
+            charts={charts}
+            isDarkMode={isDarkMode}
+            onChartReady={onChartReady}
+          />
+        </Box>
+      )}
     </>
   );
 }
@@ -142,18 +221,8 @@ function Reports({
         <Link href='./exceptions/csv'>Download exceptions CSV</Link>
       </ListItem>
       <ListItem>
-        <Link
-          href={`./stats/report?theme=${isDarkMode ? THEME_MODE.DARK : THEME_MODE.LIGHT}`}
-          target='_blank'
-        >
-          Download Report
-        </Link>
+        <ReportDownload charts={charts} isDarkMode={isDarkMode} />
       </ListItem>
-      {hasClientChartData(charts) && (
-        <ListItem>
-          <ChartsPngDownload charts={charts} isDarkMode={isDarkMode} />
-        </ListItem>
-      )}
       {extendedCsvFiles &&
         extendedCsvFiles.map(({ href, title }, index) => (
           <ListItem key={`extended-csv-${index}`}>

--- a/locust/webui/src/components/Reports/Reports.tsx
+++ b/locust/webui/src/components/Reports/Reports.tsx
@@ -16,6 +16,8 @@ const CHART_EXPORT_PIXEL_RATIO = 3;
 const CHART_EXPORT_GROUP = 'swarmReportCharts';
 const REPORT_DOWNLOAD_FALLBACK_FILENAME = 'Locust_report.html';
 const REPORT_MODULE_SCRIPT_MARKER = '<script type="module" src=';
+const REPORT_TEMPLATE_ARGS_ASSIGNMENT = 'window.templateArgs = ';
+const REPORT_THEME_ASSIGNMENT_PATTERN = /\n\s*window\.theme\s*=/;
 
 type ExportableChart = ECharts & {
   getConnectedDataURL?: (options: Record<string, unknown>) => string;
@@ -49,6 +51,35 @@ export const filenameFromContentDisposition = (contentDisposition: string | null
 };
 
 export const injectChartsPngIntoReportHtml = (reportHtml: string, chartsPng: string) => {
+  const templateArgsAssignmentStart = reportHtml.indexOf(REPORT_TEMPLATE_ARGS_ASSIGNMENT);
+  const templateArgsValueStart =
+    templateArgsAssignmentStart === -1
+      ? -1
+      : templateArgsAssignmentStart + REPORT_TEMPLATE_ARGS_ASSIGNMENT.length;
+  const templateArgsRemainder =
+    templateArgsValueStart === -1 ? '' : reportHtml.slice(templateArgsValueStart);
+  const templateArgsEndMatch = templateArgsRemainder.match(REPORT_THEME_ASSIGNMENT_PATTERN);
+
+  if (templateArgsValueStart !== -1 && templateArgsEndMatch?.index !== undefined) {
+    try {
+      const templateArgsValueEnd = templateArgsValueStart + templateArgsEndMatch.index;
+      const templateArgs = JSON.parse(
+        reportHtml.slice(templateArgsValueStart, templateArgsValueEnd).trim(),
+      );
+      const updatedTemplateArgs = JSON.stringify({
+        ...templateArgs,
+        charts_png: chartsPng,
+        history: [],
+      });
+
+      return `${reportHtml.slice(0, templateArgsValueStart)}${updatedTemplateArgs}${reportHtml.slice(
+        templateArgsValueEnd,
+      )}`;
+    } catch {
+      // Fall back to adding a small pre-module script if the report template changes.
+    }
+  }
+
   const script = `<script>window.templateArgs = Object.assign({}, window.templateArgs, ${JSON.stringify(
     { charts_png: chartsPng },
   )})</script>`;

--- a/locust/webui/src/components/SwarmCharts/SwarmCharts.tsx
+++ b/locust/webui/src/components/SwarmCharts/SwarmCharts.tsx
@@ -1,3 +1,5 @@
+import type { ECharts } from 'echarts';
+
 import LineChart from 'components/LineChart/LineChart';
 import { ILineChart } from 'components/LineChart/LineChart.types';
 import { swarmTemplateArgs } from 'constants/swarm';
@@ -20,7 +22,7 @@ const percentileColors = [
   '#E6E6FA',
 ];
 
-const availableSwarmCharts: Omit<ILineChart<ICharts>, 'charts'>[] = [
+export const availableSwarmCharts: Omit<ILineChart<ICharts>, 'charts'>[] = [
   {
     title: 'Total Requests per Second',
     lines: [
@@ -41,19 +43,27 @@ const availableSwarmCharts: Omit<ILineChart<ICharts>, 'charts'>[] = [
   },
 ];
 
+export const SWARM_CHART_COUNT = availableSwarmCharts.length;
+
 export default function SwarmCharts({
   charts,
   isDarkMode,
+  onChartReady,
+  chartGroup,
 }: {
   charts: ICharts;
   isDarkMode?: boolean;
+  onChartReady?: (chart: ECharts, index: number) => void;
+  chartGroup?: string;
 }) {
   return availableSwarmCharts.map((lineChartProps, index) => (
     <LineChart<ICharts>
       key={`swarm-chart-${index}`}
       {...lineChartProps}
+      chartGroup={chartGroup}
       charts={charts}
       isDarkMode={isDarkMode}
+      onChartReady={chart => onChartReady?.(chart, index)}
     />
   ));
 }

--- a/locust/webui/src/hooks/tests/useFetchStats.test.tsx
+++ b/locust/webui/src/hooks/tests/useFetchStats.test.tsx
@@ -43,6 +43,19 @@ describe('useFetchStats', () => {
     });
 
     expect(store.getState().ui.stats).toEqual(statsResponseTransformed.stats);
+    expect(store.getState().ui.totalRps).toEqual(statsResponseTransformed.totalRps);
+    expect((store.getState().ui.charts as ICharts).currentRps.at(-1)).toEqual([
+      expect.any(String),
+      statsResponseTransformed.stats.at(-1)?.currentRps,
+    ]);
+    expect((store.getState().ui.charts as ICharts).currentFailPerSec.at(-1)).toEqual([
+      expect.any(String),
+      statsResponseTransformed.stats.at(-1)?.currentFailPerSec,
+    ]);
+    expect((store.getState().ui.charts as ICharts).totalAvgResponseTime.at(-1)).toEqual([
+      expect.any(String),
+      0.41,
+    ]);
   });
 
   test('should add markers to charts between tests', async () => {

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -36,12 +36,10 @@ export default function useFetchStats() {
       stats,
       errors,
       totalRps,
-      totalFailPerSec,
       failRatio,
       workers,
       workerCount,
       userCount,
-      totalAvgResponseTime,
     } = statsData;
 
     const time = new Date().toISOString();
@@ -52,8 +50,11 @@ export default function useFetchStats() {
     }
 
     const totalRpsRounded = roundToDecimalPlaces(totalRps, 2);
-    const totalFailPerSecRounded = roundToDecimalPlaces(totalFailPerSec, 2);
     const totalFailureRatioRounded = roundToDecimalPlaces(failRatio * 100);
+    const totalStats = stats.at(-1);
+    const currentRpsRounded = roundToDecimalPlaces(totalStats?.currentRps ?? 0, 2);
+    const currentFailPerSecRounded = roundToDecimalPlaces(totalStats?.currentFailPerSec ?? 0, 2);
+    const totalAvgResponseTimeRounded = roundToDecimalPlaces(totalStats?.avgResponseTime ?? 0, 2);
 
     const percentilesWithTime = Object.entries(currentResponseTimePercentiles).reduce(
       (percentiles, [key, value]) => ({
@@ -65,9 +66,9 @@ export default function useFetchStats() {
 
     const newChartEntry = {
       ...percentilesWithTime,
-      currentRps: [time, totalRpsRounded],
-      currentFailPerSec: [time, totalFailPerSecRounded],
-      totalAvgResponseTime: [time, roundToDecimalPlaces(totalAvgResponseTime, 2)],
+      currentRps: [time, currentRpsRounded],
+      currentFailPerSec: [time, currentFailPerSecRounded],
+      totalAvgResponseTime: [time, totalAvgResponseTimeRounded],
       userCount: [time, userCount],
       time,
     };

--- a/locust/webui/src/pages/HtmlReport.tsx
+++ b/locust/webui/src/pages/HtmlReport.tsx
@@ -37,6 +37,7 @@ export default function HtmlReport({
   endTime,
   duration,
   charts,
+  chartsPng,
   host,
   exceptionsStatistics,
   requestsStatistics,
@@ -129,7 +130,16 @@ export default function HtmlReport({
             <Typography component='h2' mb={1} noWrap variant='h4'>
               Charts
             </Typography>
-            <SwarmCharts charts={charts} isDarkMode={isDarkMode} />
+            {chartsPng ? (
+              <Box
+                alt='Charts'
+                component='img'
+                src={chartsPng}
+                sx={{ display: 'block', maxWidth: '100%', width: '100%' }}
+              />
+            ) : (
+              <SwarmCharts charts={charts} isDarkMode={isDarkMode} />
+            )}
           </Box>
           <Box>
             <Typography component='h2' mb={1} noWrap variant='h4'>

--- a/locust/webui/src/pages/tests/HtmlReport.test.tsx
+++ b/locust/webui/src/pages/tests/HtmlReport.test.tsx
@@ -62,6 +62,15 @@ describe('HtmlReport', () => {
     expect(queryByRole('link', { name: 'Download the Report' })).toBeNull();
   });
 
+  test('renders an injected charts PNG when present', () => {
+    const chartsPng = 'data:image/png;base64,test';
+    const { getByAltText } = renderWithProvider(
+      <HtmlReport {...swarmReportMock} chartsPng={chartsPng} />,
+    );
+
+    expect(getByAltText('Charts').getAttribute('src')).toBe(chartsPng);
+  });
+
   test('renders the exceptions table when exceptions are present', () => {
     const exception = {
       count: 1,

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -47,9 +47,9 @@ export const statsResponseMock = {
       num_requests: 12652,
     },
   ],
-  total_avg_response_time: 0.41064205516736735,
-  total_fail_per_sec: 1932.5,
-  total_rps: 1932.5,
+  total_avg_response_time: 99.99,
+  total_fail_per_sec: 11.11,
+  total_rps: 22.22,
   user_count: 1,
 };
 
@@ -100,7 +100,7 @@ export const exceptionsResponseMock = {
 export const mockDate = new Date(1971, 1);
 
 export const statsResponseTransformed = {
-  totalRps: 1932.5,
+  totalRps: 22.22,
   failRatio: 100,
   stats: [
     {

--- a/locust/webui/src/types/swarm.types.ts
+++ b/locust/webui/src/types/swarm.types.ts
@@ -78,6 +78,7 @@ export interface IReport {
   duration: string;
   host: string;
   charts: ICharts;
+  chartsPng?: string;
   requestsStatistics: ISwarmStat[];
   failuresStatistics: ISwarmError[];
   responseTimeStatistics: IResponseTime[];


### PR DESCRIPTION
## Summary
- Update `Download Report` so it captures a client-side SwarmCharts PNG from the existing dashboard chart history and injects it into the downloaded HTML report.
- Keep the existing Charts-tab ECharts toolbar export as the standalone PNG path; do not add a duplicate Reports-tab PNG button.
- Strip duplicated chart history from the downloaded report payload once the PNG snapshot is embedded, while letting HtmlReport render either injected PNG or report-time charts.
- Keep live chart points aligned with report-history chart points by sourcing RPS, failures/s, and average response time from the aggregate current stats row.

## Testing
- `node .yarn/releases/yarn-4.12.0.cjs lint`
- `node .yarn/releases/yarn-4.12.0.cjs type-check`
- `node .yarn/releases/yarn-4.12.0.cjs vitest run src/hooks/tests/useFetchStats.test.tsx --silent=false`
- `node .yarn/releases/yarn-4.12.0.cjs test --run`
- `git diff --check`

## Review note
This addresses Andrew's question about the existing chart toolbar: the separate Reports-tab PNG action was removed. The PR now changes the report download path so the saved HTML report includes a snapshot of the chart data already held by the UI.

The final commit also fixes a preexisting live-chart sampling mismatch discovered while validating the downloaded report image. The top-level `total_rps` fields intentionally represent total-run summary values, but chart history uses aggregate current stats. Since this PR now captures the live chart into the report, the chart-point source needs to match report history. I kept that fix here because it directly affects the report snapshot, but it can be split out if maintainers prefer.
