### PR TITLE
Fix two exception handling bugs

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -325,10 +325,11 @@ def main():
             )
 
     if os.name != "nt":
+        minimum_open_file_limit = 10000
+        soft_limit = None
         try:
             import resource
 
-            minimum_open_file_limit = 10000
             (soft_limit, hard_limit) = resource.getrlimit(resource.RLIMIT_NOFILE)
 
             if soft_limit < minimum_open_file_limit:
@@ -336,9 +337,9 @@ def main():
                 # It does not work on all OS:es, but we should be no worse off for trying.
                 limits = minimum_open_file_limit, hard_limit
                 resource.setrlimit(resource.RLIMIT_NOFILE, limits)
-        except BaseException:
+        except Exception:
             logger.warning(
-                f"""System open file limit '{soft_limit} is below minimum setting '{minimum_open_file_limit}'.
+                f"""System open file limit '{soft_limit}' is below minimum setting '{minimum_open_file_limit}'.
 It's not high enough for load testing, and the OS didn't allow locust to increase it by itself.
 See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit for more info."""
             )

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1010,6 +1010,7 @@ class MasterRunner(DistributedRunner):
                 logging.debug(
                     "Got KeyboardInterrupt in client_listener. Other greenlets should catch this and shut down."
                 )
+                continue
             self.handle_message(client_id, msg)
 
     def handle_message(self, client_id: str, msg: Message) -> None:


### PR DESCRIPTION
## Description

This PR fixes two exception handling bugs that can cause crashes in production scenarios.

### 1. [client_listener](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:973:4-1013:47) KeyboardInterrupt fallthrough ([locust/runners.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:0:0-0:0))

When `KeyboardInterrupt` is caught in [MasterRunner.client_listener()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:973:4-1013:47), the handler logged a debug message but did not `continue` the loop. Control fell through to [self.handle_message(client_id, msg)](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:1365:4-1448:76), but `client_id` and `msg` were never assigned (the `recv_from_client()` call was interrupted). This caused either a `NameError` (first iteration) or processed stale values from a previous iteration.

**Fix:** Added `continue` after the debug log.

### 2. `except BaseException` in file limit handling ([locust/main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:0:0-0:0))

Two issues in the open file limit handling code:

- `except BaseException` caught `KeyboardInterrupt` and `SystemExit`, which should be allowed to propagate.
- If `resource.getrlimit()` itself raised an exception, `soft_limit` and `minimum_open_file_limit` were unbound when referenced in the warning message, causing a secondary `NameError` inside the exception handler.

**Fix:** Changed to `except Exception` and moved variable definitions before the `try` block.

## Testing

Both bugs are triggered by interrupt/exception edge cases. The existing test suite continues to pass. Manual verification:
- `KeyboardInterrupt` during a distributed test no longer causes a `NameError` in the master's [client_listener](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:973:4-1013:47).
- File limit warnings on platforms where `resource.getrlimit()` raises now display correctly instead of crashing with `NameError`.