### PR TITLE
Move --csv-full-history validation before process forking

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -164,6 +164,9 @@ def main():
     parser = get_parser()
     options = parser.parse_args()
 
+    if options.stats_history_enabled and (options.csv_prefix is None):
+        parser.error("'--csv-full-history' requires '--csv'.")
+
     stats.validate_stats_configuration()
 
     if options.headful:
@@ -576,8 +579,6 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
 
     if options.csv_prefix:
         gevent.spawn(stats_csv_writer.stats_writer).link_exception(greenlet_exception_handler)
-    if options.stats_history_enabled and (options.csv_prefix is None):
-        parser.error("'--csv-full-history' requires '--csv'.")
 
     if options.headless:
         start_automatic_run()


### PR DESCRIPTION
## Description

Move the validation that `--csv-full-history` requires `--csv` so it runs immediately after argument parsing, before any process forking, runner creation, or web UI setup.

Previously, the check was placed very late in [main()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:147:0-690:14), after:
- worker processes had already been forked (when `--processes` is used)
- runners were created
- the web UI was started
- [start_automatic_run()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:528:4-577:77) had potentially begun

This caused poor UX when the combination `--csv-full-history` without `--csv` was passed: workers could start up and run before the master finally errored out.

## Related Issue

Fixes the late-validation aspect of the code path described in issue #3428.

## Changes

- `main.py:167-168`: Add the `--csv-full-history` requires `--csv` validation right after `parser.parse_args()`.
- Removed the same check from its previous location after runner/web UI setup.

## Testing

The existing test [test_csv_full_history_requires_csv](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/test/test_main.py:263:4-268:82) in [locust/test/test_main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/test/test_main.py:0:0-0:0) still validates this behavior (exit code 2 and the expected error message). No new tests are needed.