### PR TITLE
[FIX] : correct  the user count metric for distributed runs

### DIFF
--- a/locust/opentelemetry.py
+++ b/locust/opentelemetry.py
@@ -1,4 +1,5 @@
 from locust import events
+from locust.runners import MasterRunner, WorkerRunner
 
 import logging
 import os
@@ -68,8 +69,16 @@ def setup_opentelemetry(locustfile: str, profile: str | None) -> bool:
             if runner is None:
                 return
 
+            if isinstance(runner, WorkerRunner):
+                # Workers will not report - only  Master would have the correct user count
+                return
+
             def observe_user_count(options):
-                for user_class, count in runner.user_classes_count.items():
+                if isinstance(runner, MasterRunner):
+                    user_classes_count = runner.reported_user_classes_count
+                else:
+                    user_classes_count = runner.user_classes_count
+                for user_class, count in user_classes_count.items():
                     yield metrics.Observation(count, {"user_class": user_class})
 
             meter.create_observable_gauge(

--- a/locust/test/test_main.py
+++ b/locust/test/test_main.py
@@ -1762,3 +1762,41 @@ class TelemetryTests(ProcessIntegrationTest):
             ) as tp:
                 tp.expect('"name": "locust.users.count"', stream="stdout")
                 tp.expect('"value": 3', stream="stdout")
+
+    def test_user_count_gauge_reports_running_users_distributed(self):
+        locustfile = textwrap.dedent(
+            """
+            from locust import User, constant, task
+
+            class SimpleUser(User):
+                wait_time = constant(1)
+
+                @task
+                def noop(self):
+                    pass
+            """
+        )
+        otel_env = {
+            "OTEL_METRICS_EXPORTER": "console",
+            "OTEL_METRIC_EXPORT_INTERVAL": "250",
+        }
+        with mock_locustfile(content=locustfile, dir=tempfile.gettempdir()) as mocked:
+            with TestProcess(
+                "locust -f - --worker --otel",
+                sigint_on_exit=False,
+                extra_env=otel_env,
+                join_timeout=3,
+            ) as tp_worker:
+                with TestProcess(
+                    f"locust -f {mocked.file_path} --headless --master --expect-workers 1 -u 4 -r 4 -t 1 --otel",
+                    sigint_on_exit=False,
+                    extra_env=otel_env,
+                    join_timeout=3,
+                ) as tp_master:
+                    # Only the master has visibility into the swarm-wide user count.
+                    tp_master.expect('"name": "locust.users.count"', stream="stdout")
+                    tp_master.expect('"value": 4', stream="stdout")
+                    tp_master.expect("Shutting down (exit code 0)")
+
+                    # Workers only know their own share, so they shouldn't report this metric at all.
+                    tp_worker.not_expect_any('"name": "locust.users.count"', stream="stdout")


### PR DESCRIPTION
# Problem
We faced inconsistent user count when running and recording user counts with `--processes` and `--master` flags. Local runs - were unaffected.

# Solution 
Essentially Master must have the accumulated user count while workers must not have the metric attached to them. We skip registering for `WorkerRunner` and have it for `MasterRunner`

