### PR TITLE
fix(fasthttp): handle zlib.error for truncated gzip streams under high load

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -10,6 +10,7 @@ import re
 import socket
 import time
 import traceback
+import zlib
 from base64 import b64encode
 from contextlib import contextmanager
 from http.cookiejar import CookieJar
@@ -282,7 +283,7 @@ class FastHttpSession:
         else:
             try:
                 request_meta["response_length"] = len(response.content) if response.content else 0
-            except (HTTPParseError, *FAILURE_EXCEPTIONS) as e:
+            except (HTTPParseError, zlib.error, *FAILURE_EXCEPTIONS) as e:
                 request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
                 request_meta["exception"] = e  # type: ignore
                 if catch_response:

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -85,6 +85,7 @@ FAILURE_EXCEPTIONS = (
     SSLError,
     Timeout,
     HTTPConnectionClosed,
+    zlib.error,
 )
 
 
@@ -283,7 +284,7 @@ class FastHttpSession:
         else:
             try:
                 request_meta["response_length"] = len(response.content) if response.content else 0
-            except (HTTPParseError, zlib.error, *FAILURE_EXCEPTIONS) as e:
+            except (HTTPParseError, *FAILURE_EXCEPTIONS) as e:
                 request_meta["response_time"] = (time.perf_counter() - start_perf_counter) * 1000
                 request_meta["exception"] = e  # type: ignore
                 if catch_response:


### PR DESCRIPTION
## Problem
Under high load, servers may close the connection before finishing 
sending the gzip-encoded body. This results in a truncated stream 
that zlib cannot decompress, raising an unhandled `zlib.error` that 
propagates out of `FastHttpSession.request()`.

Affected stacktrace:
    File "geventhttpclient/useragent.py", line 188, in unzipped
        return zlib.decompress(bodystr, 16 + zlib.MAX_WBITS)
    zlib.error: Error -5 while decompressing data: incomplete or truncated stream

## Fix
Add `zlib.error` to the existing exception handler alongside 
`HTTPParseError` so truncated gzip responses are recorded correctly 
in Locust's statistics instead of propagating as unhandled exceptions.

## Notes
Same pattern as the Brotli decompression failure — the existing 
handler already does the right thing, `zlib.error` just wasn't 
included.