### PR TITLE
fix: require host when detecting URLs

### DIFF
--- a/locust/test/test_util.py
+++ b/locust/test/test_util.py
@@ -1,5 +1,6 @@
 from locust.util.rounding import proper_round
 from locust.util.timespan import parse_timespan
+from locust.util.url import is_url
 
 import unittest
 
@@ -24,6 +25,11 @@ class TestParseTimespan(unittest.TestCase):
         self.assertRaises(ValueError, parse_timespan, "2h3m5s6")  # trailing '6' has no unit
         self.assertRaises(ValueError, parse_timespan, "1h30")  # '30' has no unit
         self.assertRaises(ValueError, parse_timespan, "30m45")  # '45' has no unit
+
+
+class TestIsUrl(unittest.TestCase):
+    def test_url_requires_host(self):
+        self.assertFalse(is_url("http://"))
 
 
 class TestRounding(unittest.TestCase):

--- a/locust/util/url.py
+++ b/locust/util/url.py
@@ -7,9 +7,6 @@ def is_url(url: str) -> bool:
     """
     try:
         result = urlparse(url)
-        if result.scheme == "https" or result.scheme == "http":
-            return True
-        else:
-            return False
+        return result.scheme in ("https", "http") and bool(result.netloc)
     except ValueError:
         return False


### PR DESCRIPTION
## Summary

- require HTTP(S) URLs to include a network location in `is_url()`
- add a focused regression test for the malformed `http://` case

Closes #3438

## Test

`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest locust/test/test_util.py`