### PR TITLE
docs: fix class-picker json() example and clarify behavior

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -200,16 +200,25 @@ to your user:
 .. code-block:: python
 
     class Example(HttpUser):
+        some_custom_arg: str = "example"
+
         @task
         def example_task(self):
             self.client.get(f"/example/{self.some_custom_arg}")
 
         @classmethod
-        def json(self):
+        def json(cls):
             return {
-                "host": self.host,
-                "some_custom_arg": "example"
+                "host": cls.host,
+                "some_custom_arg": cls.some_custom_arg
             }
+
+.. note::
+
+    The ``json`` classmethod is only used to populate the class picker UI (the gear icon next to each User class).
+    It does not automatically set the attribute values on the User class. The default values must be defined as
+    class-level attributes (e.g. ``some_custom_arg: str = "example"``). To apply changes made in the UI, click the
+    save button for each User class.
 
 Configure Users from command line
 =================================


### PR DESCRIPTION
Fixes #3435

This PR updates the `--class-picker` documentation to clarify the `json` classmethod behavior:

- Corrected the `json` classmethod example to use `cls` instead of `self`
- Added a class-level attribute definition (`some_custom_arg: str = "example"`) to show that custom attributes must be defined on the class
- Added a note clarifying that `json()` only populates the class picker UI and does not automatically apply values to the User class; users must still click **Save** in the UI

These changes address Subproblems 1 and 2 from #3435. Subproblem 3 (global `--host` overriding per-class host) is an existing design choice with a UI warning already in place, so it is not changed here.