### PR TITLE
fix: exclude missing workers from new dispatches

### DIFF
--- a/locust/runners.py
+++ b/locust/runners.py
@@ -742,7 +742,8 @@ class MasterRunner(DistributedRunner):
 
         self.target_user_count = user_count
 
-        num_workers = len(self.clients.ready) + len(self.clients.running) + len(self.clients.spawning)
+        active_workers = self.clients.ready + self.clients.running + self.clients.spawning
+        num_workers = len(active_workers)
         if not num_workers:
             logger.warning("You can't start a distributed test before at least one worker processes has connected")
             return
@@ -755,7 +756,7 @@ class MasterRunner(DistributedRunner):
 
         if self._users_dispatcher is None:
             self._users_dispatcher = self.environment.dispatcher_class(
-                worker_nodes=list(self.clients.values()), user_classes=self.user_classes
+                worker_nodes=active_workers, user_classes=self.user_classes
             )
 
         logger.info(

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -2763,6 +2763,34 @@ class TestMasterRunner(LocustRunnerTestCase):
             self.assertEqual(3, len(server.get_messages("spawn")))
             self.assertEqual(3, len(server.get_messages("spawning_complete")))
 
+    def test_new_dispatch_excludes_missing_workers(self):
+        class TestUser(User):
+            @task
+            def my_task(self):
+                pass
+
+        with (
+            mock.patch("locust.rpc.rpc.Server", mocked_rpc()) as server,
+            patch_env("LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP", "0"),
+        ):
+            master = self.get_runner(user_classes=[TestUser])
+            server.mocked_send(Message("client_ready", __version__, "missing"))
+            server.mocked_send(Message("client_ready", __version__, "healthy"))
+
+            master.start(2, 100)
+            master.clients["missing"].state = STATE_MISSING
+            master.stop(send_stop_to_client=False)
+            master.update_state(STATE_STOPPED)
+
+            previous_spawn_count = len(server.get_messages("spawn"))
+
+            master.start(2, 100)
+
+            spawn_messages = server.get_messages("spawn")[previous_spawn_count:]
+            self.assertEqual(1, len(spawn_messages))
+            self.assertEqual("healthy", spawn_messages[0].node_id)
+            self.assertEqual({"TestUser": 2}, spawn_messages[0].data["user_classes_count"])
+
     def test_start_event(self):
         """
         Tests that test_start event is fired


### PR DESCRIPTION
## Summary

- Exclude missing workers when a master creates a dispatcher for a new distributed run.
- Add a regression test for restarting after a worker becomes missing.

## Tests

- `pytest locust/test/test_runners.py::TestMasterRunner::test_sends_spawn_data_to_ready_running_spawning_workers locust/test/test_runners.py::TestMasterRunner::test_new_dispatch_excludes_missing_workers locust/test/test_runners.py::TestMasterRunner::test_last_worker_missing_stops_test -q`
- `ruff check locust/runners.py locust/test/test_runners.py`
