### PR TITLE
Explicitly close csv file handles before exit

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -659,6 +659,8 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
             stats.print_percentile_stats(runner.stats)
             stats.print_error_report(runner.stats)
         environment.events.quit.fire(exit_code=code)
+        if isinstance(stats_csv_writer, stats.StatsCSVFileWriter):
+            stats_csv_writer.close_files()
         sys.exit(code)
 
     # install SIGTERM handler

--- a/locust/main.py
+++ b/locust/main.py
@@ -659,7 +659,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
             stats.print_percentile_stats(runner.stats)
             stats.print_error_report(runner.stats)
         environment.events.quit.fire(exit_code=code)
-        if isinstance(stats_csv_writer, stats.StatsCSVFileWriter):
+        if stats_csv_writer is not None:
             stats_csv_writer.close_files()
         sys.exit(code)
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1101,7 +1101,6 @@ class StatsCSV:
         for exc in self.environment.runner.exceptions.values():
             csv_writer.writerow([exc["count"], exc["msg"], exc["traceback"], ", ".join(exc["nodes"])])
 
-
     def close_files(self) -> None:
         pass
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1102,6 +1102,10 @@ class StatsCSV:
             csv_writer.writerow([exc["count"], exc["msg"], exc["traceback"], ", ".join(exc["nodes"])])
 
 
+    def close_files(self) -> None:
+        pass
+
+
 class StatsCSVFileWriter(StatsCSV):
     """Write statistics to CSV files"""
 


### PR DESCRIPTION
## Description

Fix a CSV file handle leak in [locust/main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:0:0-0:0) shutdown.

[StatsCSVFileWriter](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1099:0-1251:56) opens 4 file handles (`_stats.csv`, `_stats_history.csv`, `_failures.csv`, `_exceptions.csv`) but [close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) was never called in the [shutdown()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:622:4-663:22) function. Tests call [close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) explicitly, but the production path relied on process exit to close the files.

Added a [close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) call in [shutdown()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:622:4-663:22) with a `None` check. Added a no-op [close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) method to the [StatsCSV](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1000:0-1105:12) base class so both [StatsCSV](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1000:0-1105:12) and [StatsCSVFileWriter](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1099:0-1251:56) have the method.

## Changes

- [locust/stats.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:0:0-0:0): added no-op [close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) to [StatsCSV](cci:2://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1000:0-1105:12) base class
- [locust/main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:0:0-0:0): call [stats_csv_writer.close_files()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:1104:4-1105:12) in [shutdown()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:622:4-663:22) when `stats_csv_writer is not None`