### PR TITLE
Fix response time percentiles being deflated by requests logged with response_time=None

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -114,7 +114,9 @@ response time percentile
 CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW = 10
 
 CachedResponseTimes = namedtuple(
-    "CachedResponseTimes", ["response_times", "num_requests", "num_none_requests"], defaults=(0,)
+    "CachedResponseTimes",
+    ["response_times", "num_requests", "num_none_requests"],
+    defaults=(0,),  # num_none_requests is optional for backwards compatibility
 )
 
 PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 0.9999, 1.0]

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -113,7 +113,9 @@ response time percentile
 """
 CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW = 10
 
-CachedResponseTimes = namedtuple("CachedResponseTimes", ["response_times", "num_requests"])
+CachedResponseTimes = namedtuple(
+    "CachedResponseTimes", ["response_times", "num_requests", "num_none_requests"], defaults=(0,)
+)
 
 PERCENTILES_TO_REPORT = [0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 0.999, 0.9999, 1.0]
 
@@ -604,7 +606,11 @@ class StatsEntry:
 
         Percent specified in range: 0.0 - 1.0
         """
-        return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
+        # response_times only holds non-None samples, so None (async) requests
+        # must be excluded from the denominator, just like in avg/median
+        return calculate_response_time_percentile(
+            self.response_times, self.num_requests - self.num_none_requests, percent
+        )
 
     def get_current_response_time_percentile(self, percent: float) -> int | None:
         """
@@ -644,7 +650,7 @@ class StatsEntry:
             # for that timeframe
             return calculate_response_time_percentile(
                 diff_response_time_dicts(self.response_times, cached.response_times),
-                self.num_requests - cached.num_requests,
+                (self.num_requests - self.num_none_requests) - (cached.num_requests - cached.num_none_requests),
                 percent,
             )
         # if time was not in response times cache window
@@ -669,6 +675,7 @@ class StatsEntry:
         self.response_times_cache[t] = CachedResponseTimes(
             response_times=copy(self.response_times),
             num_requests=self.num_requests,
+            num_none_requests=self.num_none_requests,
         )
 
         # We'll use a cache size of CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW + 10 since - in the extreme case -

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -142,6 +142,17 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(s.get_response_time_percentile(0.6), 60)
         self.assertEqual(s.get_response_time_percentile(0.95), 95)
 
+    def test_percentile_with_none_response_times(self):
+        s = StatsEntry(self.stats, "percentile_test", "GET")
+        for x in range(100):
+            s.log(x, 0)
+        for _ in range(100):
+            s.log(None, 0)
+
+        self.assertEqual(s.get_response_time_percentile(0.5), 50)
+        self.assertEqual(s.get_response_time_percentile(0.6), 60)
+        self.assertEqual(s.get_response_time_percentile(0.95), 95)
+
     def test_median(self):
         self.assertEqual(self.s.median_response_time, 79)
 
@@ -766,6 +777,19 @@ class TestStatsEntryResponseTimesCache(unittest.TestCase):
         s.response_times = {i: 2 for i in range(100)}
         s.response_times[1] = 202
         s.num_requests = 300
+
+        self.assertEqual(95, s.get_current_response_time_percentile(0.95))
+
+    def test_get_current_response_time_percentile_with_none_response_times(self):
+        s = StatsEntry(self.stats, "/", "GET", use_response_times_cache=True)
+        t = int(time.time())
+        s.response_times_cache[t - 10] = CachedResponseTimes(
+            response_times={i: 1 for i in range(100)}, num_requests=200, num_none_requests=100
+        )
+
+        s.response_times = {i: 2 for i in range(100)}
+        s.num_requests = 400
+        s.num_none_requests = 200
 
         self.assertEqual(95, s.get_current_response_time_percentile(0.95))
 


### PR DESCRIPTION
Fixes #3472

`get_response_time_percentile` passed `self.num_requests` as the denominator, but `self.response_times` only holds non-None samples, so every request logged with `response_time=None` deflated the percentiles (`avg_response_time` and `median_response_time` already subtract `num_none_requests`).

- `get_response_time_percentile`: subtract `num_none_requests`, same as avg/median
- `get_current_response_time_percentile`: `CachedResponseTimes` now also carries `num_none_requests` (with a default, so existing two-field constructions keep working) and the sliding-window denominator gets the same correction
- tests mirror `test_percentile` and `test_get_current_response_time_percentile` with None requests added; both fail without the fix