### PR TITLE
Fix proper_round for integer inputs

### DIFF
--- a/locust/test/test_util.py
+++ b/locust/test/test_util.py
@@ -45,3 +45,8 @@ class TestRounding(unittest.TestCase):
         self.assertEqual(4, proper_round(3.5))
         self.assertEqual(5, proper_round(4.5))
         self.assertEqual(6, proper_round(5.5))
+
+    def test_rounding_integer_with_digits(self):
+        self.assertEqual(0.0, proper_round(0, 2))
+        self.assertEqual(1.0, proper_round(1, 2))
+        self.assertEqual(5.0, proper_round(5, 2))

--- a/locust/util/rounding.py
+++ b/locust/util/rounding.py
@@ -1,2 +1,3 @@
 def proper_round(val, digits=0):
+    val = float(val)
     return round(val + 10 ** (-len(str(val)) - 1), digits)


### PR DESCRIPTION
Fixes #3430.

`proper_round()` used `len(str(val))` to size the epsilon it adds before rounding. For integer inputs, strings like `"0"` and `"1"` make that epsilon too large when `digits > 0`, so values like `proper_round(0, 2)` returned `0.01`.

This converts the input to `float` before computing the epsilon and adds regression coverage for integer inputs with decimal digits.

Validation:
- Focused file-level regression check for `proper_round(0, 2)`, `proper_round(1, 2)`, `proper_round(5, 2)`, and existing rounding edge cases
- `PYTHONPYCACHEPREFIX=/Volumes/STOREJET/Documents/OSC/.cache/pycache-locust python3 -m py_compile locust/util/rounding.py locust/test/test_util.py`
- `git diff --check`
