### PR TITLE
Fix url possibly unbound in headless non-worker mode

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -438,6 +438,7 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
     else:
         stats_csv_writer = stats.StatsCSV(environment, stats.PERCENTILES_TO_REPORT)
 
+    url = None
     # start Web UI
     if not options.headless and not options.worker:
         protocol = "https" if options.tls_cert and options.tls_key else "http"
@@ -610,8 +611,8 @@ See https://github.com/locustio/locust/wiki/Installation#increasing-maximum-numb
                         if runner.state != "spawning"
                         else logging.warning("Spawning users, can't stop right now")
                     ),
-                    "\r": lambda: webbrowser.open_new_tab(url),
-                    "\n": lambda: webbrowser.open_new_tab(url),
+                    "\r": lambda: webbrowser.open_new_tab(url) if url else None,
+                    "\n": lambda: webbrowser.open_new_tab(url) if url else None,
                 },
             )
         )


### PR DESCRIPTION
## Description

Fix a `NameError` crash when pressing Enter in headless non-worker mode.

The [url](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/contrib/fasthttp.py:555:4-563:19) variable is only defined inside the [if not options.headless and not options.worker](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:1355:4-1363:40) block (line 442), but the input listener lambdas referencing [url](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/contrib/fasthttp.py:555:4-563:19) are created when [not options.worker](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:1355:4-1363:40) (line 588), which includes headless non-worker mode. If a user presses Enter (`\r` or `\n`) in headless mode, `webbrowser.open_new_tab(url)` raises `NameError` because [url](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/contrib/fasthttp.py:555:4-563:19) was never assigned.

Initialize `url = None` before the web UI block and guard the `webbrowser.open_new_tab()` lambdas with a `None` check so they are no-ops when there is no web UI.

## Changes

- [locust/main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:0:0-0:0): initialize `url = None` before the web UI block
- [locust/main.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/main.py:0:0-0:0): guard the `\r` and `\n` input listener lambdas with `if url else None`
