### PR TITLE
fix: proper_round gives wrong result for integer inputs when digits > 0

### DIFF
--- a/locust/test/test_util.py
+++ b/locust/test/test_util.py
@@ -39,3 +39,11 @@ class TestRounding(unittest.TestCase):
         self.assertEqual(4, proper_round(3.5))
         self.assertEqual(5, proper_round(4.5))
         self.assertEqual(6, proper_round(5.5))
+    def test_proper_round_integer_input_with_digits(self):
+        # proper_round(int, digits) must not corrupt the value by adding an
+        # oversized epsilon.  Before the fix, str(0)='0' has length 1, so the
+        # epsilon was 10**(-2)=0.01, which survived round(..., 2) intact.
+        self.assertEqual(0.0, proper_round(0, 2))
+        self.assertEqual(1.0, proper_round(1, 2))
+        self.assertEqual(5.0, proper_round(5, 2))
+        self.assertEqual(9.0, proper_round(9, 2))

--- a/locust/util/rounding.py
+++ b/locust/util/rounding.py
@@ -1,2 +1,8 @@
 def proper_round(val, digits=0):
-    return round(val + 10 ** (-len(str(val)) - 1), digits)
+    # Convert to float first so that integer inputs like 0 produce '0.0'
+    # (length 3) rather than '0' (length 1).  Using the shorter string gives
+    # an epsilon of 10**(-2)=0.01 which is large enough to corrupt the result
+    # when digits >= 2 (e.g. proper_round(0, 2) would return 0.01 instead of
+    # 0.0 without this conversion).
+    float_val = float(val)
+    return round(float_val + 10 ** (-len(str(float_val)) - 1), digits)


### PR DESCRIPTION
## Summary

`proper_round(val, digits)` in `locust/util/rounding.py` returns an
incorrect value when `val` is an integer and `digits > 0`.

## Root cause

The epsilon used to defeat banker's rounding is computed as:

```python
10 ** (-len(str(val)) - 1)
```

For an integer input `val = 0`, `str(0)` is `'0'` (length 1), so the
epsilon is `10**(-2) = 0.01`.  With `digits = 2`:

```python
round(0 + 0.01, 2)   # → 0.01  ← wrong, should be 0.0
round(1 + 0.01, 2)   # → 1.01  ← wrong, should be 1.0
```

## Fix

Convert `val` to `float` before computing the string length.
`float(0)` becomes `0.0`, whose string representation `'0.0'` has
length 3, giving epsilon `10**(-4) = 0.0001` — small enough never to
survive rounding at any reasonable `digits` value.

## Verification

```
python -m pytest locust/test/test_util.py locust/test/test_parser.py
33 passed
```

Before the fix:

```
FAILED locust/test/test_util.py::TestRounding::test_proper_round_integer_input_with_digits
AssertionError: 0.0 != 0.01
```

After the fix: all 33 tests pass, including the 4 new assertions.

Closes #3430

> This PR was developed with AI assistance.