### PR TITLE
Fix format specifier in CSV stats history output

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1222,8 +1222,8 @@ class StatsCSVFileWriter(StatsCSV):
                         self.environment.runner.user_count if self.environment.runner is not None else 0,
                         stats_entry.method or "",
                         stats_entry.name,
-                        f"{stats_entry.current_rps:2f}",
-                        f"{stats_entry.current_fail_per_sec:2f}",
+                        f"{stats_entry.current_rps:.2f}",
+                        f"{stats_entry.current_fail_per_sec:.2f}",
                     ),
                     self._percentile_fields(stats_entry, use_current=self.full_history),
                     (


### PR DESCRIPTION
## Description

Fix incorrect format specifiers in CSV stats history output that produce 6 decimal places instead of the intended 2.

The `Requests/s` and `Failures/s` columns in `_stats_history.csv` use `:2f` which sets a minimum field width of 2 but uses the default 6 decimal places (e.g. `1.500000`). The correct specifier is `:.2f` which produces 2 decimal places (e.g. `1.50`).

This is inconsistent with the console output at `stats.py:583` which correctly uses `%.2f`.

## Reproduction

```bash
locust -f locustfile.py --headless -u 1 -r 1 -t 5s --csv-prefix report --stats-history-enabled
```

Before fix, `_stats_history.csv` contains:
```
Timestamp,User Count,Type,Name,Requests/s,Failures/s,...
1760000000,1,,"Aggregated",1.500000,0.000000,...
```

After fix:
```
Timestamp,User Count,Type,Name,Requests/s,Failures/s,...
1760000000,1,,"Aggregated",1.50,0.00,...
```

## Changes

- `locust/stats.py:1225-1226`: `:2f` → `:.2f` for [current_rps](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:450:4-459:24) and [current_fail_per_sec](cci:1://file:///Users/satyasivasundarsalagrama/open-source/locust/locust/stats.py:461:4-470:24)
