### PR TITLE
fix: use warnings.warn(DeprecationWarning) in parse_options instead of print

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -13,6 +13,7 @@ import os
 import platform
 import socket
 import sys
+import warnings
 import tempfile
 import textwrap
 from collections import OrderedDict
@@ -910,7 +911,12 @@ def get_parser(default_config_files=DEFAULT_CONFIG_FILES) -> LocustArgumentParse
 
 
 def parse_options(args=None) -> configargparse.Namespace:
-    print("Warning: This function is deprecated and may be removed in a future version")
+    warnings.warn(
+        "parse_options() is deprecated and may be removed in a future version. "
+        "Use get_parser().parse_args() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     parser = get_parser()
     parsed_opts = parser.parse_args(args=args)
     if parsed_opts.stats_history_enabled and (parsed_opts.csv_prefix is None):

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -2,10 +2,12 @@ import locust
 from locust.argument_parser import (
     get_parser,
     parse_locustfile_paths,
+    parse_options,
     ui_extra_args_dict,
 )
 
 import os
+import warnings
 import unittest
 from io import StringIO
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -91,6 +93,20 @@ class TestParser(unittest.TestCase):
         self.assertTrue(options.headless)
         self.assertEqual(["Critical", "Normal"], options.tags)
         self.assertEqual("https://example.com", options.host)
+
+    def test_parse_options_emits_deprecation_warning(self):
+        """parse_options() must signal its deprecation via warnings.warn(DeprecationWarning).
+
+        Using print() instead of warnings.warn() breaks -W flag suppression and
+        prevents callers from catching the warning with catch_warnings().
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            parse_options(args=["-f", "locustfile.py"])
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(deprecations), 1, "parse_options() must emit exactly one DeprecationWarning")
+        self.assertIn("deprecated", str(deprecations[0].message).lower())
 
 
 class TestArgumentParser(LocustTestCase):


### PR DESCRIPTION
Closes #3433

## Bug

`parse_options()` signalled its own deprecation with a bare `print()` call.
This caused the warning to be sent to **stdout** instead of stderr, made it impossible to suppress with `-W ignore::DeprecationWarning`, prevented callers from intercepting it with `catch_warnings()`, and caused it to appear on every call instead of once per call-site.

## Fix

Replace `print("Warning: ...")` with `warnings.warn(msg, DeprecationWarning, stacklevel=2)`.

## Verification

New test `TestParser.test_parse_options_emits_deprecation_warning` in `locust/test/test_parser.py`:

- **RED** (before fix): `catch_warnings(record=True)` captures 0 warnings — the message only appeared in captured stdout.
- **GREEN** (after fix): exactly one `DeprecationWarning` is captured by `catch_warnings`.

```
locust/test/test_parser.py::TestParser::test_parse_options_emits_deprecation_warning PASSED
```

All other `TestParser` and `test_util.py` tests continue to pass.