### PR TITLE
Fix rps display issue (caused by inconsistencies in current_rps vs total_rps)

### DIFF
--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -142,6 +142,7 @@ class TestWebUI(LocustTestCase, _HeaderCheckMixin):
 
         total_entry = data["stats"][-1]
         self.assertEqual(total_entry["total_rps"], data["total_rps"])
+        self.assertEqual(total_entry["current_fail_per_sec"], data["current_fail_per_sec"])
         self.assertEqual(total_entry["total_fail_per_sec"], data["total_fail_per_sec"])
 
     def test_stats_cache(self):

--- a/locust/web.py
+++ b/locust/web.py
@@ -484,6 +484,8 @@ class WebUI:
             total_stats = _stats[-1]
 
             if _stats:
+                report["current_rps"] = total_stats["current_rps"]
+                report["current_fail_per_sec"] = total_stats["current_fail_per_sec"]
                 report["total_rps"] = total_stats["total_rps"]
                 report["total_fail_per_sec"] = total_stats["total_fail_per_sec"]
                 report["fail_ratio"] = environment.runner.stats.total.fail_ratio

--- a/locust/webui/src/components/Layout/Navbar/SwarmMonitor.test.tsx
+++ b/locust/webui/src/components/Layout/Navbar/SwarmMonitor.test.tsx
@@ -6,7 +6,7 @@ import { swarmStateMock } from 'test/mocks/swarmState.mock';
 import { renderWithProvider } from 'test/testUtils';
 
 const mockUiState = {
-  totalRps: '5',
+  currentRps: '5',
   failRatio: '3',
   stats: [],
   errors: [],
@@ -41,7 +41,7 @@ describe('SwarmMonitor', () => {
 
     expect(getByText('Host').nextElementSibling?.textContent).toBe(swarmStateMock.host);
     expect(getByText('Status').nextElementSibling?.textContent).toBe(SWARM_STATE.RUNNING);
-    expect(getByText('RPS').nextElementSibling?.textContent).toBe(mockUiState.totalRps);
+    expect(getByText('RPS').nextElementSibling?.textContent).toBe(mockUiState.currentRps);
     expect(getByText('Users').nextElementSibling?.textContent).toBe(mockUiState.userCount);
     expect(getByText('Failures').nextElementSibling?.textContent).toBe(`${mockUiState.failRatio}%`);
   });

--- a/locust/webui/src/components/Layout/Navbar/SwarmMonitor.tsx
+++ b/locust/webui/src/components/Layout/Navbar/SwarmMonitor.tsx
@@ -8,13 +8,13 @@ import { ISwarmState } from 'types/swarm.types';
 
 interface ISwarmMonitor
   extends Pick<ISwarmState, 'isDistributed' | 'host' | 'state' | 'workerCount'>,
-    Pick<IUiState, 'totalRps' | 'failRatio' | 'userCount'> {}
+    Pick<IUiState, 'currentRps' | 'failRatio' | 'userCount'> {}
 
 function SwarmMonitor({
   isDistributed,
   state,
   host,
-  totalRps,
+  currentRps,
   failRatio,
   userCount,
   workerCount,
@@ -70,7 +70,7 @@ function SwarmMonitor({
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: { md: 'center' } }}>
         <Typography sx={{ fontWeight: 'bold' }}>RPS</Typography>
         <Typography noWrap variant='button'>
-          {totalRps}
+          {currentRps}
         </Typography>
       </Box>
       <Divider flexItem orientation='vertical' />
@@ -84,12 +84,12 @@ function SwarmMonitor({
 
 const storeConnector = ({
   swarm: { isDistributed, state, host, workerCount },
-  ui: { totalRps, failRatio, userCount },
+  ui: { currentRps, failRatio, userCount },
 }: IRootState) => ({
   isDistributed,
   state,
   host,
-  totalRps,
+  currentRps,
   failRatio,
   userCount,
   workerCount,

--- a/locust/webui/src/hooks/useFetchStats.ts
+++ b/locust/webui/src/hooks/useFetchStats.ts
@@ -35,8 +35,8 @@ export default function useFetchStats() {
       extendedStats,
       stats,
       errors,
-      totalRps,
-      totalFailPerSec,
+      currentRps,
+      currentFailPerSec,
       failRatio,
       workers,
       workerCount,
@@ -51,8 +51,8 @@ export default function useFetchStats() {
       updateChartMarkers(time);
     }
 
-    const totalRpsRounded = roundToDecimalPlaces(totalRps, 2);
-    const totalFailPerSecRounded = roundToDecimalPlaces(totalFailPerSec, 2);
+    const currentRpsRounded = roundToDecimalPlaces(currentRps, 2);
+    const currentFailPerSecRounded = roundToDecimalPlaces(currentFailPerSec, 2);
     const totalFailureRatioRounded = roundToDecimalPlaces(failRatio * 100);
 
     const percentilesWithTime = Object.entries(currentResponseTimePercentiles).reduce(
@@ -65,8 +65,8 @@ export default function useFetchStats() {
 
     const newChartEntry = {
       ...percentilesWithTime,
-      currentRps: [time, totalRpsRounded],
-      currentFailPerSec: [time, totalFailPerSecRounded],
+      currentRps: [time, currentRpsRounded],
+      currentFailPerSec: [time, currentFailPerSecRounded],
       totalAvgResponseTime: [time, roundToDecimalPlaces(totalAvgResponseTime, 2)],
       userCount: [time, userCount],
       time,
@@ -76,7 +76,7 @@ export default function useFetchStats() {
       extendedStats,
       stats,
       errors,
-      totalRps: totalRpsRounded,
+      currentRps: currentRpsRounded,
       failRatio: totalFailureRatioRounded,
       workers,
       userCount,

--- a/locust/webui/src/redux/slice/tests/ui.slice.test.ts
+++ b/locust/webui/src/redux/slice/tests/ui.slice.test.ts
@@ -10,7 +10,7 @@ const responseTimePercentileKey2 =
   `responseTimePercentile${percentilesToChart[1]}` as `responseTimePercentile${number}`;
 
 const initialState = {
-  totalRps: 0,
+  currentRps: 0,
   failRatio: 0,
   startTime: '',
   stats: [],
@@ -32,13 +32,13 @@ const initialState = {
 describe('uiSlice', () => {
   test('should set UI state', () => {
     const action = (uiActions.setUi as (payload: Partial<IUiState>) => UiAction)({
-      totalRps: 100,
+      currentRps: 100,
       userCount: 50,
     });
     const nextState = uiSlice(initialState, action);
     expect(nextState).toEqual({
       ...initialState,
-      totalRps: 100,
+      currentRps: 100,
       userCount: 50,
     });
   });

--- a/locust/webui/src/redux/slice/ui.slice.ts
+++ b/locust/webui/src/redux/slice/ui.slice.ts
@@ -15,7 +15,7 @@ import { updateArraysAtProps } from 'utils/object';
 
 export interface IUiState {
   extendedStats?: IExtendedStat[];
-  totalRps: number;
+  currentRps: number;
   failRatio: number;
   startTime: string;
   stats: ISwarmStat[];
@@ -30,7 +30,7 @@ export interface IUiState {
 export type UiAction = PayloadAction<Partial<IUiState>>;
 
 const initialState = {
-  totalRps: 0,
+  currentRps: 0,
   failRatio: 0,
   startTime: '',
   stats: [] as ISwarmStat[],

--- a/locust/webui/src/test/mocks/statsRequest.mock.ts
+++ b/locust/webui/src/test/mocks/statsRequest.mock.ts
@@ -102,7 +102,7 @@ export const exceptionsResponseMock = {
 export const mockDate = new Date(1971, 1);
 
 export const statsResponseTransformed = {
-  totalRps: 1932.5,
+  currentRps: 1932.5,
   failRatio: 100,
   stats: [
     {

--- a/locust/webui/src/types/ui.types.ts
+++ b/locust/webui/src/types/ui.types.ts
@@ -95,6 +95,8 @@ export interface IStatsResponse {
   workerCount: number;
   currentRps: number;
   currentFailPerSec: number;
+  totalRps: number;
+  totalFailPerSec: number;
   totalAvgResponseTime: number;
   currentResponseTimePercentiles: {
     [key: `responseTimePercentile${number}`]: number | null;

--- a/locust/webui/src/types/ui.types.ts
+++ b/locust/webui/src/types/ui.types.ts
@@ -93,8 +93,8 @@ export interface IStatsResponse {
   errors: ISwarmError[];
   workers: ISwarmWorker[];
   workerCount: number;
-  totalRps: number;
-  totalFailPerSec: number;
+  currentRps: number;
+  currentFailPerSec: number;
   totalAvgResponseTime: number;
   currentResponseTimePercentiles: {
     [key: `responseTimePercentile${number}`]: number | null;


### PR DESCRIPTION
Should fix #3451

I think the UI was depending on the endpoint returning the wrong values, which was fixed earlier.