### PR TITLE
docs: guard custom web routes without web UI

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -108,11 +108,14 @@ to the Flask app instance and use that to set up a new route::
 
     @events.init.add_listener
     def on_locust_init(environment, **kw):
-        @environment.web_ui.app.route("/added_page")
-        def my_added_page():
-            return "Another page"
+        if environment.web_ui:
+            @environment.web_ui.app.route("/added_page")
+            def my_added_page():
+                return "Another page"
 
 You should now be able to start locust and browse to http://127.0.0.1:8089/added_page. Note that it doesn't get automatically added as a new tab - you'll need to enter the URL directly.
+The ``if environment.web_ui`` guard is needed when running workers, headless mode, or ``--processes``,
+where the Web UI only exists in the master process.
 
 Extending Web UI
 ================


### PR DESCRIPTION
## Summary
- Update the custom web route example to guard `environment.web_ui` before registering Flask routes.
- Clarify that workers, headless mode, and `--processes` do not have a Web UI in every process.

Docs-only replacement requested in #3415.

## Validation
- `git diff --check`

AI assistance was used to prepare this docs-only replacement; I reviewed the final diff.