### PR TITLE
Disable UI lib npm package publication

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -542,18 +542,18 @@ jobs:
           cmd: config set npmAuthToken ${{ secrets.NPM_AUTH_TOKEN }}
           dir: locust/webui
 
-      # Publish UI lib
-      - uses: borales/actions-yarn@v5
-        name: Publish package on NPM
-        if: github.ref == 'refs/heads/master'
-        with:
-          cmd: npm publish --tag next
-          dir: locust/webui
+    #   # Publish UI lib
+    #   - uses: borales/actions-yarn@v5
+    #     name: Publish package on NPM
+    #     if: github.ref == 'refs/heads/master'
+    #     with:
+    #       cmd: npm publish --tag next
+    #       dir: locust/webui
 
-      # On tag builds
-      - uses: borales/actions-yarn@v5
-        name: Publish package on NPM
-        if: startsWith(github.event.ref, 'refs/tags')
-        with:
-          cmd: npm publish
-          dir: locust/webui
+    #   # On tag builds
+    #   - uses: borales/actions-yarn@v5
+    #     name: Publish package on NPM
+    #     if: startsWith(github.event.ref, 'refs/tags')
+    #     with:
+    #       cmd: npm publish
+    #       dir: locust/webui


### PR DESCRIPTION
 It breaks occasionally, and with Locust Cloud gone, it is unlikely anyone needs it.