### PR TITLE
Fix filename unbound and print() in locustfile distribution

### DIFF
--- a/locust/rpc/zmqrpc.py
+++ b/locust/rpc/zmqrpc.py
@@ -1,3 +1,5 @@
+import logging
+
 from locust.exception import RPCError, RPCReceiveError, RPCSendError
 from locust.util.exception_handler import retry
 
@@ -69,7 +71,7 @@ class BaseSocket:
             if str(csocket.getaddrinfo(host, port, proto=csocket.IPPROTO_TCP)).find("Family.AF_INET6") == -1:
                 return True
         except gaierror as e:
-            print(f"Error resolving address: {e}")
+            logging.error(f"Error resolving address: {e}")
             return False
         return False
 

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -1067,6 +1067,7 @@ class MasterRunner(DistributedRunner):
                     if os.path.isdir(locustfile_option):
                         locustfile_list.extend(get_abspaths_in(locustfile_option, extension=".py"))
 
+                filename = None
                 try:
                     locustfiles: list[str | dict[str, str]] = []
 
@@ -1075,10 +1076,9 @@ class MasterRunner(DistributedRunner):
                             locustfiles.append(filename)
                         else:
                             with open(filename) as f:
-                                filename = os.path.basename(filename)
                                 file_contents = f.read()
 
-                            locustfiles.append({"filename": filename, "contents": file_contents})
+                            locustfiles.append({"filename": os.path.basename(filename), "contents": file_contents})
                 except Exception as e:
                     error_message = "locustfile must be a full path to a single locustfile, a comma-separated list of .py files, or a URL for file distribution to work"
                     logger.error(f"{error_message} {e}")


### PR DESCRIPTION
## Description

Fix two bugs in locustfile distribution and one logging inconsistency in RPC code.

### [runners.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:0:0-0:0) — `filename` possibly unbound in locustfile distribution error handler

When `locustfile_list` is empty (e.g. locustfile path is a directory with no `.py` files) or an exception occurs before the `for` loop assigns `filename`, the `except` block references `filename` which would raise `NameError`, crashing the master's [client_listener](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:973:4-1013:47) greenlet.

Additionally, `filename` was being reassigned with `os.path.basename(filename)` inside the loop, so if `f.read()` failed after the reassignment, the error message would show the basename instead of the full path.

### [zmqrpc.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/rpc/zmqrpc.py:0:0-0:0) — `print()` instead of `logging.error()`

The [ipv4_only](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/rpc/zmqrpc.py:66:4-75:20) method used `print()` for error logging, which bypasses logging configuration and can interfere with output parsing in headless mode. Replaced with `logging.error()` for consistency with the rest of the codebase.

## Changes

- [locust/runners.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/runners.py:0:0-0:0): initialize `filename = None` before the try block; use `os.path.basename(filename)` directly in the dict instead of reassigning `filename`
- [locust/rpc/zmqrpc.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/rpc/zmqrpc.py:0:0-0:0): replace `print()` with `logging.error()`; add `import logging`