### PR TITLE
Handle custom web routes without UI

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -108,11 +108,14 @@ to the Flask app instance and use that to set up a new route::
 
     @events.init.add_listener
     def on_locust_init(environment, **kw):
-        @environment.web_ui.app.route("/added_page")
-        def my_added_page():
-            return "Another page"
+        if environment.web_ui:
+            @environment.web_ui.app.route("/added_page")
+            def my_added_page():
+                return "Another page"
 
 You should now be able to start locust and browse to http://127.0.0.1:8089/added_page. Note that it doesn't get automatically added as a new tab - you'll need to enter the URL directly.
+The ``if environment.web_ui`` guard is needed when running workers, headless mode, or ``--processes``,
+where the Web UI only exists in the master process.
 
 Extending Web UI
 ================

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -995,7 +995,7 @@ class StandaloneIntegrationTests(ProcessIntegrationTest):
 
     def test_error_when_locustfiles_directory_is_empty(self):
         with TemporaryDirectory() as temp_dir:
-            with TestProcess(f"locust -f {temp_dir}", expect_return_code=1) as tp:
+            with TestProcess(f"locust -f {temp_dir}", expect_return_code=1, sigint_on_exit=False) as tp:
                 tp.expect(f"Could not find any locustfiles in directory '{temp_dir}'")
 
     def test_error_when_no_tasks_match_tags(self):

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1510,6 +1510,48 @@ class AnyUser(HttpUser):
                 tp.not_expect_any("Traceback")
 
     @unittest.skipIf(IS_WINDOWS, reason="--processes doesnt work on windows")
+    def test_processes_custom_web_route(self):
+        web_port = get_free_tcp_port()
+        master_port = get_free_tcp_port()
+        with mock_locustfile(
+            content=textwrap.dedent(
+                """
+                from locust import HttpUser, events, task
+
+                @events.init.add_listener
+                def on_locust_init(environment, **kw):
+                    if environment.web_ui:
+                        @environment.web_ui.app.route("/added_page")
+                        def my_added_page():
+                            return "Another page"
+
+                class ExampleUser(HttpUser):
+                    host = "http://127.0.0.1:8089"
+
+                    @task
+                    def example_task(self):
+                        pass
+                """
+            )
+        ) as mocked:
+            with TestProcess(
+                f"locust -f {mocked.file_path} --processes 2 --web-port {web_port} --master-bind-port {master_port} --master-port {master_port}",
+                join_timeout=2,
+            ) as tp:
+                tp.expect("(index 1) reported as ready")
+                wait_for_server(f"http://127.0.0.1:{web_port}/added_page")
+                resp = requests.get(f"http://127.0.0.1:{web_port}/added_page", timeout=5)
+                self.assertEqual("Another page", resp.text)
+                requests.post(
+                    f"http://127.0.0.1:{web_port}/swarm",
+                    data={"user_count": 1, "spawn_rate": 1, "host": "http://127.0.0.1:8089"},
+                    timeout=5,
+                )
+                tp.expect("All users spawned")
+                tp.not_expect_any("Uncaught exception in event handler")
+                tp.not_expect_any("Traceback")
+
+    @unittest.skipIf(IS_WINDOWS, reason="--processes doesnt work on windows")
     def test_processes_autodetect(self):
         with mock_locustfile() as mocked:
             with TestProcess(


### PR DESCRIPTION
Fixes #3396.

## Summary
- add a falsey no-op web UI during init on worker/headless nodes so documented route decorators do not crash when no real web UI exists
- keep `environment.web_ui` restored to `None` after init when there is no real UI
- add a process-mode regression test that registers a custom route, verifies it on the master UI, and starts the test
- make the empty locustfile directory test wait for its expected process exit instead of sending SIGINT during teardown

## Tests
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest locust/test/test_main.py::StandaloneIntegrationTests::test_error_when_locustfiles_directory_is_empty locust/test/test_main.py::DistributedIntegrationTests::test_processes_custom_web_route -q`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest locust/test/test_main.py::DistributedIntegrationTests::test_processes_custom_web_route locust/test/test_main.py::DistributedIntegrationTests::test_processes locust/test/test_main.py::StandaloneIntegrationTests::test_exception_in_init_event -q`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run ruff check .`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run ruff format --check`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run mypy locust/`
- `git diff --check`