### PR TITLE
fix: fix pythonVersion in ruffConfig and fix extend-exclude setting

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -15,6 +15,7 @@ import socket
 import sys
 import tempfile
 import textwrap
+import tomllib
 from collections import OrderedDict
 from typing import Any, NamedTuple
 from urllib.parse import urlparse
@@ -23,7 +24,6 @@ from uuid import uuid4
 import configargparse
 import gevent
 import requests
-import tomllib
 
 from .util.directory import get_abspaths_in
 from .util.timespan import parse_timespan

--- a/locust/debug.py
+++ b/locust/debug.py
@@ -8,7 +8,7 @@ from locust.exception import CatchResponseError, RescheduleTask
 
 import inspect
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ class PrintListener:
 
         if self.include_time:
             if start_time:
-                _print_t(datetime.fromtimestamp(start_time, tz=timezone.utc))
+                _print_t(datetime.fromtimestamp(start_time, tz=UTC))
             else:
                 _print_t(datetime.now())
 

--- a/locust/util/date.py
+++ b/locust/util/date.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def format_utc_timestamp(unix_timestamp):
-    return datetime.fromtimestamp(int(unix_timestamp), timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.fromtimestamp(int(unix_timestamp), UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def format_safe_timestamp(unix_timestamp):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,14 @@ local_scheme = "no-local-version"
 [tool.hatch.build.targets.BuildFrontend.hooks.custom]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 120
+force-exclude = true
 extend-exclude = [
     "build",
     "examples/issue_*.py",
     "src/readthedocs-sphinx-search/",
-    "examples/grpc/hello_pb2.py",
+    "examples/grpc/hello_pb2*.py",
 ]
 lint.ignore = ["E402", "E501", "E713", "E731", "E741", "UP031", "PERF203"]
 lint.select = ["E", "F", "W", "UP", "FA102", "I001", "FURB", "PERF"]


### PR DESCRIPTION
Hello

In PR:
1) fix pythonVersion in ruff config (3.10 -> 3.11 like https://github.com/locustio/locust/blob/master/pyproject.toml#L11)
2) fix resulting warnings
3) add exclude more generated file
4) add https://docs.astral.sh/ruff/settings/#force-exclude in ruffConfig (otherwise files that should not be edited get edited - see screenshot)
<img width="1512" height="945" alt="Снимок экрана 2026-08-26 в 16 47 53" src="https://github.com/user-attachments/assets/84149af9-4a66-45fa-9328-7abc20d21426" /> 
 