### PR TITLE
Fix variable shadowing in _aggregate_dispatched_users

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1527,4 +1527,4 @@ def _format_user_classes_count_for_log(user_classes_count: dict[str, int]) -> st
 def _aggregate_dispatched_users(d: dict[str, dict[str, int]]) -> dict[str, int]:
     # TODO: Test it
     user_classes = list(next(iter(d.values())).keys())
-    return {u: sum(d[u] for d in d.values()) for u in user_classes}
+    return {u: sum(worker_counts[u] for worker_counts in d.values()) for u in user_classes}


### PR DESCRIPTION
## Description

Fix a variable shadowing bug in [_aggregate_dispatched_users](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:1526:0-1529:91) in [locust/runners.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:0:0-0:0).

The inner comprehension variable `d` in `for d in d.values()` shadows the outer parameter `d`:

```python
def _aggregate_dispatched_users(d: dict[str, dict[str, int]]) -> dict[str, int]:
    user_classes = list(next(iter(d.values())).keys())
    return {u: sum(d[u] for d in d.values()) for u in user_classes}
```

While the code works by accident (the inner `d` values are the `dict[str, int]` dicts that `d[u]` correctly indexes), it is confusing and fragile — if the function is ever refactored, this will silently break.

Renamed the inner variable to `worker_counts` for clarity:

```python
return {u: sum(worker_counts[u] for worker_counts in d.values()) for u in user_classes}
```

## Changes

- [locust/runners.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:0:0-0:0): renamed inner loop variable from `d` to `worker_counts` in [_aggregate_dispatched_users](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:1526:0-1529:91)
