### PR TITLE
Fix Echart Styles

### DIFF
--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -82,7 +82,7 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
   grid,
   scatterplot,
 }: ILineChart<ChartType>) => ({
-  title: { text: title },
+  title: { text: title, left: 'left' },
   tooltip: {
     trigger: 'axis',
     formatter: (params?: ILineChartTooltipFormatterParams[] | null) => {

--- a/locust/webui/src/components/LineChart/LineChart.utils.ts
+++ b/locust/webui/src/components/LineChart/LineChart.utils.ts
@@ -126,6 +126,14 @@ export const createOptions = <ChartType extends Pick<ICharts, 'time'>>({
   color: colors,
   toolbox: {
     right: 10,
+    iconStyle: {
+      borderColor: '#666',
+    },
+    emphasis: {
+      iconStyle: {
+        borderColor: '#3E98C5',
+      },
+    },
     feature: {
       dataZoom: {
         title: {


### PR DESCRIPTION
Echarts 6 introduces some new defaults for styles. This restores the styles to previous defaults

<img width="3018" height="1844" alt="image" src="https://github.com/user-attachments/assets/a41c651b-5cbb-4a83-bb51-2611892449fb" />
