### PR TITLE
fix(fasthttp): add 308 to redirect_resonse_codes in LocustUserAgent

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -256,7 +256,7 @@ class FastHttpSession:
 
         if not allow_redirects:
             old_redirect_response_codes = self.client.redirect_resonse_codes
-            self.client.redirect_resonse_codes = []
+            self.client.redirect_resonse_codes = frozenset()
 
         start_perf_counter = time.perf_counter()
         # send request, and catch any exceptions

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -674,6 +674,7 @@ class LocustUserAgent(UserAgent):
     response_type = FastResponse
     request_type = FastRequest
     valid_response_codes = frozenset([200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 301, 302, 303, 304, 307, 308])
+    redirect_resonse_codes = frozenset([301, 302, 303, 307, 308])
 
     def __init__(self, client_pool: HTTPClientPool | None = None, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
308 redirects (RFC 7538) have been accepted as valid status codes since commit 70184dfb, but they are never automatically followed.

The underlying geventhttpclient UserAgent defines redirect_resonse_codes = frozenset([301, 302, 303, 307]), and LocustUserAgent never overrode it. This means 308 responses pass _verify_status() but the redirect loop in urlopen() skips them because 308 is not in redirect_resonse_codes.

Add a redirect_resonse_codes override to LocustUserAgent that includes 308, so the client follows 308 redirects automatically, matching the behavior of 301/302/303/307.

Changes in locust/contrib/fasthttp.py:

redirect_resonse_codes = frozenset([301, 302, 303, 307, 308])