### PR TITLE
Fix FastHttpUser streaming response_length using wrong header key

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -273,8 +273,8 @@ class FastHttpSession:
         # get the length of the content, but if the argument stream is set to True, we take
         # the size from the content-length header, in order to not trigger fetching of the body
         if stream:
-            if response.headers and "response_length" in response.headers:
-                request_meta["response_length"] = int(response.headers["response_length"])
+            if response.headers and "content-length" in response.headers:
+                request_meta["response_length"] = int(response.headers["content-length"])
         else:
             try:
                 request_meta["response_length"] = len(response.content) if response.content else 0


### PR DESCRIPTION
# Fix: FastHttpUser streaming requests report `response_length=0`

## Summary

Fixes an issue where `FastHttpUser` with `stream=True` always reports `response_length=0`, even when the response includes a valid `Content-Length` header.

## Problem

`FastHttpSession.request()` incorrectly checks for `"response_length"` in the HTTP response headers:

```python
if stream:
    if response.headers and "response_length" in response.headers:
        request_meta["response_length"] = int(response.headers["response_length"])
```

`The correct header is `content-length`.

## Fix

Update the header lookup to use `content-length`:

```python
if stream:
    if response.headers and "content-length" in response.headers:
        request_meta["response_length"] = int(response.headers["content-length"])
```

This matches the existing behavior in `HttpSession` and correctly reports response sizes for streaming requests.

