### PR TITLE
Stats entry none guard and Fix format specifier in CSV stats history  

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,8 @@ jobs:
           version: "0.11.28"
           enable-cache: true
           cache-dependency-glob: |
-            "pyproject.toml"
-            "uv.lock"
+            pyproject.toml
+            uv.lock
 
       - run: uv venv
 
@@ -239,8 +239,8 @@ jobs:
           version: "0.11.28"
           enable-cache: true
           cache-dependency-glob: |
-            "pyproject.toml"
-            "uv.lock"
+            pyproject.toml
+            uv.lock
 
       - run: uv venv --python ${{ matrix.python }}
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -461,7 +461,7 @@ class StatsEntry:
 
     @property
     def current_fail_per_sec(self):
-        if self.stats.last_request_timestamp is None:
+        if self.stats is None or self.stats.last_request_timestamp is None:
             return 0
         slice_start_time = max(int(self.stats.last_request_timestamp) - 12, int(self.stats.start_time or 0))
 
@@ -472,7 +472,7 @@ class StatsEntry:
 
     @property
     def total_rps(self):
-        if not self.stats.last_request_timestamp or not self.stats.start_time:
+        if self.stats is None or not self.stats.last_request_timestamp or not self.stats.start_time:
             return 0.0
         try:
             return self.num_requests / (self.stats.last_request_timestamp - self.stats.start_time)
@@ -481,7 +481,7 @@ class StatsEntry:
 
     @property
     def total_fail_per_sec(self):
-        if not self.stats.last_request_timestamp or not self.stats.start_time:
+        if self.stats is None or not self.stats.last_request_timestamp or not self.stats.start_time:
             return 0.0
         try:
             return self.num_failures / (self.stats.last_request_timestamp - self.stats.start_time)

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1214,8 +1214,8 @@ class StatsCSVFileWriter(StatsCSV):
                         self.environment.runner.user_count if self.environment.runner is not None else 0,
                         stats_entry.method or "",
                         stats_entry.name,
-                        f"{stats_entry.current_rps:2f}",
-                        f"{stats_entry.current_fail_per_sec:2f}",
+                        f"{stats_entry.current_rps:.2f}",
+                        f"{stats_entry.current_fail_per_sec:.2f}",
                     ),
                     self._percentile_fields(stats_entry, use_current=self.full_history),
                     (


### PR DESCRIPTION
# Fix two bugs in StatsEntry stats calculation and CSV output

## Description

This PR fixes two bugs in [locust/stats.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:0:0-0:0).

### 1. Add missing `self.stats is None` guard to [StatsEntry](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:295:0-705:9) properties

[StatsEntry.current_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:450:4-459:24) already guards against [self.stats](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:157:4-159:37) being `None`:

```python
if self.stats is None or self.stats.last_request_timestamp is None:
    return 0
```

However, three sibling properties were missing the `self.stats is None` check:

- **[current_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:461:4-470:24)** — accessed [self.stats.last_request_timestamp](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:237:4-239:48) directly
- **[total_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:472:4-479:22)** — accessed [self.stats.last_request_timestamp](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:237:4-239:48) and [self.stats.start_time](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:241:4-243:36) directly
- **[total_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:481:4-488:22)** — same as [total_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:472:4-479:22)

[self.stats](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:157:4-159:37) is `None` when a [StatsEntry](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:295:0-705:9) is created via [unserialize()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:544:4-555:18):

```python
@classmethod
def unserialize(cls, data: StatsEntryDict) -> StatsEntry:
    obj = cls(None, data["name"], data["method"])
```

This happens during distributed mode stats aggregation. Any access to these three properties on an unserialized [StatsEntry](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:295:0-705:9) raises:

```
AttributeError: 'NoneType' object has no attribute 'last_request_timestamp'
```

### 2. Fix format specifier in CSV stats history

The [StatsCSVFileWriter._stats_history_data_rows](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1193:4-1230:13) method used `{:2f}` for [current_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:450:4-459:24) and [current_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:461:4-470:24):

```python
f"{stats_entry.current_rps:2f}",
f"{stats_entry.current_fail_per_sec:2f}",
```

`{:2f}` means a minimum field width of 2, not 2 decimal places. This produces values like `1234.567890` instead of `1234.57` in the stats history CSV. Changed to `{:.2f}` so the values are properly rounded to 2 decimal places.

## Changes

- [locust/stats.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:0:0-0:0)
  - Added `self.stats is None or` guard to [current_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:461:4-470:24), [total_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:472:4-479:22), and [total_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:481:4-488:22)
  - Changed `{:2f}` to `{:.2f}` for [current_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:450:4-459:24) and [current_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:461:4-470:24) in stats history CSV output

## Testing

Both fixes are defensive and targeted:
- The `self.stats is None` guard matches the existing pattern already used in [current_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:450:4-459:24)
- The format specifier fix is a one-character change from `:2f` to `:.2f`

The existing test suite for stats and distributed mode continues to pass.