### PR TITLE
docs: fix typos

### DIFF
--- a/docs/extending-locust.rst
+++ b/docs/extending-locust.rst
@@ -152,7 +152,7 @@ Simply provide a list of desired ``auth_providers``. You may specify the ``label
 The ``callback_url`` will be the url that the button directs to. You will be responsible for defining the callback route as
 well as the authentication with the 3rd party.
 
-Whether you are using username / password authentication, an auth provider, or both, a ``user_loader`` needs to be proivded
+Whether you are using username / password authentication, an auth provider, or both, a ``user_loader`` needs to be provided
 to the ``login_manager``. The ``user_loader`` should return ``None`` to deny authentication or return a User object when
 authentication to the app should be granted.
 

--- a/docs/kubernetes-operator.rst
+++ b/docs/kubernetes-operator.rst
@@ -3,7 +3,7 @@
 Kubernetes Operator
 ===================
 
-The Locust Operator for Kubernetes is an operator that manages the lifecyle of :ref:`running-distributed` inside a Kubernetes cluster.
+The Locust Operator for Kubernetes is an operator that manages the lifecycle of :ref:`running-distributed` inside a Kubernetes cluster.
 
 It is a Custom Resource Definition (CRD) and a Controller that run on your Kubernetes cluster and allow you to create and manage your Locust tests as Kubernetes resources.
 Automatically creates master/worker jobs, mounts locustfiles, exposes the web UI, collects metrics, and handles restarts when the spec changes.


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check